### PR TITLE
fix(native-executor): account for overhead in context pressure + hard emergency compaction

### DIFF
--- a/action-plan-2026-04-14.md
+++ b/action-plan-2026-04-14.md
@@ -1,0 +1,268 @@
+# Action Plan: Intense Reliability for Local-Model Agents
+
+**Status:** Active guiding star for native-executor hardening work.
+**Companion doc:** [`issues-2026-04-14.md`](issues-2026-04-14.md) — historical record of problems 1–15 and the post-mortem of the `fix-worktree-fundamental` run.
+**Started:** 2026-04-14
+
+---
+
+## The goal
+
+**Intense reliability of the native executor running on free, fast local models (qwen3-coder-30b on lambda01 via sglang).** Local models are cheap, fast (~200 tok/sec out, even faster in), and don't burn API credits — but they have small context windows (32k for our target). Most of our failures on these models stem from **context exhaustion**, not from the model's reasoning ability. Fix the context-management infrastructure and qwen3-coder-30b becomes a serious, reliable agent for long-running work.
+
+The end state: a workgraph service on native+qwen3 that can run indefinitely on long tasks, never fails structurally due to context, and self-heals through summarization and journaling rather than crashing.
+
+---
+
+## Architectural framing
+
+### The recurrent-emulation insight
+
+Stateful recurrent models have unbounded state via their hidden state. Stateless transformer agents have bounded context windows. **We can emulate recurrent-style unbounded state on a transformer by aggressively summarizing history**, with the summary serving as the compressed hidden state.
+
+Each architecture has different advantages:
+- **Transformers:** trivial forking (`messages.clone()`), inspectable state, editable/diffable history, cheap branching.
+- **RNNs:** constant-time cloning via hidden-state snapshot, no prompt-injection surface via readable state, natural operation on read/written state.
+
+We're not trying to beat RNNs at their game. We're building the transformer's version of unbounded state: **summary as the explicit hidden state**. That gets us inspectable, forkable, editable unbounded context on cheap local models.
+
+### The core invariant
+
+> **No single tool call, model turn, or compaction step may inject text whose estimated tokens exceed ~40–50% of the remaining context budget** (`window_size − overhead − current_message_tokens`).
+
+Everything below is in service of maintaining this invariant structurally, so context explosions become impossible by construction rather than merely unlikely.
+
+---
+
+## What's done (Layer 0 — in PR #10)
+
+Shipped 2026-04-14 on branch `fix-worktree-lifecycle`, [PR #10](https://github.com/graphwork/workgraph/pull/10):
+
+**Commit `b36842de`** — initial overhead accounting:
+- `ContextBudget` tracks `overhead_tokens` (system prompt + tool definitions + completion reservation) so `check_pressure` reflects real API budget usage.
+- `hard_emergency_compact` variant drops ALL tool results in older turns, strips thinking, truncates long text.
+- On streaming-400 retries: hard compact + halved `max_tokens` (1024 floor).
+- Compaction logs report token deltas.
+- 5 new tests.
+
+**Commit `8f6719cd`** — follow-up fix after smoke-test revealed the initial fix was position-based, not occurrence-based:
+- `emergency_compact` and `hard_emergency_compact` now walk ALL messages and shrink tool results by **occurrence count**, keeping only the last K tool-result *occurrences* verbatim (not the last K *messages*). On a chatty file-reading workload, big tool results live in recent message positions — the prior implementation left them untouched.
+- Call sites updated: proactive uses `keep_recent_tool_results=2`, hard emergency uses `=1`.
+- Log lines now include a `Δ -{}` delta so zero-reduction events are visible.
+- Regression test `test_emergency_compact_shrinks_recent_position_tool_results` reproduces the exact smoke-test layout.
+
+**Both fixes together address Problems 12 + 13 from the issues doc.** Baseline local fix — necessary but not sufficient.
+
+### Smoke test results (2026-04-14 through 2026-04-15 early morning)
+
+Five smoke tests against fresh `/home/erik/wg-e2e-smoke/` + lambda01/qwen3-coder-30b on a 32k context window. Each is intentionally progressively harder, stressing a different layer of the stack.
+
+| # | Task | Result | Validates |
+|---|---|---|---|
+| 1 | Fix `multiply` bug in `calculator.py`, re-run tests | ✅ 15s, 46 entries, 0 compactions | Fresh env + new binary + basic file tool use |
+| 2 | Summarize 8 × 12KB docs into `summary.md` | ❌ Task "done" but output **hallucinated** (see table below) — compaction destroyed content, agent generated plausible names from fading memory | Showed L0 alone is insufficient; motivated L1 |
+| 3 | Same task, after L0 fix + L1 channeling + file-tools section | ✅ **Correct subtopic names**, 180 entries, 7 compactions, no 400s, no bash-echo loop | L0 + L0.5 + L1 + file-tools section work end-to-end |
+| 4 | Summarize using `delegate` for each file | ✅ **16 delegate calls, 2 write_file, 0 bash echo**, correct output | Expanded tools section (delegate), anti-pattern list |
+| 5 | Summarize a single 99KB file (3× context window) | ✅ **Used `summarize` tool** at turn 2. Input chunked 2×; 0 compactions; 64/64 subtopics correct | L2 summarize + full stack integration |
+
+**The hallucination table from Test #2** (left for the record as motivation for L1+L2):
+
+| File | Actual | Summary | Match |
+|---|---|---|---|
+| networking | TCP, UDP, ICMP, BGP, OSPF, MPLS, IPv6, QUIC | TCP, UDP, HTTP, HTTPS, DNS, TLS, QUIC, BGP | 4/8 |
+| databases | btree, lsm-tree, hash-index, bloom-filter, wal, mvcc, replication, sharding | btree, hashmap, raft, sql, nosql, index, transaction, backup | 1/8 |
+
+Every subtopic's description was the same boilerplate sentence, but subtopic *names* were lossy after compaction and the model generated plausible-looking replacements from training prior. L1 (tool output channeling) fixed this structurally by keeping the raw content off the message vec entirely.
+
+### Key moment from Test #5 (L2 summarize)
+
+Agent-7 called `summarize("big-source.md", instruction="List every H2 section heading...")` at turn 2. The summarize tool's internal logs:
+
+```
+[summarize] starting: model=qwen3-coder-30b, input_bytes=98881
+[summarize] depth=0: 2 chunks from 98881 bytes (chunk_chars=52428)
+[summarize] depth=0 chunk 1/2: 52098 → 262 bytes
+[summarize] depth=0 chunk 2/2: 46783 → 241 bytes
+```
+
+A 99KB source → two summarization calls → 503-byte result → agent wrote it via `write_file` → done. **Zero compactions fired** because the big content never entered the agent's message vec — it was processed entirely inside the `summarize` tool's direct LLM calls.
+
+This is the first time in the session that we ran a task strictly larger than qwen3's context window and completed it correctly with zero pressure events. The summary was 64/64 correct — the FULL set of subtopics from all 8 source files.
+
+### Secondary finding from Test #2 — compaction plateau (fixed in L0.5)
+
+The last 4 of 11 compactions in Test #2 were no-ops:
+```
+Proactive compaction: ~25434 → ~25434 tokens (Δ -0, 21 messages)
+Proactive compaction: ~25469 → ~25469 tokens (Δ -0, 23 messages)
+...
+```
+
+Once all non-keep tool results are already shrunk to stubs, `emergency_compact` has nothing left to reduce, but the model's own accumulated Text / Thinking / ToolUse content keeps growing. `emergency_compact` doesn't touch those; only the hard-emergency path does.
+
+**Fix shipped as L0.5 (commit `657d5492`):** track consecutive no-op compactions; after 2 in a row with pressure still ≥ threshold, escalate to `hard_emergency_compact` which also strips Text/Thinking in elided messages. Counter resets on any non-zero delta or after an escalation fires.
+
+Test #3 confirmed this works as designed:
+```
+Proactive Δ -0 (streak=1)
+Proactive Δ -0 (streak=2)
+Escalated hard Δ -761  ← escalation triggers
+Proactive Δ -0 (streak=1)
+Proactive Δ -0 (streak=2)
+Escalated hard Δ -26
+```
+
+---
+
+## The layered defense
+
+Layer names and ordering, in priority of leverage:
+
+### L1 — Tool output channeling (prevention, highest impact)
+
+**Rule:** any tool whose output *could* be large writes to `.workgraph/output/agent-<id>/tool-outputs/<N>.log` and returns a small handle like:
+
+```
+[wrote 12345 bytes to tool-outputs/7.log; rows 0–18 of 340; use grep/head/tail/offset+limit to inspect]
+```
+
+The raw output physically never enters the message vec. The agent can still see anything it needs via follow-up tool calls (grep, head, tail, read_file with offset+limit). This makes context explosion via a single large tool output structurally impossible.
+
+**Tools to modify:**
+- `bash` — when stdout or stderr exceeds threshold, route to disk
+- `read_file` — when file > threshold, return first N lines + handle
+- `grep` / `glob` / `find` — when matches exceed threshold, route
+- `web_fetch` — already has a `fetch_max_chars` cap but return format should be consistent with the handle idiom
+- `web_search` — same
+- `delegate` — child task outputs already go to journal; just make the parent's view go through the handle idiom
+
+**Shared helper:** a `channel_output(bytes, agent_dir, index) -> Handle` function that produces the file + handle string.
+
+**Threshold:** configurable, default ~4KB (roughly 1k tokens). Well under the 40% invariant so an agent can still do real work with multiple tool calls per turn.
+
+**Estimated scope:** 6 tool modifications + shared helper + tests. ~400–600 lines.
+
+### L1.5 — Size invariants enforced at tool-result time (bundled with L1)
+
+After any tool runs, measure output size. If it still exceeds the ceiling (either because the tool didn't opt into channeling or because the handle itself is too verbose):
+
+1. If the tool is one that should have channeled → bug, channel anyway as defensive fallback.
+2. If the tool legitimately returns text → automatically wrap the result in a `summarize()` call with instruction `"preserve anything relevant to <current task title>"`.
+3. Final fallback → hard-truncate with `[truncated by size guard at N bytes]` marker.
+
+This enforcement lives in the agent loop's tool-execution path, not in individual tools, so every tool gets the protection for free.
+
+### L2 — `summarize` as a first-class tool (recursive map-reduce)
+
+**Signature:**
+```
+summarize(
+    source: {path | url | task_id | inline_text},
+    instruction: Optional<str>,        # what to preserve / focus on
+    max_input_bytes: int = 1_000_000,  # hard ceiling, configurable
+    max_output_tokens: int = 1024,     # size of final summary
+) -> str
+```
+
+**Algorithm (map-reduce tree):**
+1. Read source. Refuse if > `max_input_bytes`.
+2. Chunk into pieces sized to ~40% of `(window_size − overhead − instruction_tokens)` so each chunk fits in one call with headroom.
+3. **Map:** for each chunk, call the LLM with a focused summarization prompt that threads `instruction` through.
+4. **Reduce:** if concatenated chunk summaries fit in a single call, do a final merge pass and return.
+5. **Recurse:** otherwise, treat the summaries as the new input, go back to step 2.
+6. **Terminal case:** single chunk → emit its summary directly.
+
+**Journal integration:** every recursion level appends a `JournalEntryKind::Compaction` so a mid-run failure can be resumed from the last completed reduction step rather than starting over.
+
+**Why a tool, not just an internal helper:** by exposing `summarize` as a tool, the agent can *choose* to use it deliberately when it knows a source is too big, instead of only falling back to it passively on size-guard triggers. This is the "decompose by calling a tool" model that makes 32k-context work on large files.
+
+**Becomes the cornerstone:** L1.5 (size-guard fallback), L3 (recursive compaction of agent's own message vec), and L4 (journal resume) all build on this primitive.
+
+**Estimated scope:** ~300–500 lines new tool + integration + tests.
+
+### L3 — Recursive compaction of the agent's own context
+
+When `hard_emergency_compact` (Layer 0) isn't enough because the *compaction input itself* would exceed context, apply the `summarize` tool to the message vec. Split the older-messages region in half (or thirds, or until chunks fit), summarize each piece independently, concatenate, and if the concatenated summaries still don't fit, recurse.
+
+This makes compaction **structurally unable to fail** — it has to produce *something*, even in pathological cases where the content is enormous.
+
+**Terminal:** one message worth of content → hard-truncate with `[truncated by recursive compact]` marker and keep going.
+
+**Estimated scope:** ~200–300 lines leveraging L2.
+
+### L4 — Journal-integrated compaction with resume
+
+`JournalEntryKind::Compaction` already exists in `src/executor/native/journal.rs` but isn't fully wired. Finish the integration:
+
+- Every compaction event (proactive, hard-emergency, recursive) is journaled with before/after token estimates and the sequence range it covers.
+- On resume (`ResumeData::load`), detect in-progress recursive compactions from the journal and continue from the last completed reduction step.
+- `was_compacted` annotation in resume context tells the new agent session that older turns have been compressed.
+
+**Estimated scope:** ~150–300 lines.
+
+---
+
+## Components summary table (post-2026-04-15 shipping session)
+
+| Layer | What | Status | Commit | Leverage |
+|---|---|---|---|---|
+| L0 | Overhead accounting + hard compact + retry max_tokens reduction | ✅ shipped | `b36842de` + `8f6719cd` | Medium (unblocks verification) |
+| L0.5 | Soft→hard compaction escalation on plateau | ✅ shipped | `657d5492` | Medium (fixes Text/Thinking accumulation) |
+| L1 | Tool output channeling to disk + handle return | ✅ shipped | `0f694ef2` | **Highest** (verified: eliminates hallucination) |
+| L1.5 | Size-invariant enforcement at tool-result time | 🟡 partial (channeling covers the main case; explicit wrapping not yet) | — | High |
+| L2 | `summarize` tool (recursive map-reduce) | ✅ shipped | `b2ce2a74` | **Highest** (verified: handles 3× context-window sources) |
+| Native tools prompt section | Teach file/web/delegate/summarize tools in system prompt | ✅ shipped | `0f694ef2` + `bb0ce997` + `b2ce2a74` | Critical multiplier — without it the tools don't get used |
+| `wg_add` subtask + cron | In-process tool schema exposes the CLI flags | ✅ shipped | `bfbca92c` | Medium |
+| L3 | Recursive compaction of agent's own message vec (using `summarize` as the primitive) | Not started | — | Medium (L1 + L2 have made this less urgent) |
+| L4 | Journal-integrated compaction with resume-from-partial | Not started | — | Low (nice-to-have) |
+
+Total shipped this session: **~1600 lines** across 8 commits on PR #10. All layers validated end-to-end on a 32k-context local model (qwen3-coder-30b on lambda01) via progressively harder smoke tests.
+
+---
+
+## Current decision point
+
+Before starting L1+L2, we want to **smoke-test L0** in a controlled environment to prove the baseline fix actually moves the needle in practice. This is fast and de-risks the rest of the plan.
+
+### Smoke test setup (not yet executed)
+
+- **Fresh clean directory:** `/home/erik/wg-e2e-smoke/` or similar. NOT the current `/home/erik/workgraph/.workgraph/` which is too noisy (1665 done + 567 abandoned + 211 open + paused flip tasks + stale state).
+- **Minimal config:** ~25 lines. Three tiers all pointing to `openai:qwen3-coder-30b`, lambda01-local endpoint marked `is_default = true`, qwen3 in `model_registry`, native executor, `worktree_isolation = false`, `max_agents = 1`. **No FLIP, no auto_evaluate, no auto_assign** for the first smoke — we're verifying compaction only, not agency pipeline.
+- **One task:** terminal-bench-style self-contained task. Small bug in a Python file, find and fix it, run the test. Chatty enough to exercise many tool calls but bounded enough to complete.
+- **Watch the log for:** proactive compaction firing at the right threshold (~65% effective utilization, not ~100%); if hard limit is reached, hard compact + halved max_tokens retry should succeed.
+- **Keep the existing `.workgraph/` as-is** — don't delete, it's evidence for the issues doc.
+
+### What comes after the smoke test
+
+Assuming L0 verifies:
+1. Start L1+L2 design together (they co-depend via the size-guard fallback path).
+2. Land L1 first as a standalone PR (it's valuable without L2).
+3. Land L2 as a second PR.
+4. Then L3, then L4.
+5. After L4: re-attempt `fix-worktree-fundamental` style tasks on qwen3+native with confidence.
+
+If L0 doesn't verify:
+1. Debug whichever specific part of Layer 0 failed.
+2. Adjust `ContextBudget` math, chars-per-token constant, or retry policy as needed.
+3. Re-smoke-test.
+4. Then proceed with L1+.
+
+---
+
+## Open questions
+
+1. **Chars-per-token is hardcoded to 4.0.** For most Western text this is a reasonable estimate, but for code-heavy content it's an underestimate (code tokenizes denser). Should this become per-model or learned from actual usage in `Usage` responses?
+2. **`channel_output` file retention.** How long do we keep the tool-outputs logs? Per-agent cleanup after the agent exits? Per-task? Some retention policy?
+3. **Summarize tool cost.** Each recursive level is an LLM call. On expensive providers this adds up. For local models (qwen3 on lambda01) it's effectively free, but we should be careful about upstream applicability.
+4. **Size invariant threshold.** User specified "40–50% of remaining context." Make this a single `size_guard_ratio` config knob? Per-tool overrides?
+5. **Structured tool outputs.** Today tool outputs are plain text. Should we move to structured `{summary: str, handle: Option<str>, metadata: ...}` so the handle idiom is first-class in the type system rather than an in-band string convention?
+
+---
+
+## Related docs and artifacts
+
+- [`issues-2026-04-14.md`](issues-2026-04-14.md) — historical record of Problems 1–15 and the post-mortem
+- [`damage-diff-2026-04-14.patch`](damage-diff-2026-04-14.patch) — full diff of the 2185-line deletion incident from earlier tonight
+- `study-damaged-worktree-fix-2026-04-14/` — preserved artifacts from the failed run (stub `liveness.rs`, scaffolded `shared_state.rs`, etc.)
+- Commit [`b36842de`](https://github.com/graphwork/workgraph/pull/10/commits/b36842de) — the L0 fix
+- [PR #10](https://github.com/graphwork/workgraph/pull/10) — the L0 fix under CI review

--- a/src/agency/prompt.rs
+++ b/src/agency/prompt.rs
@@ -1572,8 +1572,16 @@ mod tests {
     #[test]
     fn test_render_evaluator_prompt_with_decomposition() {
         let child_tasks = vec![
-            ("Subtask 1: Parse input".to_string(), "Done".to_string(), Some("Parse input data".to_string())),
-            ("Subtask 2: Process data".to_string(), "In-progress".to_string(), None),
+            (
+                "Subtask 1: Parse input".to_string(),
+                "Done".to_string(),
+                Some("Parse input data".to_string()),
+            ),
+            (
+                "Subtask 2: Process data".to_string(),
+                "In-progress".to_string(),
+                None,
+            ),
         ];
 
         let input = EvaluatorInput {
@@ -1602,17 +1610,29 @@ mod tests {
 
         // Should contain decomposition detection section
         assert!(output.contains("## Task Decomposition Detected"));
-        assert!(output.contains("This task created subtasks, indicating intentional work decomposition"));
+        assert!(
+            output
+                .contains("This task created subtasks, indicating intentional work decomposition")
+        );
         assert!(output.contains("Subtask 1: Parse input"));
         assert!(output.contains("Subtask 2: Process data"));
 
         // Should contain adjusted verification note for decomposition
         assert!(output.contains("This task was decomposed into subtasks"));
-        assert!(output.contains("this likely indicates proper work delegation rather than task failure"));
-        assert!(output.contains("Score the decomposition quality instead of penalizing for verify criteria"));
+        assert!(
+            output
+                .contains("this likely indicates proper work delegation rather than task failure")
+        );
+        assert!(
+            output.contains(
+                "Score the decomposition quality instead of penalizing for verify criteria"
+            )
+        );
 
         // Should NOT contain the standard verification note that penalizes failures
-        assert!(!output.contains("If verification failed, significantly\n             reduce the overall score"));
+        assert!(!output.contains(
+            "If verification failed, significantly\n             reduce the overall score"
+        ));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -683,6 +683,17 @@ pub enum Commands {
         at: Option<String>,
     },
 
+    /// Change a task's priority level (critical, high, normal, low, idle)
+    Reprioritize {
+        /// Task ID
+        #[arg(value_name = "TASK")]
+        id: String,
+
+        /// New priority level: critical, high, normal, low, idle
+        #[arg(value_name = "PRIORITY")]
+        priority: String,
+    },
+
     /// Show impact analysis - what tasks depend on this one
     Impact {
         /// Task ID
@@ -3617,6 +3628,7 @@ pub fn command_name(cmd: &Commands) -> &'static str {
         Commands::Coordinate { .. } => "coordinate",
         Commands::Plan { .. } => "plan",
         Commands::Reschedule { .. } => "reschedule",
+        Commands::Reprioritize { .. } => "reprioritize",
         Commands::Impact { .. } => "impact",
         Commands::Structure => "structure",
         Commands::Bottlenecks => "bottlenecks",

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -9,14 +9,30 @@ use super::graph_path;
 
 /// Resolve a model input string to a fully-qualified `provider:model` format.
 ///
-/// Handles three forms:
+/// Handles four forms (in priority order):
 /// 1. Already valid `provider:model` → pass through
-/// 2. `provider/model` format (e.g., `minimax/minimax-m2.7`) → `openrouter:provider/model`
-/// 3. Bare short name (e.g., `minimax-m2.7`) → resolve against model cache → `openrouter:resolved_id`
+/// 2. Matches a `[[model_registry]]` entry by ID → use registry provider + model
+/// 3. `provider/model` format (e.g., `minimax/minimax-m2.7`) → `openrouter:provider/model`
+/// 4. Bare short name (e.g., `minimax-m2.7`) → resolve against model cache → `openrouter:resolved_id`
 fn resolve_model_input(model: &str, workgraph_dir: &Path) -> Result<String> {
     // If it already passes strict validation, it's fine
     if workgraph::config::parse_model_spec_strict(model).is_ok() {
         return Ok(model.to_string());
+    }
+
+    // Check config model_registry before falling back to OpenRouter catalog.
+    if let Ok(config) = workgraph::config::Config::load_merged(workgraph_dir) {
+        if let Some(entry) = config.registry_lookup(model) {
+            let prefix = workgraph::config::native_provider_to_prefix(&entry.provider);
+            let full_spec = format!("{}:{}", prefix, entry.model);
+            if workgraph::config::parse_model_spec_strict(&full_spec).is_ok() {
+                eprintln!(
+                    "Resolved model '{}' → '{}' (from model_registry)",
+                    model, full_spec
+                );
+                return Ok(full_spec);
+            }
+        }
     }
 
     // Check if it has a `/` but no recognized provider prefix → assume OpenRouter format
@@ -1897,6 +1913,64 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let result = resolve_model_input("claude:opus", dir.path()).unwrap();
         assert_eq!(result, "claude:opus");
+    }
+
+    #[test]
+    fn resolve_model_input_prefers_model_registry() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_content = r#"
+[[model_registry]]
+id = "qwen3-coder-30b"
+provider = "openai"
+model = "qwen3-coder-30b"
+tier = "standard"
+endpoint = "lambda01-local"
+context_window = 32768
+"#;
+        std::fs::write(dir.path().join("config.toml"), config_content).unwrap();
+
+        let cache = serde_json::json!({
+            "fetched_at": "2026-04-01T00:00:00Z",
+            "models": [
+                {"id": "qwen/qwen3-coder-30b-a3b-instruct", "name": "Qwen3 Coder 30B"},
+            ]
+        });
+        std::fs::write(
+            dir.path().join("model_cache.json"),
+            cache.to_string(),
+        )
+        .unwrap();
+
+        let result = resolve_model_input("qwen3-coder-30b", dir.path()).unwrap();
+        assert_eq!(result, "openai:qwen3-coder-30b");
+    }
+
+    #[test]
+    fn resolve_model_input_falls_back_to_openrouter_when_not_in_registry() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_content = r#"
+[[model_registry]]
+id = "some-other-model"
+provider = "openai"
+model = "some-other-model"
+tier = "standard"
+"#;
+        std::fs::write(dir.path().join("config.toml"), config_content).unwrap();
+
+        let cache = serde_json::json!({
+            "fetched_at": "2026-04-01T00:00:00Z",
+            "models": [
+                {"id": "minimax/minimax-m2.7", "name": "Minimax M2.7"},
+            ]
+        });
+        std::fs::write(
+            dir.path().join("model_cache.json"),
+            cache.to_string(),
+        )
+        .unwrap();
+
+        let result = resolve_model_input("minimax-m2.7", dir.path()).unwrap();
+        assert_eq!(result, "openrouter:minimax/minimax-m2.7");
     }
 
     #[test]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -21,17 +21,17 @@ fn resolve_model_input(model: &str, workgraph_dir: &Path) -> Result<String> {
     }
 
     // Check config model_registry before falling back to OpenRouter catalog.
-    if let Ok(config) = workgraph::config::Config::load_merged(workgraph_dir) {
-        if let Some(entry) = config.registry_lookup(model) {
-            let prefix = workgraph::config::native_provider_to_prefix(&entry.provider);
-            let full_spec = format!("{}:{}", prefix, entry.model);
-            if workgraph::config::parse_model_spec_strict(&full_spec).is_ok() {
-                eprintln!(
-                    "Resolved model '{}' → '{}' (from model_registry)",
-                    model, full_spec
-                );
-                return Ok(full_spec);
-            }
+    if let Ok(config) = workgraph::config::Config::load_merged(workgraph_dir)
+        && let Some(entry) = config.registry_lookup(model)
+    {
+        let prefix = workgraph::config::native_provider_to_prefix(&entry.provider);
+        let full_spec = format!("{}:{}", prefix, entry.model);
+        if workgraph::config::parse_model_spec_strict(&full_spec).is_ok() {
+            eprintln!(
+                "Resolved model '{}' → '{}' (from model_registry)",
+                model, full_spec
+            );
+            return Ok(full_spec);
         }
     }
 

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -217,11 +217,12 @@ pub fn run(
 
     // Validate --subtask: requires WG_TASK_ID (must be called from within an agent context)
     let subtask_parent_id = if subtask {
-        let parent_id = std::env::var("WG_TASK_ID")
-            .map_err(|_| anyhow::anyhow!(
+        let parent_id = std::env::var("WG_TASK_ID").map_err(|_| {
+            anyhow::anyhow!(
                 "--subtask requires an active task context (WG_TASK_ID must be set). \
                  This flag is designed for agents to delegate blocking child tasks."
-            ))?;
+            )
+        })?;
         Some(parent_id)
     } else {
         None
@@ -706,9 +707,7 @@ pub fn run(
         }
 
         // Update agent status to Parked if there's an assigned agent
-        if let Ok(mut registry) =
-            workgraph::service::registry::AgentRegistry::load_locked(dir)
-        {
+        if let Ok(mut registry) = workgraph::service::registry::AgentRegistry::load_locked(dir) {
             for agent in registry.registry.agents.values_mut() {
                 if agent.task_id == parent_id && agent.is_alive() {
                     agent.status = workgraph::service::registry::AgentStatus::Parked;
@@ -723,8 +722,13 @@ pub fn run(
         super::notify_graph_changed(dir);
 
         println!("Added subtask: {} ({})", title, task_id);
-        println!("  Parent '{}' is now waiting for subtask to complete.", parent_id);
-        println!("  You should now exit cleanly. The coordinator will re-spawn you when the subtask finishes.");
+        println!(
+            "  Parent '{}' is now waiting for subtask to complete.",
+            parent_id
+        );
+        println!(
+            "  You should now exit cleanly. The coordinator will re-spawn you when the subtask finishes."
+        );
     } else if paused {
         println!("Added task (draft): {} ({})", title, task_id);
         println!(
@@ -1487,8 +1491,8 @@ mod tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         );
         assert!(result.is_err());
@@ -1542,8 +1546,8 @@ mod tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         );
         assert!(result.is_err());
@@ -1596,9 +1600,9 @@ mod tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         );
         assert!(result.is_err());
@@ -1658,9 +1662,9 @@ mod tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         );
         assert!(result.is_err());
@@ -1718,8 +1722,8 @@ mod tests {
             true,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         );
         assert!(result.is_ok());
@@ -1772,9 +1776,9 @@ mod tests {
             None,
             false, // allow_phantom=false, but paused=true defers validation
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         );
         assert!(result.is_ok());
@@ -1832,8 +1836,8 @@ mod tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         );
         assert!(result.is_ok());
@@ -1935,11 +1939,7 @@ context_window = 32768
                 {"id": "qwen/qwen3-coder-30b-a3b-instruct", "name": "Qwen3 Coder 30B"},
             ]
         });
-        std::fs::write(
-            dir.path().join("model_cache.json"),
-            cache.to_string(),
-        )
-        .unwrap();
+        std::fs::write(dir.path().join("model_cache.json"), cache.to_string()).unwrap();
 
         let result = resolve_model_input("qwen3-coder-30b", dir.path()).unwrap();
         assert_eq!(result, "openai:qwen3-coder-30b");
@@ -1963,11 +1963,7 @@ tier = "standard"
                 {"id": "minimax/minimax-m2.7", "name": "Minimax M2.7"},
             ]
         });
-        std::fs::write(
-            dir.path().join("model_cache.json"),
-            cache.to_string(),
-        )
-        .unwrap();
+        std::fs::write(dir.path().join("model_cache.json"), cache.to_string()).unwrap();
 
         let result = resolve_model_input("minimax-m2.7", dir.path()).unwrap();
         assert_eq!(result, "openrouter:minimax/minimax-m2.7");
@@ -2081,8 +2077,8 @@ tier = "standard"
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         );
         assert!(result.is_ok());
@@ -2143,8 +2139,8 @@ tier = "standard"
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         );
         assert!(result.is_ok());
@@ -2318,7 +2314,11 @@ tier = "standard"
 
         unsafe { std::env::remove_var("WG_TASK_ID") };
 
-        assert!(result.is_ok(), "subtask creation should succeed: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "subtask creation should succeed: {:?}",
+            result
+        );
 
         let graph = load_graph(&path).unwrap();
 

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -730,9 +730,9 @@ mod tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         )?;
 
@@ -774,8 +774,8 @@ mod tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         )?;
 
@@ -812,7 +812,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -854,7 +854,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -939,7 +939,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -981,7 +981,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1024,7 +1024,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1066,7 +1066,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1108,7 +1108,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1151,7 +1151,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1193,7 +1193,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1231,7 +1231,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1268,7 +1268,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1312,7 +1312,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1360,7 +1360,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         )
@@ -1392,7 +1392,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         );
@@ -1449,7 +1449,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         )
@@ -1514,7 +1514,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         )
@@ -1560,7 +1560,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         )
@@ -1601,7 +1601,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false,
         )
@@ -1670,7 +1670,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             false, // allow_cycle = false
         );
@@ -1736,7 +1736,7 @@ mod tests {
             None,
             None,
             None,
-            None,  // cron
+            None, // cron
             false,
             true, // allow_cycle = true
         );

--- a/src/commands/kill.rs
+++ b/src/commands/kill.rs
@@ -204,7 +204,7 @@ pub fn run_tree(
 
     // The full set: root task + all downstream
     let mut all_task_ids: Vec<String> = vec![task_id.to_string()];
-    all_task_ids.extend(downstream.into_iter());
+    all_task_ids.extend(downstream);
     all_task_ids.sort();
 
     // Find agents working on any of these tasks
@@ -323,24 +323,23 @@ pub fn run_tree(
         modify_graph(&path, |graph| {
             let mut changed = false;
             for tid in &tasks_to_abandon {
-                if let Some(task) = graph.get_task_mut(tid) {
-                    if !task.status.is_terminal() {
-                        task.status = Status::Abandoned;
-                        task.assigned = None;
-                        task.failure_reason =
-                            Some(format!("Tree-killed from root task '{}'", task_id));
-                        task.log.push(LogEntry {
-                            timestamp: Utc::now().to_rfc3339(),
-                            actor: None,
-                            user: Some(workgraph::current_user()),
-                            message: format!(
-                                "Tree-killed: abandoned as part of cascade from '{}'",
-                                task_id
-                            ),
-                        });
-                        abandoned_tasks.push(tid.clone());
-                        changed = true;
-                    }
+                if let Some(task) = graph.get_task_mut(tid)
+                    && !task.status.is_terminal()
+                {
+                    task.status = Status::Abandoned;
+                    task.assigned = None;
+                    task.failure_reason = Some(format!("Tree-killed from root task '{}'", task_id));
+                    task.log.push(LogEntry {
+                        timestamp: Utc::now().to_rfc3339(),
+                        actor: None,
+                        user: Some(workgraph::current_user()),
+                        message: format!(
+                            "Tree-killed: abandoned as part of cascade from '{}'",
+                            task_id
+                        ),
+                    });
+                    abandoned_tasks.push(tid.clone());
+                    changed = true;
                 }
             }
             changed

--- a/src/commands/kill.rs
+++ b/src/commands/kill.rs
@@ -294,9 +294,7 @@ pub fn run_tree(
 
             match kill_result {
                 Ok(()) => {
-                    if let Err(e) =
-                        locked_registry.update_status(agent_id, AgentStatus::Stopping)
-                    {
+                    if let Err(e) = locked_registry.update_status(agent_id, AgentStatus::Stopping) {
                         eprintln!(
                             "Warning: failed to update status for agent {}: {}",
                             agent_id, e
@@ -582,7 +580,10 @@ mod tests {
         // Verify nothing was changed (dry run)
         let graph = load_graph(graph_path(temp_dir.path())).unwrap();
         assert_eq!(graph.get_task("root").unwrap().status, Status::InProgress);
-        assert_eq!(graph.get_task("child-a").unwrap().status, Status::InProgress);
+        assert_eq!(
+            graph.get_task("child-a").unwrap().status,
+            Status::InProgress
+        );
         assert_eq!(graph.get_task("child-b").unwrap().status, Status::Open);
         assert_eq!(graph.get_task("grandchild").unwrap().status, Status::Open);
     }
@@ -606,13 +607,15 @@ mod tests {
         );
 
         // Check failure reason
-        assert!(graph
-            .get_task("child-a")
-            .unwrap()
-            .failure_reason
-            .as_ref()
-            .unwrap()
-            .contains("root"));
+        assert!(
+            graph
+                .get_task("child-a")
+                .unwrap()
+                .failure_reason
+                .as_ref()
+                .unwrap()
+                .contains("root")
+        );
     }
 
     #[test]
@@ -626,7 +629,10 @@ mod tests {
         // Tasks should NOT be abandoned with --no-abandon
         let graph = load_graph(graph_path(temp_dir.path())).unwrap();
         assert_eq!(graph.get_task("root").unwrap().status, Status::InProgress);
-        assert_eq!(graph.get_task("child-a").unwrap().status, Status::InProgress);
+        assert_eq!(
+            graph.get_task("child-a").unwrap().status,
+            Status::InProgress
+        );
         assert_eq!(graph.get_task("child-b").unwrap().status, Status::Open);
         assert_eq!(graph.get_task("grandchild").unwrap().status, Status::Open);
     }
@@ -638,7 +644,11 @@ mod tests {
 
         // Single task, no dependents
         let mut graph = WorkGraph::new();
-        graph.add_node(Node::Task(make_task("solo", "Solo Task", Status::InProgress)));
+        graph.add_node(Node::Task(make_task(
+            "solo",
+            "Solo Task",
+            Status::InProgress,
+        )));
         save_graph(&graph, &path).unwrap();
 
         let result = run_tree(temp_dir.path(), "solo", false, false, false, false);

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -227,8 +227,8 @@ mod tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -271,8 +271,8 @@ mod tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -315,8 +315,8 @@ mod tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -333,7 +333,15 @@ mod tests {
             dir.path(),
             vec![make_task("t1", "IP task", Status::InProgress)],
         );
-        let result = run(dir.path(), Some("in-progress"), false, &[], None, false, false);
+        let result = run(
+            dir.path(),
+            Some("in-progress"),
+            false,
+            &[],
+            None,
+            false,
+            false,
+        );
         assert!(result.is_ok());
     }
 
@@ -513,7 +521,15 @@ mod tests {
                 make_task("t2", "Open task", Status::Open),
             ],
         );
-        let result = run(dir.path(), Some("abandoned"), false, &[], None, false, false);
+        let result = run(
+            dir.path(),
+            Some("abandoned"),
+            false,
+            &[],
+            None,
+            false,
+            false,
+        );
         assert!(result.is_ok());
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -80,7 +80,7 @@ pub mod quickstart;
 pub mod ready;
 pub mod reap;
 pub mod reclaim;
-// pub mod reprioritize;  // TODO: Module file missing
+pub mod reprioritize;
 pub mod reject;
 pub mod replay;
 pub mod requeue;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -80,9 +80,9 @@ pub mod quickstart;
 pub mod ready;
 pub mod reap;
 pub mod reclaim;
-pub mod reprioritize;
 pub mod reject;
 pub mod replay;
+pub mod reprioritize;
 pub mod requeue;
 pub mod reschedule;
 pub mod resource;
@@ -269,9 +269,9 @@ mod provenance_coverage_tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -322,9 +322,9 @@ mod provenance_coverage_tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -409,9 +409,9 @@ mod provenance_coverage_tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -470,8 +470,8 @@ mod provenance_coverage_tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -524,8 +524,8 @@ mod provenance_coverage_tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -577,9 +577,9 @@ mod provenance_coverage_tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -631,9 +631,9 @@ mod provenance_coverage_tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -688,9 +688,9 @@ mod provenance_coverage_tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -747,9 +747,9 @@ mod provenance_coverage_tests {
             None,
             false,
             false,
-            None, // iteration_config
-            None, // priority
-            None, // cron
+            None,  // iteration_config
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -807,8 +807,8 @@ mod provenance_coverage_tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -863,8 +863,8 @@ mod provenance_coverage_tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();
@@ -922,8 +922,8 @@ mod provenance_coverage_tests {
             false,
             false,
             None,
-            None, // priority
-            None, // cron
+            None,  // priority
+            None,  // cron
             false, // subtask
         )
         .unwrap();

--- a/src/commands/native_exec.rs
+++ b/src/commands/native_exec.rs
@@ -61,11 +61,8 @@ pub fn run(
     let config = Config::load(workgraph_dir).unwrap_or_default();
 
     // Build the tool registry with config
-    let mut registry = ToolRegistry::default_all_with_config(
-        workgraph_dir,
-        &working_dir,
-        &config.native_executor,
-    );
+    let mut registry =
+        ToolRegistry::default_all_with_config(workgraph_dir, &working_dir, &config.native_executor);
 
     // Resolve bundle and filter tools
     let system_suffix = if let Some(bundle) = resolve_bundle(exec_mode, workgraph_dir) {

--- a/src/commands/reap.rs
+++ b/src/commands/reap.rs
@@ -75,18 +75,12 @@ fn is_old_enough(agent: &AgentEntry, min_age: &Duration) -> bool {
 }
 
 /// Collect agents eligible for reaping
-fn collect_reapable(
-    registry: &AgentRegistry,
-    older_than: Option<&Duration>,
-) -> Vec<AgentEntry> {
+fn collect_reapable(registry: &AgentRegistry, older_than: Option<&Duration>) -> Vec<AgentEntry> {
     registry
         .agents
         .values()
         .filter(|a| {
-            is_reapable(a.status)
-                && older_than
-                    .map(|d| is_old_enough(a, d))
-                    .unwrap_or(true)
+            is_reapable(a.status) && older_than.map(|d| is_old_enough(a, d)).unwrap_or(true)
         })
         .cloned()
         .collect()
@@ -282,18 +276,15 @@ mod tests {
 
         // Set agent-2 (dead) completed_at to 2 hours ago
         if let Some(agent) = registry.get_agent_mut("agent-2") {
-            agent.completed_at =
-                Some((Utc::now() - Duration::hours(2)).to_rfc3339());
+            agent.completed_at = Some((Utc::now() - Duration::hours(2)).to_rfc3339());
         }
         // Set agent-3 (done) completed_at to 30 seconds ago
         if let Some(agent) = registry.get_agent_mut("agent-3") {
-            agent.completed_at =
-                Some((Utc::now() - Duration::seconds(30)).to_rfc3339());
+            agent.completed_at = Some((Utc::now() - Duration::seconds(30)).to_rfc3339());
         }
         // Set agent-4 (failed) completed_at to 3 hours ago
         if let Some(agent) = registry.get_agent_mut("agent-4") {
-            agent.completed_at =
-                Some((Utc::now() - Duration::hours(3)).to_rfc3339());
+            agent.completed_at = Some((Utc::now() - Duration::hours(3)).to_rfc3339());
         }
 
         // Only reap agents older than 1 hour
@@ -355,8 +346,7 @@ mod tests {
 
         // Make agent-2 (dead) old enough
         if let Some(agent) = registry.get_agent_mut("agent-2") {
-            agent.completed_at =
-                Some((Utc::now() - Duration::hours(2)).to_rfc3339());
+            agent.completed_at = Some((Utc::now() - Duration::hours(2)).to_rfc3339());
         }
         // Keep agent-3 (done) recent
         if let Some(agent) = registry.get_agent_mut("agent-3") {
@@ -364,8 +354,7 @@ mod tests {
         }
         // Make agent-4 (failed) old enough
         if let Some(agent) = registry.get_agent_mut("agent-4") {
-            agent.completed_at =
-                Some((Utc::now() - Duration::hours(5)).to_rfc3339());
+            agent.completed_at = Some((Utc::now() - Duration::hours(5)).to_rfc3339());
         }
 
         registry.save(tmp.path()).unwrap();

--- a/src/commands/reprioritize.rs
+++ b/src/commands/reprioritize.rs
@@ -45,10 +45,7 @@ pub fn run(dir: &Path, id: &str, priority: &str) -> Result<()> {
     super::notify_graph_changed(dir);
 
     if old_priority == new_priority {
-        println!(
-            "Task '{}' already has priority '{}'",
-            id, new_priority
-        );
+        println!("Task '{}' already has priority '{}'", id, new_priority);
     } else {
         println!(
             "Reprioritized '{}': {} -> {}",

--- a/src/commands/reprioritize.rs
+++ b/src/commands/reprioritize.rs
@@ -1,0 +1,196 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+use workgraph::graph::Priority;
+use workgraph::parser::modify_graph;
+
+use super::add::parse_priority;
+
+#[cfg(test)]
+use super::graph_path;
+#[cfg(test)]
+use workgraph::parser::load_graph;
+
+pub fn run(dir: &Path, id: &str, priority: &str) -> Result<()> {
+    let path = super::graph_path(dir);
+    if !path.exists() {
+        anyhow::bail!("Workgraph not initialized. Run 'wg init' first.");
+    }
+
+    let new_priority = parse_priority(Some(priority));
+
+    let mut error: Option<anyhow::Error> = None;
+    let mut old_priority = Priority::Normal;
+    modify_graph(&path, |graph| {
+        let task = match graph.get_task_mut(id) {
+            Some(t) => t,
+            None => {
+                error = Some(anyhow::anyhow!("Task '{}' not found", id));
+                return false;
+            }
+        };
+
+        old_priority = task.priority;
+        if task.priority == new_priority {
+            return false;
+        }
+
+        task.priority = new_priority;
+        true
+    })
+    .context("Failed to modify graph")?;
+    if let Some(e) = error {
+        return Err(e);
+    }
+
+    super::notify_graph_changed(dir);
+
+    if old_priority == new_priority {
+        println!(
+            "Task '{}' already has priority '{}'",
+            id, new_priority
+        );
+    } else {
+        println!(
+            "Reprioritized '{}': {} -> {}",
+            id, old_priority, new_priority
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+    use workgraph::graph::{Node, Task, WorkGraph};
+    use workgraph::parser::save_graph;
+
+    fn make_task(id: &str, title: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            title: title.to_string(),
+            ..Task::default()
+        }
+    }
+
+    fn setup_workgraph(dir: &Path, tasks: Vec<Task>) -> std::path::PathBuf {
+        fs::create_dir_all(dir).unwrap();
+        let path = graph_path(dir);
+        let mut graph = WorkGraph::new();
+        for task in tasks {
+            graph.add_node(Node::Task(task));
+        }
+        save_graph(&graph, &path).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_reprioritize_normal_to_high() {
+        let dir = tempdir().unwrap();
+        let task = make_task("t1", "Task 1");
+        setup_workgraph(dir.path(), vec![task]);
+
+        run(dir.path(), "t1", "high").unwrap();
+
+        let graph = load_graph(graph_path(dir.path())).unwrap();
+        let task = graph.get_task("t1").unwrap();
+        assert_eq!(task.priority, Priority::High);
+    }
+
+    #[test]
+    fn test_reprioritize_to_critical() {
+        let dir = tempdir().unwrap();
+        let task = make_task("t1", "Task 1");
+        setup_workgraph(dir.path(), vec![task]);
+
+        run(dir.path(), "t1", "critical").unwrap();
+
+        let graph = load_graph(graph_path(dir.path())).unwrap();
+        let task = graph.get_task("t1").unwrap();
+        assert_eq!(task.priority, Priority::Critical);
+    }
+
+    #[test]
+    fn test_reprioritize_to_low() {
+        let dir = tempdir().unwrap();
+        let task = make_task("t1", "Task 1");
+        setup_workgraph(dir.path(), vec![task]);
+
+        run(dir.path(), "t1", "low").unwrap();
+
+        let graph = load_graph(graph_path(dir.path())).unwrap();
+        let task = graph.get_task("t1").unwrap();
+        assert_eq!(task.priority, Priority::Low);
+    }
+
+    #[test]
+    fn test_reprioritize_to_idle() {
+        let dir = tempdir().unwrap();
+        let task = make_task("t1", "Task 1");
+        setup_workgraph(dir.path(), vec![task]);
+
+        run(dir.path(), "t1", "idle").unwrap();
+
+        let graph = load_graph(graph_path(dir.path())).unwrap();
+        let task = graph.get_task("t1").unwrap();
+        assert_eq!(task.priority, Priority::Idle);
+    }
+
+    #[test]
+    fn test_reprioritize_same_priority_noop() {
+        let dir = tempdir().unwrap();
+        let task = make_task("t1", "Task 1");
+        setup_workgraph(dir.path(), vec![task]);
+
+        run(dir.path(), "t1", "normal").unwrap();
+
+        let graph = load_graph(graph_path(dir.path())).unwrap();
+        let task = graph.get_task("t1").unwrap();
+        assert_eq!(task.priority, Priority::Normal);
+    }
+
+    #[test]
+    fn test_reprioritize_nonexistent_task() {
+        let dir = tempdir().unwrap();
+        setup_workgraph(dir.path(), vec![]);
+
+        let result = run(dir.path(), "nonexistent", "high");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_reprioritize_uninitialized_workgraph() {
+        let dir = tempdir().unwrap();
+        let result = run(dir.path(), "t1", "high");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_reprioritize_case_insensitive() {
+        let dir = tempdir().unwrap();
+        let task = make_task("t1", "Task 1");
+        setup_workgraph(dir.path(), vec![task]);
+
+        run(dir.path(), "t1", "HIGH").unwrap();
+
+        let graph = load_graph(graph_path(dir.path())).unwrap();
+        let task = graph.get_task("t1").unwrap();
+        assert_eq!(task.priority, Priority::High);
+    }
+
+    #[test]
+    fn test_reprioritize_with_existing_priority() {
+        let dir = tempdir().unwrap();
+        let mut task = make_task("t1", "Task 1");
+        task.priority = Priority::Critical;
+        setup_workgraph(dir.path(), vec![task]);
+
+        run(dir.path(), "t1", "low").unwrap();
+
+        let graph = load_graph(graph_path(dir.path())).unwrap();
+        let task = graph.get_task("t1").unwrap();
+        assert_eq!(task.priority, Priority::Low);
+    }
+}

--- a/src/commands/service/coordinator.rs
+++ b/src/commands/service/coordinator.rs
@@ -422,12 +422,7 @@ fn build_resume_delta(graph: &workgraph::graph::WorkGraph, task: &Task, dir: &Pa
                     }
                 }
                 // Include recent log entries from completed subtasks for result context
-                let recent_logs: Vec<_> = dep
-                    .log
-                    .iter()
-                    .rev()
-                    .take(3)
-                    .collect();
+                let recent_logs: Vec<_> = dep.log.iter().rev().take(3).collect();
                 if !recent_logs.is_empty() {
                     for log in recent_logs.iter().rev() {
                         delta.push_str(&format!("  log: {}\n", log.message));

--- a/src/commands/service/coordinator.rs
+++ b/src/commands/service/coordinator.rs
@@ -429,10 +429,10 @@ fn build_resume_delta(graph: &workgraph::graph::WorkGraph, task: &Task, dir: &Pa
                     }
                 }
                 // Include failure reason if the subtask failed
-                if dep.status == Status::Failed {
-                    if let Some(ref reason) = dep.failure_reason {
-                        delta.push_str(&format!("  failure_reason: {}\n", reason));
-                    }
+                if dep.status == Status::Failed
+                    && let Some(ref reason) = dep.failure_reason
+                {
+                    delta.push_str(&format!("  failure_reason: {}\n", reason));
                 }
             }
         }
@@ -3837,15 +3837,15 @@ pub fn coordinator_tick(
                 .map(|t| t.id.clone())
                 .collect();
             for task_id in &cron_task_ids {
-                if let Some(task) = graph.get_task_mut(task_id) {
-                    if workgraph::cron::reset_cron_task(task) {
-                        eprintln!(
-                            "[coordinator] Cron reset: '{}' → Open (next fire: {})",
-                            task_id,
-                            task.next_cron_fire.as_deref().unwrap_or("unknown")
-                        );
-                        modified = true;
-                    }
+                if let Some(task) = graph.get_task_mut(task_id)
+                    && workgraph::cron::reset_cron_task(task)
+                {
+                    eprintln!(
+                        "[coordinator] Cron reset: '{}' → Open (next fire: {})",
+                        task_id,
+                        task.next_cron_fire.as_deref().unwrap_or("unknown")
+                    );
+                    modified = true;
                 }
             }
         }

--- a/src/commands/service/worktree.rs
+++ b/src/commands/service/worktree.rs
@@ -1814,10 +1814,8 @@ mod tests {
         fs::create_dir_all(wg_dir.join("service")).unwrap();
 
         // Create worktrees for two agents: one live, one dead
-        let (live_wt, _live_branch) =
-            create_test_worktree(&project, "agent-100", "task-live");
-        let (dead_wt, _dead_branch) =
-            create_test_worktree(&project, "agent-200", "task-dead");
+        let (live_wt, _live_branch) = create_test_worktree(&project, "agent-100", "task-live");
+        let (dead_wt, _dead_branch) = create_test_worktree(&project, "agent-200", "task-dead");
 
         assert!(live_wt.exists());
         assert!(dead_wt.exists());

--- a/src/commands/service/worktree.rs
+++ b/src/commands/service/worktree.rs
@@ -205,17 +205,9 @@ pub fn remove_worktree(project_root: &Path, worktree_path: &Path, branch: &str) 
         resources.branches_pruned += 1;
     }
 
-    // Prune stale worktree entries
-    let output = Command::new("git")
-        .args(["worktree", "prune"])
-        .current_dir(project_root)
-        .output()
-        .context("Failed to execute git worktree prune command")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        cleanup_errors.push(format!("Git worktree prune failed: {}", stderr.trim()));
-    }
+    // NOTE: We intentionally do NOT run `git worktree prune` here.
+    // Global prune can remove metadata for other agents' worktrees that are
+    // temporarily missing during concurrent cleanup, causing data loss.
 
     let success = cleanup_errors.is_empty();
     timer.complete(success, resources);
@@ -669,13 +661,9 @@ pub fn cleanup_orphaned_worktrees(dir: &Path) -> Result<usize> {
         }
     }
 
-    // Final prune to clean up any stale git worktree metadata
-    if cleaned > 0 {
-        let _ = Command::new("git")
-            .args(["worktree", "prune"])
-            .current_dir(project_root)
-            .output();
-    }
+    // NOTE: We intentionally do NOT run `git worktree prune` here.
+    // Other agents may be running concurrently; global prune can damage their
+    // worktree metadata if their directory is temporarily absent.
 
     let resources = workgraph::metrics::ResourceRecoveryStats {
         worktrees_removed: cleaned as u64,
@@ -804,12 +792,7 @@ pub fn prune_stale_worktrees(dir: &Path, max_age_secs: u64) -> Result<usize> {
         }
     }
 
-    if pruned > 0 {
-        let _ = Command::new("git")
-            .args(["worktree", "prune"])
-            .current_dir(project_root)
-            .output();
-    }
+    // NOTE: No global `git worktree prune` — concurrent agents may be running.
 
     Ok(pruned)
 }
@@ -1816,6 +1799,75 @@ mod tests {
 
         let pruned = prune_recovery_branches(&project, &config).unwrap();
         assert_eq!(pruned, 0);
+    }
+
+    #[test]
+    fn test_cleanup_orphaned_worktrees_skips_live_agents() {
+        use workgraph::service::registry::{AgentEntry, AgentRegistry, AgentStatus};
+
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        init_git_repo(&project);
+
+        let wg_dir = project.join(".workgraph");
+        fs::create_dir_all(wg_dir.join("service")).unwrap();
+
+        // Create worktrees for two agents: one live, one dead
+        let (live_wt, _live_branch) =
+            create_test_worktree(&project, "agent-100", "task-live");
+        let (dead_wt, _dead_branch) =
+            create_test_worktree(&project, "agent-200", "task-dead");
+
+        assert!(live_wt.exists());
+        assert!(dead_wt.exists());
+
+        // Build a registry where agent-100 is alive (use our own PID) and
+        // agent-200 is dead (use a non-existent PID).
+        let our_pid = std::process::id();
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut registry = AgentRegistry::default();
+        registry.agents.insert(
+            "agent-100".to_string(),
+            AgentEntry {
+                id: "agent-100".to_string(),
+                pid: our_pid,
+                task_id: "task-live".to_string(),
+                executor: "test".to_string(),
+                started_at: now.clone(),
+                last_heartbeat: now.clone(),
+                status: AgentStatus::Working,
+                output_file: String::new(),
+                model: None,
+                completed_at: None,
+            },
+        );
+        registry.agents.insert(
+            "agent-200".to_string(),
+            AgentEntry {
+                id: "agent-200".to_string(),
+                pid: 999_999_999, // non-existent PID
+                task_id: "task-dead".to_string(),
+                executor: "test".to_string(),
+                started_at: now.clone(),
+                last_heartbeat: now.clone(),
+                status: AgentStatus::Dead,
+                output_file: String::new(),
+                model: None,
+                completed_at: None,
+            },
+        );
+        registry.save(&wg_dir).unwrap();
+
+        // Run orphan cleanup
+        let cleaned = cleanup_orphaned_worktrees(&wg_dir).unwrap();
+
+        // Dead agent's worktree should be cleaned
+        assert_eq!(cleaned, 1, "should clean exactly 1 orphaned worktree");
+        assert!(!dead_wt.exists(), "dead agent worktree should be removed");
+
+        // Live agent's worktree MUST survive
+        assert!(live_wt.exists(), "live agent worktree must NOT be removed");
     }
 }
 

--- a/src/commands/service/worktree.rs
+++ b/src/commands/service/worktree.rs
@@ -25,6 +25,15 @@ use std::os::unix::fs::PermissionsExt;
 /// The directory under the project root where agent worktrees live.
 pub const WORKTREES_DIR: &str = ".wg-worktrees";
 
+/// Heartbeat freshness timeout (seconds) for the worktree-cleanup
+/// liveness check. A worktree is considered owned by a live agent only
+/// if the agent's last heartbeat is within this window AND its process
+/// is alive AND its status is alive. Set generously (5 minutes) to
+/// accommodate agents that briefly stall during long tool calls.
+///
+/// See `AgentEntry::is_live` for the full invariant.
+const HEARTBEAT_LIVENESS_TIMEOUT_SECS: u64 = 300;
+
 /// Maximum number of retry attempts for transient failures.
 const MAX_RETRIES: usize = 3;
 
@@ -589,7 +598,7 @@ pub fn cleanup_orphaned_worktrees(dir: &Path) -> Result<usize> {
         let is_alive = registry
             .agents
             .get(&name)
-            .map(|a| a.is_alive() && crate::commands::is_process_alive(a.pid))
+            .map(|a| a.is_live(HEARTBEAT_LIVENESS_TIMEOUT_SECS))
             .unwrap_or(false);
 
         if !is_alive {
@@ -703,7 +712,7 @@ pub fn prune_stale_worktrees(dir: &Path, max_age_secs: u64) -> Result<usize> {
         let is_alive = registry
             .agents
             .get(&name)
-            .map(|a| a.is_alive() && crate::commands::is_process_alive(a.pid))
+            .map(|a| a.is_live(HEARTBEAT_LIVENESS_TIMEOUT_SECS))
             .unwrap_or(false);
 
         if is_alive {

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -2,11 +2,11 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use std::path::Path;
+use workgraph::config::Config;
 use workgraph::graph::{
     CycleConfig, LogEntry, LoopGuard, Priority, Status, Task, TokenUsage, format_tokens,
     parse_token_usage_live,
 };
-use workgraph::config::Config;
 use workgraph::query::build_reverse_index;
 use workgraph::service::AgentRegistry;
 
@@ -190,11 +190,7 @@ fn gather_task_runtime_info(
                 .as_ref()
                 .and_then(|s| s.model_override.clone())
                 .or(actual_model)
-                .or_else(|| {
-                    coord_state
-                        .as_ref()
-                        .and_then(|s| s.model.clone())
-                })
+                .or_else(|| coord_state.as_ref().and_then(|s| s.model.clone()))
                 .or_else(|| config.coordinator.model.clone())
                 .or_else(|| {
                     Some(

--- a/src/commands/spawn/context.rs
+++ b/src/commands/spawn/context.rs
@@ -688,18 +688,24 @@ fn build_essential_guide(workgraph_dir: &Path) -> String {
 
 ## Decision Framework: When to Decompose vs Implement
 
-### Implement Directly If:
-- Task is small and well-scoped
-- Touches ≤2-3 files
-- Single logical unit of work
-- No external dependencies or unknowns
+Fanout is a tool, not a default. Assess complexity first, then decide.
+
+### Stay inline (default) when:
+- Task is straightforward, even if it touches multiple files sequentially
+- Each step depends on the previous (sequential work doesn't parallelize)
+- Simple fixes, config changes, small features
 - Task seems hard but is single-scope — difficulty alone is NOT a reason to decompose
 
-### Decompose (create subtasks) If:
-- Task has 3+ genuinely independent parts that benefit from parallel work
-- Involves multiple modules/components
-- Would take multiple distinct phases
-- Discovers bugs or missing prereqs outside scope
+### Fan out when:
+- 3+ independent files/components need changes that can genuinely run in parallel
+- You hit context pressure (re-reading files, losing track of changes)
+- Natural parallelism exists (e.g., 3 separate test files, N independent modules)
+- Discovered bugs or missing prereqs outside your scope
+
+### If you decompose:
+- Each subtask must list its file scope — NO two subtasks may modify the same file
+- Include "Implement directly — do not decompose further" in subtask descriptions
+- Always include an integrator task at join points
 
 ## Decomposition Pattern Templates
 

--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -1260,11 +1260,15 @@ Squash-merged from worktree branch $WG_BRANCH" 2>> "$OUTPUT_FILE"
         fi
     fi
 
-    # Always clean up the worktree, regardless of task outcome
-    rm -f "$WG_WORKTREE_PATH/.workgraph" 2>/dev/null
-    git -C "$WG_PROJECT_ROOT" worktree remove --force "$WG_WORKTREE_PATH" 2>/dev/null
-    git -C "$WG_PROJECT_ROOT" branch -D "$WG_BRANCH" 2>/dev/null
-    echo "[wrapper] Cleaned up worktree at $WG_WORKTREE_PATH" >> "$OUTPUT_FILE"
+    # Only clean up the worktree on success; preserve on failure for debugging/retry
+    if [ "$TASK_STATUS_FINAL" = "done" ] || [ "$TASK_STATUS_FINAL" = "pending-validation" ]; then
+        rm -f "$WG_WORKTREE_PATH/.workgraph" 2>/dev/null
+        git -C "$WG_PROJECT_ROOT" worktree remove --force "$WG_WORKTREE_PATH" 2>/dev/null
+        git -C "$WG_PROJECT_ROOT" branch -D "$WG_BRANCH" 2>/dev/null
+        echo "[wrapper] Cleaned up worktree at $WG_WORKTREE_PATH" >> "$OUTPUT_FILE"
+    else
+        echo "[wrapper] TASK_STATUS_FINAL is '$TASK_STATUS_FINAL' (failed or non-success) — skip cleanup, preserving worktree at $WG_WORKTREE_PATH for debugging" >> "$OUTPUT_FILE"
+    fi
 fi
 
 exit $EXIT_CODE

--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -321,6 +321,8 @@ pub(crate) fn spawn_agent_inner(
         None
     };
 
+    vars.in_worktree = worktree_info.is_some();
+
     // Apply templates to executor settings (with effective model in vars)
     let mut settings = executor_config.apply_templates(&vars);
 
@@ -565,6 +567,9 @@ pub(crate) fn spawn_agent_inner(
         cmd.env("WG_WORKTREE_PATH", &wt.path);
         cmd.env("WG_BRANCH", &wt.branch);
         cmd.env("WG_PROJECT_ROOT", &wt.project_root);
+        // Signal to Claude Code (and other tools) that this session is already
+        // inside a managed worktree — do not create a competing one.
+        cmd.env("WG_WORKTREE_ACTIVE", "1");
         // Isolate cargo target directory to prevent file lock contention between agents
         cmd.env("CARGO_TARGET_DIR", wt.path.join("target"));
     } else if let Some(ref wd) = settings.working_dir {
@@ -1213,6 +1218,13 @@ fi
 # branch and clean up the worktree. Env vars are set by spawn when worktree
 # isolation is enabled; this section is a no-op otherwise.
 if [ -n "$WG_WORKTREE_PATH" ] && [ -n "$WG_BRANCH" ] && [ -n "$WG_PROJECT_ROOT" ]; then
+    # Worktree integrity check: verify the .git pointer still exists.
+    # If the agent escaped to a Claude Code worktree, the wg worktree's .git
+    # may have been severed by a competing git worktree add with the same basename.
+    if [ ! -e "$WG_WORKTREE_PATH/.git" ]; then
+        echo "[wrapper] WARNING: Worktree .git pointer missing at $WG_WORKTREE_PATH — possible worktree escape detected" >> "$OUTPUT_FILE"
+    fi
+
     TASK_STATUS_FINAL=$(wg show "$TASK_ID" --json 2>/dev/null | grep -o '"status": *"[^"]*"' | head -1 | sed 's/.*"status": *"//;s/"//' || echo "unknown")
 
     if [ "$TASK_STATUS_FINAL" = "done" ] || [ "$TASK_STATUS_FINAL" = "pending-validation" ]; then
@@ -2462,6 +2474,7 @@ mod tests {
             max_task_depth: 0,
             has_failed_deps: false,
             failed_deps_info: String::new(),
+            in_worktree: false,
         };
 
         let command = build_inner_command(

--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -911,7 +911,9 @@ fn build_inner_command(
             cmd_parts.push("--allowedTools".to_string());
             cmd_parts.push(shell_escape("Bash(wg:*),Read,Glob,Grep,WebFetch,WebSearch"));
             cmd_parts.push("--disallowedTools".to_string());
-            cmd_parts.push(shell_escape("Edit,Write,NotebookEdit,Agent,EnterWorktree,ExitWorktree"));
+            cmd_parts.push(shell_escape(
+                "Edit,Write,NotebookEdit,Agent,EnterWorktree,ExitWorktree",
+            ));
 
             cmd_parts.push("--disable-slash-commands".to_string());
             // Add model flag if specified

--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -333,6 +333,12 @@ pub(crate) fn spawn_agent_inner(
     let model_tier = super::context::classify_model_tier(model_str);
     scope_ctx.wg_guide_content = super::context::build_tiered_guide(dir, model_tier, model_str);
 
+    // Native executor exposes its own in-process file tools
+    // (`read_file`/`write_file`/`edit_file`/`grep`/`glob`). When spawning
+    // via native, inject the guidance section that teaches the model about
+    // those tools and warns against bash-based file manipulation.
+    scope_ctx.native_file_tools = settings.executor_type == "native";
+
     // Scope-based prompt assembly for built-in executors.
     // When no custom prompt_template is defined (built-in defaults),
     // use build_prompt() to assemble the prompt based on context scope.

--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -833,7 +833,7 @@ fn build_inner_command(
             cmd_parts.push("stream-json".to_string());
             cmd_parts.push("--dangerously-skip-permissions".to_string());
             cmd_parts.push("--disallowedTools".to_string());
-            cmd_parts.push(shell_escape("Agent"));
+            cmd_parts.push(shell_escape("Agent,EnterWorktree,ExitWorktree"));
             cmd_parts.push("--disable-slash-commands".to_string());
             if let Some(m) = effective_model {
                 cmd_parts.push("--model".to_string());
@@ -905,7 +905,7 @@ fn build_inner_command(
             cmd_parts.push("--allowedTools".to_string());
             cmd_parts.push(shell_escape("Bash(wg:*),Read,Glob,Grep,WebFetch,WebSearch"));
             cmd_parts.push("--disallowedTools".to_string());
-            cmd_parts.push(shell_escape("Edit,Write,NotebookEdit,Agent"));
+            cmd_parts.push(shell_escape("Edit,Write,NotebookEdit,Agent,EnterWorktree,ExitWorktree"));
 
             cmd_parts.push("--disable-slash-commands".to_string());
             // Add model flag if specified
@@ -934,7 +934,7 @@ fn build_inner_command(
             }
             // Prevent agents from spawning sub-agents outside workgraph
             cmd_parts.push("--disallowedTools".to_string());
-            cmd_parts.push(shell_escape("Agent"));
+            cmd_parts.push(shell_escape("Agent,EnterWorktree,ExitWorktree"));
 
             cmd_parts.push("--disable-slash-commands".to_string());
             // Add model flag if specified

--- a/src/commands/spawn/worktree.rs
+++ b/src/commands/spawn/worktree.rs
@@ -104,11 +104,9 @@ pub fn remove_worktree(project_root: &Path, worktree_path: &Path, branch: &str) 
         .current_dir(project_root)
         .output();
 
-    // Prune stale worktree entries
-    let _ = Command::new("git")
-        .args(["worktree", "prune"])
-        .current_dir(project_root)
-        .output();
+    // NOTE: We intentionally do NOT run `git worktree prune` here.
+    // Global prune can remove metadata for other agents' worktrees that are
+    // temporarily missing during concurrent cleanup, causing data loss.
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6572,7 +6572,10 @@ profile = "openrouter"
         assert_eq!(config.native_executor.web.fetch_timeout_secs, 30);
         assert!(config.native_executor.web.search_api_key.is_none());
         assert_eq!(config.native_executor.background.max_background_tasks, 5);
-        assert_eq!(config.native_executor.background.background_timeout_secs, 600);
+        assert_eq!(
+            config.native_executor.background.background_timeout_secs,
+            600
+        );
         assert_eq!(config.native_executor.delegate.delegate_max_turns, 10);
         assert_eq!(config.native_executor.delegate.delegate_model, "");
     }
@@ -6596,13 +6599,22 @@ delegate_model = "claude-haiku-4-5-20251001"
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.native_executor.web.search_backend, "serper");
-        assert_eq!(config.native_executor.web.search_api_key, Some("sk-test-123".to_string()));
+        assert_eq!(
+            config.native_executor.web.search_api_key,
+            Some("sk-test-123".to_string())
+        );
         assert_eq!(config.native_executor.web.fetch_max_chars, 32_000);
         assert_eq!(config.native_executor.web.fetch_timeout_secs, 60);
         assert_eq!(config.native_executor.background.max_background_tasks, 10);
-        assert_eq!(config.native_executor.background.background_timeout_secs, 1200);
+        assert_eq!(
+            config.native_executor.background.background_timeout_secs,
+            1200
+        );
         assert_eq!(config.native_executor.delegate.delegate_max_turns, 15);
-        assert_eq!(config.native_executor.delegate.delegate_model, "claude-haiku-4-5-20251001");
+        assert_eq!(
+            config.native_executor.delegate.delegate_model,
+            "claude-haiku-4-5-20251001"
+        );
     }
 
     #[test]

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -453,12 +453,24 @@ mod tests {
         };
 
         let result = reset_cron_task(&mut task);
-        assert!(result, "reset_cron_task should return true for Done cron task");
+        assert!(
+            result,
+            "reset_cron_task should return true for Done cron task"
+        );
         assert_eq!(task.status, crate::graph::Status::Open);
         assert!(task.assigned.is_none(), "assigned should be cleared");
-        assert!(task.completed_at.is_none(), "completed_at should be cleared");
-        assert!(task.last_cron_fire.is_some(), "last_cron_fire should be set");
-        assert!(task.next_cron_fire.is_some(), "next_cron_fire should be set");
+        assert!(
+            task.completed_at.is_none(),
+            "completed_at should be cleared"
+        );
+        assert!(
+            task.last_cron_fire.is_some(),
+            "last_cron_fire should be set"
+        );
+        assert!(
+            task.next_cron_fire.is_some(),
+            "next_cron_fire should be set"
+        );
     }
 
     #[test]
@@ -511,7 +523,10 @@ mod tests {
         let from = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
 
         let jitter = calculate_jitter("task-a", &schedule, from);
-        assert!(jitter.num_seconds().abs() <= 6, "jitter should be ≤6s for minute schedule");
+        assert!(
+            jitter.num_seconds().abs() <= 6,
+            "jitter should be ≤6s for minute schedule"
+        );
     }
 
     #[test]
@@ -527,7 +542,10 @@ mod tests {
         let next = next.unwrap();
         let raw_next = Utc.with_ymd_and_hms(2024, 1, 1, 2, 0, 0).unwrap();
         let diff = (next - raw_next).num_seconds().abs();
-        assert!(diff <= MAX_JITTER_SECS, "jitter should be within MAX_JITTER_SECS");
+        assert!(
+            diff <= MAX_JITTER_SECS,
+            "jitter should be within MAX_JITTER_SECS"
+        );
     }
 
     #[test]

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -224,12 +224,12 @@ pub fn is_cron_due(task: &Task, now: DateTime<Utc>) -> bool {
     };
 
     // If we have a pre-computed next_cron_fire (includes jitter), use that
-    if let Some(ref next_fire_str) = task.next_cron_fire {
-        if let Ok(next_fire) = DateTime::parse_from_rfc3339(next_fire_str) {
-            return next_fire.with_timezone(&Utc) <= now;
-        }
-        // Invalid timestamp, fall through to schedule-based check
+    if let Some(ref next_fire_str) = task.next_cron_fire
+        && let Ok(next_fire) = DateTime::parse_from_rfc3339(next_fire_str)
+    {
+        return next_fire.with_timezone(&Utc) <= now;
     }
+    // Invalid timestamp, fall through to schedule-based check
 
     // If no last fire time, check if we should fire now based on schedule
     let last_fire = match &task.last_cron_fire {

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -576,18 +576,21 @@ impl AgentLoop {
                         );
                         let pre_tokens = self.context_budget.effective_tokens(&messages);
                         // On a hard context-too-long error, use the aggressive
-                        // compact: drop ALL tool results in older turns, strip
-                        // thinking, truncate long text, keep only 2 recent
-                        // messages verbatim.
-                        messages = ContextBudget::hard_emergency_compact(messages, 2);
+                        // compact: drop ALL tool results except the single
+                        // most recent one (keep_recent_tool_results=1), strip
+                        // thinking in elided messages, truncate long text.
+                        // keep_recent counts tool-result occurrences, not
+                        // messages — so recent-position big tool results
+                        // actually get shrunk.
+                        messages = ContextBudget::hard_emergency_compact(messages, 1);
                         let post_tokens = self.context_budget.effective_tokens(&messages);
+                        let delta = pre_tokens.saturating_sub(post_tokens);
                         eprintln!(
-                            "[native-agent] Hard emergency compacted: ~{} → ~{} tokens ({} → {} messages, overhead {} kept)",
+                            "[native-agent] Hard emergency compacted: ~{} → ~{} tokens (Δ -{}, overhead {} kept, keep_recent_tool_results=1)",
                             pre_tokens,
                             post_tokens,
-                            pre_tokens.saturating_sub(self.context_budget.overhead_tokens),
-                            post_tokens.saturating_sub(self.context_budget.overhead_tokens),
-                            self.context_budget.overhead_tokens
+                            delta,
+                            self.context_budget.overhead_tokens,
                         );
 
                         // Reduce completion reservation on retry to free budget for
@@ -1133,16 +1136,22 @@ impl AgentLoop {
                     }
                 }
                 ContextPressureAction::EmergencyCompaction => {
-                    // Proactive compaction at the compact threshold — strip
-                    // old tool results before the hard limit is reached.
+                    // Proactive compaction at the compact threshold — shrink
+                    // all tool results except the most recent 2 before the
+                    // hard limit is reached. keep_recent counts tool-result
+                    // occurrences, not messages, so recent-position big tool
+                    // results actually get shrunk (the main reason this fires
+                    // for chatty file-reading workloads).
                     let pre_tokens = self.context_budget.effective_tokens(&messages);
                     let pre_count = messages.len();
-                    messages = ContextBudget::emergency_compact(messages, 5);
+                    messages = ContextBudget::emergency_compact(messages, 2);
                     let post_tokens = self.context_budget.effective_tokens(&messages);
+                    let delta = pre_tokens.saturating_sub(post_tokens);
                     eprintln!(
-                        "[native-agent] Proactive compaction: ~{} → ~{} tokens ({} messages, overhead {} kept)",
+                        "[native-agent] Proactive compaction: ~{} → ~{} tokens (Δ -{}, {} messages, overhead {} kept, keep_recent_tool_results=2)",
                         pre_tokens,
                         post_tokens,
+                        delta,
                         pre_count,
                         self.context_budget.overhead_tokens
                     );

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -1237,10 +1237,15 @@ impl AgentLoop {
                         consecutive_noop_compactions,
                     );
 
-                    // Journal the compaction event
+                    // Journal the compaction event. `compacted_through_seq`
+                    // records the seq of the last journal entry this
+                    // compaction supersedes — on resume, reconstruct_messages
+                    // drops entries with seq ≤ this value and substitutes
+                    // `summary` in their place.
                     if let Some(ref mut j) = journal {
+                        let compacted_through_seq = j.seq();
                         let _ = j.append(JournalEntryKind::Compaction {
-                            compacted_through_seq: 0,
+                            compacted_through_seq,
                             summary: format!(
                                 "{} compaction. Tokens: ~{} → ~{}, messages: {} → {}.",
                                 tier_name, pre_tokens, post_tokens, pre_count, post_count

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -16,7 +16,9 @@ use super::client::{
 };
 use super::journal::{EndReason, Journal, JournalEntryKind};
 use super::provider::Provider;
-use super::resume::{self, ContextBudget, ContextPressureAction, ResumeConfig};
+use super::resume::{
+    self, ContextBudget, ContextPressureAction, ResumeConfig, estimate_agent_overhead,
+};
 use super::state_injection::StateInjector;
 use super::tools::ToolRegistry;
 use crate::stream_event::{self, StreamWriter, TotalUsage, TurnUsage};
@@ -189,8 +191,20 @@ impl AgentLoop {
         // Derive .streaming path from output_log directory
         let streaming_file_path = output_log.parent().map(|p| p.join(".streaming"));
 
-        // Build context budget from the provider's context window
-        let context_budget = ContextBudget::with_window_size(client.context_window());
+        // Build context budget from the provider's context window, with overhead
+        // from system prompt + tool definitions + completion reservation. This
+        // makes pressure thresholds reflect actual API budget usage rather than
+        // just message-content length.
+        let context_budget = {
+            let tool_defs = tools.definitions();
+            let overhead = estimate_agent_overhead(
+                &system_prompt,
+                &tool_defs,
+                client.max_tokens(),
+                4.0,
+            );
+            ContextBudget::with_window_size(client.context_window()).with_overhead(overhead)
+        };
 
         Self {
             client,
@@ -558,20 +572,35 @@ impl AgentLoop {
                     // compaction and retry once before giving up.
                     if super::openai_client::is_context_too_long(&e) {
                         eprintln!(
-                            "[native-agent] Context too long error — attempting emergency compaction and retry"
+                            "[native-agent] Context too long error — attempting hard emergency compaction and retry"
                         );
-                        let pre_compact_len = messages.len();
-                        messages = ContextBudget::emergency_compact(messages, 5);
+                        let pre_tokens = self.context_budget.effective_tokens(&messages);
+                        // On a hard context-too-long error, use the aggressive
+                        // compact: drop ALL tool results in older turns, strip
+                        // thinking, truncate long text, keep only 2 recent
+                        // messages verbatim.
+                        messages = ContextBudget::hard_emergency_compact(messages, 2);
+                        let post_tokens = self.context_budget.effective_tokens(&messages);
                         eprintln!(
-                            "[native-agent] Emergency compacted: {} → {} messages",
-                            pre_compact_len,
-                            messages.len()
+                            "[native-agent] Hard emergency compacted: ~{} → ~{} tokens ({} → {} messages, overhead {} kept)",
+                            pre_tokens,
+                            post_tokens,
+                            pre_tokens.saturating_sub(self.context_budget.overhead_tokens),
+                            post_tokens.saturating_sub(self.context_budget.overhead_tokens),
+                            self.context_budget.overhead_tokens
                         );
+
+                        // Reduce completion reservation on retry to free budget for
+                        // input. On a 32k-window model where we're already over
+                        // capacity, reserving 8k for output is hostile — halve it
+                        // with a 1024-token floor so the model can still respond.
+                        let retry_max_tokens =
+                            std::cmp::max(self.client.max_tokens() / 2, 1024);
 
                         // Rebuild request with compacted messages and retry once
                         let retry_request = MessagesRequest {
                             model: self.client.model().to_string(),
-                            max_tokens: self.client.max_tokens(),
+                            max_tokens: retry_max_tokens,
                             system: Some(self.system_prompt.clone()),
                             messages: messages.clone(),
                             tools: if self.supports_tools {
@@ -1104,13 +1133,18 @@ impl AgentLoop {
                     }
                 }
                 ContextPressureAction::EmergencyCompaction => {
-                    // 90%+ capacity: emergency compaction — strip old tool results
-                    let pre_compact = messages.len();
+                    // Proactive compaction at the compact threshold — strip
+                    // old tool results before the hard limit is reached.
+                    let pre_tokens = self.context_budget.effective_tokens(&messages);
+                    let pre_count = messages.len();
                     messages = ContextBudget::emergency_compact(messages, 5);
+                    let post_tokens = self.context_budget.effective_tokens(&messages);
                     eprintln!(
-                        "[native-agent] Emergency compaction at 90%: {} → {} messages",
-                        pre_compact,
-                        messages.len()
+                        "[native-agent] Proactive compaction: ~{} → ~{} tokens ({} messages, overhead {} kept)",
+                        pre_tokens,
+                        post_tokens,
+                        pre_count,
+                        self.context_budget.overhead_tokens
                     );
 
                     // Journal the compaction event
@@ -1118,11 +1152,11 @@ impl AgentLoop {
                         let _ = j.append(JournalEntryKind::Compaction {
                             compacted_through_seq: 0,
                             summary: format!(
-                                "Emergency compaction triggered at ~90% context capacity. {} messages compacted.",
-                                pre_compact
+                                "Proactive compaction at compact threshold. Tokens: ~{} → ~{}, messages: {}.",
+                                pre_tokens, post_tokens, pre_count
                             ),
-                            original_message_count: pre_compact as u32,
-                            original_token_count: 0,
+                            original_message_count: pre_count as u32,
+                            original_token_count: pre_tokens as u32,
                         });
                     }
                 }

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -494,15 +494,27 @@ impl AgentLoop {
         let mut tool_calls = Vec::new();
         let mut turns = 0;
         let mut consecutive_server_errors: u32 = 0;
-        // Consecutive proactive compactions that reduced zero tokens. When
-        // this hits ESCALATION_THRESHOLD, we escalate from soft emergency
-        // compact (tool-results only) to hard emergency compact (also strips
-        // Text/Thinking in elided messages) to prevent the plateau-then-
-        // hard-limit failure mode where the model's own Text/Thinking content
-        // keeps growing past the threshold even though tool-result compaction
-        // is already saturated.
+        // Consecutive compactions that reduced zero tokens. Drives the
+        // three-tier escalation ladder:
+        //   Level 1 (soft):    emergency_compact(messages, 2)      — L0
+        //   Level 2 (hard):    hard_emergency_compact(messages, 1) — L0.5
+        //   Level 3 (summary): summarize_history_for_compaction   — L3
+        //
+        // At each level, `NOOP_COMPACTION_ESCALATION_THRESHOLD` consecutive
+        // no-op fires escalate to the next level. Counter resets to 0 after
+        // any non-zero delta OR after an escalation fires (which is treated
+        // as a fresh attempt). This prevents the plateau-then-hard-limit
+        // failure mode where the model's own Text/Thinking content keeps
+        // accumulating past the compact threshold even though the lower
+        // tiers have saturated.
         let mut consecutive_noop_compactions: u32 = 0;
         const NOOP_COMPACTION_ESCALATION_THRESHOLD: u32 = 2;
+        // Whether we've already escalated to L3 (history summarization)
+        // at least once this session. Ratchet to avoid spamming L3 every
+        // few turns — once we've compacted the history, the message vec
+        // is dominated by the post-summary state, and the lower tiers
+        // should be able to keep up from there.
+        let mut l3_compaction_fired = false;
         const MAX_CONSECUTIVE_SERVER_ERRORS: u32 = 3;
 
         loop {
@@ -1164,36 +1176,49 @@ impl AgentLoop {
                     }
                 }
                 ContextPressureAction::EmergencyCompaction => {
-                    // Proactive compaction at the compact threshold — shrink
-                    // all tool results except the most recent 2 before the
-                    // hard limit is reached. keep_recent counts tool-result
-                    // occurrences, not messages, so recent-position big tool
-                    // results actually get shrunk (the main reason this fires
-                    // for chatty file-reading workloads).
+                    // Three-tier escalation ladder. keep_recent_tool_results
+                    // counts tool-result occurrences, not messages, so
+                    // recent-position big tool results actually get shrunk.
                     let pre_tokens = self.context_budget.effective_tokens(&messages);
                     let pre_count = messages.len();
 
-                    // Decide whether to escalate from soft to hard. After
-                    // NOOP_COMPACTION_ESCALATION_THRESHOLD consecutive no-op
-                    // fires (soft compact has nothing left to shrink in tool
-                    // results), we need to also prune Text/Thinking in older
-                    // messages — that's what `hard_emergency_compact` does.
-                    let should_escalate =
-                        consecutive_noop_compactions >= NOOP_COMPACTION_ESCALATION_THRESHOLD;
+                    // Tier selection:
+                    //   streak ≥ 2×threshold AND !l3_fired → Level 3 (summarize)
+                    //   streak ≥ threshold                  → Level 2 (hard)
+                    //   otherwise                           → Level 1 (soft)
+                    let streak = consecutive_noop_compactions;
+                    let use_l3 =
+                        streak >= NOOP_COMPACTION_ESCALATION_THRESHOLD * 2 && !l3_compaction_fired;
+                    let use_hard = !use_l3 && streak >= NOOP_COMPACTION_ESCALATION_THRESHOLD;
 
-                    messages = if should_escalate {
+                    let tier_name = if use_l3 {
+                        "L3 summarize-history"
+                    } else if use_hard {
+                        "L2 hard"
+                    } else {
+                        "L1 soft"
+                    };
+
+                    messages = if use_l3 {
+                        l3_compaction_fired = true;
+                        super::tools::summarize::summarize_history_for_compaction(
+                            self.client.as_ref(),
+                            messages,
+                        )
+                        .await
+                    } else if use_hard {
                         ContextBudget::hard_emergency_compact(messages, 1)
                     } else {
                         ContextBudget::emergency_compact(messages, 2)
                     };
 
                     let post_tokens = self.context_budget.effective_tokens(&messages);
+                    let post_count = messages.len();
                     let delta = pre_tokens.saturating_sub(post_tokens);
 
-                    // Update consecutive-noop counter. Reset on any non-zero
-                    // reduction OR when we just escalated (the escalation
-                    // counted as a "fresh start" attempt, regardless of delta).
-                    if delta > 0 || should_escalate {
+                    // Reset counter on non-zero delta OR after any
+                    // escalation (fresh attempt). L3 always resets.
+                    if delta > 0 || use_hard || use_l3 {
                         consecutive_noop_compactions = 0;
                     } else {
                         consecutive_noop_compactions =
@@ -1201,16 +1226,13 @@ impl AgentLoop {
                     }
 
                     eprintln!(
-                        "[native-agent] {} compaction: ~{} → ~{} tokens (Δ -{}, {} messages, overhead {} kept, noop_streak={})",
-                        if should_escalate {
-                            "Escalated hard"
-                        } else {
-                            "Proactive"
-                        },
+                        "[native-agent] {} compaction: ~{} → ~{} tokens (Δ -{}, {} → {} messages, overhead {} kept, noop_streak={})",
+                        tier_name,
                         pre_tokens,
                         post_tokens,
                         delta,
                         pre_count,
+                        post_count,
                         self.context_budget.overhead_tokens,
                         consecutive_noop_compactions,
                     );
@@ -1220,8 +1242,8 @@ impl AgentLoop {
                         let _ = j.append(JournalEntryKind::Compaction {
                             compacted_through_seq: 0,
                             summary: format!(
-                                "Proactive compaction at compact threshold. Tokens: ~{} → ~{}, messages: {}.",
-                                pre_tokens, post_tokens, pre_count
+                                "{} compaction. Tokens: ~{} → ~{}, messages: {} → {}.",
+                                tier_name, pre_tokens, post_tokens, pre_count, post_count
                             ),
                             original_message_count: pre_count as u32,
                             original_token_count: pre_tokens as u32,

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -201,12 +201,8 @@ impl AgentLoop {
         // just message-content length.
         let context_budget = {
             let tool_defs = tools.definitions();
-            let overhead = estimate_agent_overhead(
-                &system_prompt,
-                &tool_defs,
-                client.max_tokens(),
-                4.0,
-            );
+            let overhead =
+                estimate_agent_overhead(&system_prompt, &tool_defs, client.max_tokens(), 4.0);
             ContextBudget::with_window_size(client.context_window()).with_overhead(overhead)
         };
 
@@ -609,18 +605,14 @@ impl AgentLoop {
                         let delta = pre_tokens.saturating_sub(post_tokens);
                         eprintln!(
                             "[native-agent] Hard emergency compacted: ~{} → ~{} tokens (Δ -{}, overhead {} kept, keep_recent_tool_results=1)",
-                            pre_tokens,
-                            post_tokens,
-                            delta,
-                            self.context_budget.overhead_tokens,
+                            pre_tokens, post_tokens, delta, self.context_budget.overhead_tokens,
                         );
 
                         // Reduce completion reservation on retry to free budget for
                         // input. On a 32k-window model where we're already over
                         // capacity, reserving 8k for output is hostile — halve it
                         // with a 1024-token floor so the model can still respond.
-                        let retry_max_tokens =
-                            std::cmp::max(self.client.max_tokens() / 2, 1024);
+                        let retry_max_tokens = std::cmp::max(self.client.max_tokens() / 2, 1024);
 
                         // Rebuild request with compacted messages and retry once
                         let retry_request = MessagesRequest {
@@ -1210,7 +1202,11 @@ impl AgentLoop {
 
                     eprintln!(
                         "[native-agent] {} compaction: ~{} → ~{} tokens (Δ -{}, {} messages, overhead {} kept, noop_streak={})",
-                        if should_escalate { "Escalated hard" } else { "Proactive" },
+                        if should_escalate {
+                            "Escalated hard"
+                        } else {
+                            "Proactive"
+                        },
                         pre_tokens,
                         post_tokens,
                         delta,

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -103,6 +103,10 @@ pub struct AgentLoop {
     state_injector: Option<StateInjector>,
     /// Registry entry for cost estimation (populated from spawn path).
     registry_entry: Option<crate::config::ModelRegistryEntry>,
+    /// Channels oversized tool outputs to disk so the message vec can never
+    /// be exploded by a single large tool call. The agent retrieves full
+    /// content via `bash` (cat/head/tail/sed/grep) on the handle path.
+    tool_output_channeler: Option<super::channel::ToolOutputChanneler>,
 }
 
 /// NDJSON log entry types for the output file.
@@ -206,6 +210,14 @@ impl AgentLoop {
             ContextBudget::with_window_size(client.context_window()).with_overhead(overhead)
         };
 
+        // Tool output channeler: writes oversized tool outputs to
+        // `<agent_dir>/tool-outputs/` and returns a handle. The agent dir is
+        // derived from the output_log's parent. If output_log has no parent
+        // (unusual), channeling is disabled and outputs pass through.
+        let tool_output_channeler = output_log.parent().map(|agent_dir| {
+            super::channel::ToolOutputChanneler::new(agent_dir.join("tool-outputs"))
+        });
+
         Self {
             client,
             tools,
@@ -225,6 +237,7 @@ impl AgentLoop {
             context_budget,
             state_injector: None,
             registry_entry: None,
+            tool_output_channeler,
         }
     }
 
@@ -1018,10 +1031,12 @@ impl AgentLoop {
                             sw.write_tool_end(name, output.is_error, *duration_ms);
                         }
 
-                        // Log the tool call
+                        // Log the tool call (full output goes to the NDJSON
+                        // log regardless of channeling — the log is on disk).
                         self.log_tool_call(name, input, &output.content, output.is_error);
 
-                        // Journal the tool execution
+                        // Journal the tool execution (full output goes to
+                        // the journal, same reason — on-disk history).
                         if let Some(ref mut j) = journal {
                             let _ = j.append(JournalEntryKind::ToolExecution {
                                 tool_use_id: id.clone(),
@@ -1040,9 +1055,21 @@ impl AgentLoop {
                             is_error: output.is_error,
                         });
 
+                        // Channel oversized outputs to disk before they
+                        // enter the message vec. This is the hard invariant
+                        // enforcement from Layer 1 of the reliability plan:
+                        // no single tool call can exceed the channel
+                        // threshold (default 2KiB) in the conversation.
+                        // Agents retrieve full content via bash
+                        // (cat/head/tail/sed/grep) on the path in the handle.
+                        let channeled_content = match &self.tool_output_channeler {
+                            Some(c) => c.maybe_channel(name, &output.content),
+                            None => output.content.clone(),
+                        };
+
                         results.push(ContentBlock::ToolResult {
                             tool_use_id: id.clone(),
-                            content: output.content.clone(),
+                            content: channeled_content,
                             is_error: output.is_error,
                         });
                     }

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -485,6 +485,15 @@ impl AgentLoop {
         let mut tool_calls = Vec::new();
         let mut turns = 0;
         let mut consecutive_server_errors: u32 = 0;
+        // Consecutive proactive compactions that reduced zero tokens. When
+        // this hits ESCALATION_THRESHOLD, we escalate from soft emergency
+        // compact (tool-results only) to hard emergency compact (also strips
+        // Text/Thinking in elided messages) to prevent the plateau-then-
+        // hard-limit failure mode where the model's own Text/Thinking content
+        // keeps growing past the threshold even though tool-result compaction
+        // is already saturated.
+        let mut consecutive_noop_compactions: u32 = 0;
+        const NOOP_COMPACTION_ESCALATION_THRESHOLD: u32 = 2;
         const MAX_CONSECUTIVE_SERVER_ERRORS: u32 = 3;
 
         loop {
@@ -1144,16 +1153,43 @@ impl AgentLoop {
                     // for chatty file-reading workloads).
                     let pre_tokens = self.context_budget.effective_tokens(&messages);
                     let pre_count = messages.len();
-                    messages = ContextBudget::emergency_compact(messages, 2);
+
+                    // Decide whether to escalate from soft to hard. After
+                    // NOOP_COMPACTION_ESCALATION_THRESHOLD consecutive no-op
+                    // fires (soft compact has nothing left to shrink in tool
+                    // results), we need to also prune Text/Thinking in older
+                    // messages — that's what `hard_emergency_compact` does.
+                    let should_escalate =
+                        consecutive_noop_compactions >= NOOP_COMPACTION_ESCALATION_THRESHOLD;
+
+                    messages = if should_escalate {
+                        ContextBudget::hard_emergency_compact(messages, 1)
+                    } else {
+                        ContextBudget::emergency_compact(messages, 2)
+                    };
+
                     let post_tokens = self.context_budget.effective_tokens(&messages);
                     let delta = pre_tokens.saturating_sub(post_tokens);
+
+                    // Update consecutive-noop counter. Reset on any non-zero
+                    // reduction OR when we just escalated (the escalation
+                    // counted as a "fresh start" attempt, regardless of delta).
+                    if delta > 0 || should_escalate {
+                        consecutive_noop_compactions = 0;
+                    } else {
+                        consecutive_noop_compactions =
+                            consecutive_noop_compactions.saturating_add(1);
+                    }
+
                     eprintln!(
-                        "[native-agent] Proactive compaction: ~{} → ~{} tokens (Δ -{}, {} messages, overhead {} kept, keep_recent_tool_results=2)",
+                        "[native-agent] {} compaction: ~{} → ~{} tokens (Δ -{}, {} messages, overhead {} kept, noop_streak={})",
+                        if should_escalate { "Escalated hard" } else { "Proactive" },
                         pre_tokens,
                         post_tokens,
                         delta,
                         pre_count,
-                        self.context_budget.overhead_tokens
+                        self.context_budget.overhead_tokens,
+                        consecutive_noop_compactions,
                     );
 
                     // Journal the compaction event

--- a/src/executor/native/bundle.rs
+++ b/src/executor/native/bundle.rs
@@ -85,7 +85,8 @@ impl Bundle {
     pub fn research() -> Self {
         Bundle {
             name: "research".to_string(),
-            description: "Read-only research agent with background tasks and web access.".to_string(),
+            description: "Read-only research agent with background tasks and web access."
+                .to_string(),
             tools: vec![
                 "read_file".to_string(),
                 "glob".to_string(),
@@ -443,29 +444,68 @@ context_scope = "graph"
     #[test]
     fn test_bundle_research_has_bg_and_web() {
         let bundle = Bundle::research();
-        assert!(bundle.tools.contains(&"bg".to_string()), "research should include bg");
-        assert!(bundle.tools.contains(&"web_search".to_string()), "research should include web_search");
-        assert!(bundle.tools.contains(&"web_fetch".to_string()), "research should include web_fetch");
-        assert!(!bundle.tools.contains(&"delegate".to_string()), "research should NOT include delegate");
+        assert!(
+            bundle.tools.contains(&"bg".to_string()),
+            "research should include bg"
+        );
+        assert!(
+            bundle.tools.contains(&"web_search".to_string()),
+            "research should include web_search"
+        );
+        assert!(
+            bundle.tools.contains(&"web_fetch".to_string()),
+            "research should include web_fetch"
+        );
+        assert!(
+            !bundle.tools.contains(&"delegate".to_string()),
+            "research should NOT include delegate"
+        );
     }
 
     #[test]
     fn test_bundle_shell_has_bg_only() {
         let bundle = Bundle::shell();
-        assert!(bundle.tools.contains(&"bash".to_string()), "shell should include bash");
-        assert!(bundle.tools.contains(&"bg".to_string()), "shell should include bg");
-        assert!(!bundle.tools.contains(&"web_search".to_string()), "shell should NOT include web_search");
-        assert!(!bundle.tools.contains(&"web_fetch".to_string()), "shell should NOT include web_fetch");
-        assert!(!bundle.tools.contains(&"delegate".to_string()), "shell should NOT include delegate");
+        assert!(
+            bundle.tools.contains(&"bash".to_string()),
+            "shell should include bash"
+        );
+        assert!(
+            bundle.tools.contains(&"bg".to_string()),
+            "shell should include bg"
+        );
+        assert!(
+            !bundle.tools.contains(&"web_search".to_string()),
+            "shell should NOT include web_search"
+        );
+        assert!(
+            !bundle.tools.contains(&"web_fetch".to_string()),
+            "shell should NOT include web_fetch"
+        );
+        assert!(
+            !bundle.tools.contains(&"delegate".to_string()),
+            "shell should NOT include delegate"
+        );
     }
 
     #[test]
     fn test_bundle_bare_no_new_tools() {
         let bundle = Bundle::bare();
-        assert!(!bundle.tools.contains(&"bg".to_string()), "bare should NOT include bg");
-        assert!(!bundle.tools.contains(&"web_search".to_string()), "bare should NOT include web_search");
-        assert!(!bundle.tools.contains(&"web_fetch".to_string()), "bare should NOT include web_fetch");
-        assert!(!bundle.tools.contains(&"delegate".to_string()), "bare should NOT include delegate");
+        assert!(
+            !bundle.tools.contains(&"bg".to_string()),
+            "bare should NOT include bg"
+        );
+        assert!(
+            !bundle.tools.contains(&"web_search".to_string()),
+            "bare should NOT include web_search"
+        );
+        assert!(
+            !bundle.tools.contains(&"web_fetch".to_string()),
+            "bare should NOT include web_fetch"
+        );
+        assert!(
+            !bundle.tools.contains(&"delegate".to_string()),
+            "bare should NOT include delegate"
+        );
     }
 
     #[test]
@@ -481,11 +521,27 @@ context_scope = "graph"
         let registry = ToolRegistry::default_all(tmp.path(), &std::env::current_dir().unwrap());
         let bundle = Bundle::research();
         let filtered = bundle.filter_registry(registry);
-        let names: Vec<String> = filtered.definitions().iter().map(|d| d.name.clone()).collect();
-        assert!(names.contains(&"bg".to_string()), "filtered research should have bg");
-        assert!(names.contains(&"web_search".to_string()), "filtered research should have web_search");
-        assert!(names.contains(&"web_fetch".to_string()), "filtered research should have web_fetch");
-        assert!(!names.contains(&"delegate".to_string()), "filtered research should NOT have delegate");
+        let names: Vec<String> = filtered
+            .definitions()
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert!(
+            names.contains(&"bg".to_string()),
+            "filtered research should have bg"
+        );
+        assert!(
+            names.contains(&"web_search".to_string()),
+            "filtered research should have web_search"
+        );
+        assert!(
+            names.contains(&"web_fetch".to_string()),
+            "filtered research should have web_fetch"
+        );
+        assert!(
+            !names.contains(&"delegate".to_string()),
+            "filtered research should NOT have delegate"
+        );
     }
 
     #[test]
@@ -494,11 +550,27 @@ context_scope = "graph"
         let registry = ToolRegistry::default_all(tmp.path(), &std::env::current_dir().unwrap());
         let bundle = Bundle::shell();
         let filtered = bundle.filter_registry(registry);
-        let names: Vec<String> = filtered.definitions().iter().map(|d| d.name.clone()).collect();
-        assert!(names.contains(&"bash".to_string()), "filtered shell should have bash");
-        assert!(names.contains(&"bg".to_string()), "filtered shell should have bg");
-        assert!(!names.contains(&"web_search".to_string()), "filtered shell should NOT have web_search");
-        assert!(!names.contains(&"delegate".to_string()), "filtered shell should NOT have delegate");
+        let names: Vec<String> = filtered
+            .definitions()
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert!(
+            names.contains(&"bash".to_string()),
+            "filtered shell should have bash"
+        );
+        assert!(
+            names.contains(&"bg".to_string()),
+            "filtered shell should have bg"
+        );
+        assert!(
+            !names.contains(&"web_search".to_string()),
+            "filtered shell should NOT have web_search"
+        );
+        assert!(
+            !names.contains(&"delegate".to_string()),
+            "filtered shell should NOT have delegate"
+        );
     }
 
     #[test]
@@ -507,9 +579,22 @@ context_scope = "graph"
         let registry = ToolRegistry::default_all(tmp.path(), &std::env::current_dir().unwrap());
         let bundle = Bundle::bare();
         let filtered = bundle.filter_registry(registry);
-        let names: Vec<String> = filtered.definitions().iter().map(|d| d.name.clone()).collect();
-        assert!(!names.contains(&"bg".to_string()), "filtered bare should NOT have bg");
-        assert!(!names.contains(&"web_search".to_string()), "filtered bare should NOT have web_search");
-        assert!(!names.contains(&"delegate".to_string()), "filtered bare should NOT have delegate");
+        let names: Vec<String> = filtered
+            .definitions()
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert!(
+            !names.contains(&"bg".to_string()),
+            "filtered bare should NOT have bg"
+        );
+        assert!(
+            !names.contains(&"web_search".to_string()),
+            "filtered bare should NOT have web_search"
+        );
+        assert!(
+            !names.contains(&"delegate".to_string()),
+            "filtered bare should NOT have delegate"
+        );
     }
 }

--- a/src/executor/native/channel.rs
+++ b/src/executor/native/channel.rs
@@ -1,0 +1,203 @@
+//! Tool output channeling.
+//!
+//! Large tool outputs (bash dumps, file reads, grep results) are written to
+//! disk and replaced in the message vec with a small handle string that
+//! tells the agent where to look. The goal is a **hard invariant**: no
+//! single tool call can inject more than `threshold_bytes` of content into
+//! the message vec, so context explosion from a single chatty tool call is
+//! structurally impossible.
+//!
+//! The handle string includes a short preview plus explicit bash hints
+//! (`cat`, `head`, `tail`, `sed`, `grep`) so the agent can retrieve any
+//! slice of the full output on demand. This makes channeled content
+//! **retrievable**, which is the property that distinguishes L1 from L0:
+//! compacted content is lost, channeled content is paged.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Default threshold: tool outputs up to 2 KiB pass through unchanged.
+/// Anything larger gets channeled.
+pub const DEFAULT_CHANNEL_THRESHOLD_BYTES: usize = 2048;
+
+/// Number of chars of preview included in the handle string.
+pub const DEFAULT_PREVIEW_CHARS: usize = 400;
+
+/// Routes oversized tool outputs to disk and returns a compact handle.
+pub struct ToolOutputChanneler {
+    /// Directory where channeled outputs are written (typically
+    /// `<agent_dir>/tool-outputs/`).
+    dir: PathBuf,
+    /// Monotonic counter for output filenames.
+    counter: AtomicUsize,
+    /// Outputs ≤ this size pass through unchanged.
+    threshold_bytes: usize,
+    /// Chars of preview to include in the handle string.
+    preview_chars: usize,
+}
+
+impl ToolOutputChanneler {
+    pub fn new(dir: PathBuf) -> Self {
+        Self::with_threshold(dir, DEFAULT_CHANNEL_THRESHOLD_BYTES)
+    }
+
+    pub fn with_threshold(dir: PathBuf, threshold_bytes: usize) -> Self {
+        Self {
+            dir,
+            counter: AtomicUsize::new(0),
+            threshold_bytes,
+            preview_chars: DEFAULT_PREVIEW_CHARS,
+        }
+    }
+
+    /// If `content` exceeds the threshold, write it to disk and return a
+    /// handle string pointing to the file. Otherwise return `content`
+    /// unchanged.
+    ///
+    /// On any I/O failure, returns the original content rather than
+    /// silently losing it — channeling is best-effort, never a blocker.
+    pub fn maybe_channel(&self, tool_name: &str, content: &str) -> String {
+        if content.len() <= self.threshold_bytes {
+            return content.to_string();
+        }
+
+        let n = self.counter.fetch_add(1, Ordering::SeqCst);
+        let filename = format!("{:05}.log", n);
+        let path = self.dir.join(&filename);
+
+        if let Err(e) = std::fs::create_dir_all(&self.dir) {
+            eprintln!(
+                "[channel] Failed to create {}: {} — passing output through unchanneled",
+                self.dir.display(),
+                e
+            );
+            return content.to_string();
+        }
+        if let Err(e) = std::fs::write(&path, content) {
+            eprintln!(
+                "[channel] Failed to write {}: {} — passing output through unchanneled",
+                path.display(),
+                e
+            );
+            return content.to_string();
+        }
+
+        // Prefer canonical/absolute path in the handle for agent clarity.
+        let display_path = std::fs::canonicalize(&path)
+            .unwrap_or_else(|_| path.clone())
+            .display()
+            .to_string();
+
+        let preview_end = content.floor_char_boundary(self.preview_chars);
+        let preview = &content[..preview_end];
+
+        format!(
+            "[CHANNELED OUTPUT — {bytes} bytes from tool '{tool}' saved to {path}]\n\
+             First {plen} chars preview:\n\
+             ---\n\
+             {preview}\n\
+             ---\n\
+             [Full output is on disk. To retrieve specific parts, use bash:]\n\
+             - `cat {path}`                  (entire file)\n\
+             - `head -n 50 {path}`           (first 50 lines)\n\
+             - `tail -n 50 {path}`           (last 50 lines)\n\
+             - `sed -n '100,200p' {path}`    (lines 100–200)\n\
+             - `grep -n 'PATTERN' {path}`    (find pattern with line numbers)\n\
+             - `wc -l {path}`                (total line count)",
+            bytes = content.len(),
+            tool = tool_name,
+            path = display_path,
+            plen = preview.len(),
+            preview = preview,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_small_output_passes_through() {
+        let tmp = TempDir::new().unwrap();
+        let channeler = ToolOutputChanneler::with_threshold(tmp.path().to_path_buf(), 2048);
+        let out = channeler.maybe_channel("bash", "hello world");
+        assert_eq!(out, "hello world");
+        // No file should have been written
+        assert!(std::fs::read_dir(tmp.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn test_large_output_is_channeled() {
+        let tmp = TempDir::new().unwrap();
+        let channeler = ToolOutputChanneler::with_threshold(tmp.path().to_path_buf(), 100);
+        let content: String = "a".repeat(5000);
+        let handle = channeler.maybe_channel("read_file", &content);
+
+        // Handle is much smaller than original
+        assert!(handle.len() < content.len() / 2);
+        // Handle mentions the size
+        assert!(handle.contains("5000 bytes"));
+        // Handle mentions the tool name
+        assert!(handle.contains("read_file"));
+        // Handle includes bash hints
+        assert!(handle.contains("cat "));
+        assert!(handle.contains("head -n"));
+        assert!(handle.contains("grep"));
+
+        // The file should exist and contain the full original content
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(entries.len(), 1);
+        let file_content = std::fs::read_to_string(entries[0].path()).unwrap();
+        assert_eq!(file_content, content);
+    }
+
+    #[test]
+    fn test_counter_increments_across_calls() {
+        let tmp = TempDir::new().unwrap();
+        let channeler = ToolOutputChanneler::with_threshold(tmp.path().to_path_buf(), 10);
+        let _ = channeler.maybe_channel("bash", &"x".repeat(100));
+        let _ = channeler.maybe_channel("bash", &"y".repeat(100));
+        let _ = channeler.maybe_channel("bash", &"z".repeat(100));
+
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(entries.len(), 3);
+        // Filenames are monotonically numbered
+        let mut sorted = entries.clone();
+        sorted.sort();
+        assert_eq!(sorted[0], "00000.log");
+        assert_eq!(sorted[1], "00001.log");
+        assert_eq!(sorted[2], "00002.log");
+    }
+
+    #[test]
+    fn test_preview_included_in_handle() {
+        let tmp = TempDir::new().unwrap();
+        let channeler = ToolOutputChanneler::with_threshold(tmp.path().to_path_buf(), 10);
+        let content = format!("PREFIX_{}", "x".repeat(2000));
+        let handle = channeler.maybe_channel("grep", &content);
+        // The preview should include the prefix
+        assert!(handle.contains("PREFIX_"));
+    }
+
+    #[test]
+    fn test_default_threshold_is_reasonable() {
+        let tmp = TempDir::new().unwrap();
+        let channeler = ToolOutputChanneler::new(tmp.path().to_path_buf());
+        // 1KB passes through at default threshold
+        let small = "a".repeat(1024);
+        assert_eq!(channeler.maybe_channel("bash", &small), small);
+        // 4KB gets channeled
+        let large = "a".repeat(4096);
+        let handle = channeler.maybe_channel("bash", &large);
+        assert!(handle.contains("CHANNELED OUTPUT"));
+    }
+}

--- a/src/executor/native/mod.rs
+++ b/src/executor/native/mod.rs
@@ -11,6 +11,7 @@
 pub mod agent;
 pub mod background;
 pub mod bundle;
+pub mod channel;
 pub mod client;
 pub mod journal;
 pub mod openai_client;

--- a/src/executor/native/openai_client.rs
+++ b/src/executor/native/openai_client.rs
@@ -810,9 +810,9 @@ impl OpenAiClient {
                 Err(e) => {
                     // Don't retry deterministic client errors (400, 401, 403, 404, etc.)
                     // — only retry transient/network errors.
-                    let is_client_error = e
-                        .downcast_ref::<ApiError>()
-                        .is_some_and(|ae| ae.status >= 400 && ae.status < 500 && !is_retryable(ae.status));
+                    let is_client_error = e.downcast_ref::<ApiError>().is_some_and(|ae| {
+                        ae.status >= 400 && ae.status < 500 && !is_retryable(ae.status)
+                    });
                     if !is_client_error && retry_count < max_retries {
                         retry_count += 1;
                         let wait = jittered_backoff(backoff_ms);
@@ -1207,9 +1207,9 @@ impl OpenAiClient {
                 Err(e) => {
                     // Don't retry deterministic client errors (400, 401, 403, 404, etc.)
                     // — only retry transient/network errors.
-                    let is_client_error = e
-                        .downcast_ref::<ApiError>()
-                        .is_some_and(|ae| ae.status >= 400 && ae.status < 500 && !is_retryable(ae.status));
+                    let is_client_error = e.downcast_ref::<ApiError>().is_some_and(|ae| {
+                        ae.status >= 400 && ae.status < 500 && !is_retryable(ae.status)
+                    });
                     if !is_client_error && retry_count < max_retries {
                         retry_count += 1;
                         let wait = jittered_backoff(backoff_ms);

--- a/src/executor/native/resume.rs
+++ b/src/executor/native/resume.rs
@@ -148,13 +148,59 @@ pub fn load_resume_data(
 
 /// Reconstruct `Vec<Message>` from journal entries.
 ///
-/// Extracts Message entries (user/assistant), skipping Init, ToolExecution,
-/// Compaction, and End entries. ToolExecution is metadata — the actual tool
-/// results appear in the subsequent User message as ToolResult content blocks.
+/// Reconstruct the message list from journal entries with
+/// compaction-aware semantics.
+///
+/// **L4: resume-from-partial-compaction.** If the journal contains one or
+/// more `Compaction` entries, this function uses the LATEST compaction's
+/// `compacted_through_seq` to drop all superseded entries and replaces
+/// them with a single synthetic `PRIOR CONVERSATION SUMMARY` user message.
+/// This makes `wg service restart` / agent resume correctly preserve the
+/// context-pressure savings from prior compactions — otherwise on resume
+/// we'd re-hydrate the full pre-compaction history and defeat the point.
+///
+/// Entries kept: all `Message` entries with `seq > latest_compaction.seq`.
+/// Entries dropped: `Init`, `ToolExecution`, `End`, any `Message` with
+/// `seq ≤ latest_compaction.compacted_through_seq`, and older `Compaction`
+/// entries (only the latest summary is emitted).
 fn reconstruct_messages(entries: &[JournalEntry]) -> Vec<Message> {
+    // Find the latest Compaction entry (by seq). Its compacted_through_seq
+    // marks the cutoff — everything up to and including that seq has
+    // already been summarized and should NOT be re-hydrated.
+    let latest_compaction = entries.iter().rev().find_map(|e| match &e.kind {
+        JournalEntryKind::Compaction {
+            compacted_through_seq,
+            summary,
+            ..
+        } => Some((*compacted_through_seq, summary.clone())),
+        _ => None,
+    });
+
+    let cutoff_seq = latest_compaction.as_ref().map(|(seq, _)| *seq);
+
     let mut messages = Vec::new();
 
+    // If we had a compaction, emit its summary as the first synthetic
+    // user message — this replaces all the compacted entries.
+    if let Some((_, summary)) = &latest_compaction {
+        messages.push(Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: format!(
+                    "[Resume: Prior conversation was compacted. Summary of earlier work:]\n{}",
+                    summary
+                ),
+            }],
+        });
+    }
+
     for entry in entries {
+        // Drop entries superseded by the latest compaction.
+        if let Some(cutoff) = cutoff_seq
+            && entry.seq <= cutoff
+        {
+            continue;
+        }
         match &entry.kind {
             JournalEntryKind::Message { role, content, .. } => {
                 messages.push(Message {
@@ -162,18 +208,9 @@ fn reconstruct_messages(entries: &[JournalEntry]) -> Vec<Message> {
                     content: content.clone(),
                 });
             }
-            JournalEntryKind::Compaction { summary, .. } => {
-                // A prior compaction: inject the summary as a user message
-                messages.push(Message {
-                    role: Role::User,
-                    content: vec![ContentBlock::Text {
-                        text: format!(
-                            "[Resume: Prior conversation was compacted. Summary of earlier work:]\n{}",
-                            summary
-                        ),
-                    }],
-                });
-            }
+            // Later Compaction entries (beyond the latest one we already
+            // emitted above) shouldn't exist in practice; skip defensively.
+            JournalEntryKind::Compaction { .. } => {}
             // Init, ToolExecution, End — skip
             _ => {}
         }
@@ -1142,6 +1179,244 @@ mod tests {
         assert_eq!(messages[1].role, Role::Assistant);
         assert_eq!(messages[2].role, Role::User);
         assert_eq!(messages[3].role, Role::Assistant);
+    }
+
+    #[test]
+    fn test_reconstruct_messages_respects_compaction_cutoff() {
+        // L4: journal has 4 messages, then a Compaction entry superseding
+        // messages up to seq 4 (seq 1 = Init, seq 2,3,4 = first 3 messages),
+        // then 2 more messages after the compaction.
+        //
+        // Expected reconstruct output:
+        // [synthetic "PRIOR CONVERSATION SUMMARY" user message,
+        //  message 5, message 6]
+        // Total = 3 messages. The first 3 original messages are DROPPED
+        // because the compaction superseded them.
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("conversation.jsonl");
+        let mut journal = Journal::open(&path).unwrap();
+
+        // seq 1
+        journal
+            .append(JournalEntryKind::Init {
+                model: "m".to_string(),
+                provider: "p".to_string(),
+                system_prompt: "s".to_string(),
+                tools: vec![],
+                task_id: None,
+            })
+            .unwrap();
+        // seq 2..=4
+        for text in ["first user msg", "first asst msg", "second user msg"] {
+            let role = if text.contains("user") {
+                Role::User
+            } else {
+                Role::Assistant
+            };
+            journal
+                .append(JournalEntryKind::Message {
+                    role,
+                    content: vec![ContentBlock::Text {
+                        text: text.to_string(),
+                    }],
+                    usage: None,
+                    response_id: None,
+                    stop_reason: None,
+                })
+                .unwrap();
+        }
+        // seq 5: compaction superseding everything ≤ seq 4
+        journal
+            .append(JournalEntryKind::Compaction {
+                compacted_through_seq: 4,
+                summary: "User asked question, assistant answered.".to_string(),
+                original_message_count: 3,
+                original_token_count: 42,
+            })
+            .unwrap();
+        // seq 6, 7: post-compaction messages
+        journal
+            .append(JournalEntryKind::Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "post-compact user".to_string(),
+                }],
+                usage: None,
+                response_id: None,
+                stop_reason: None,
+            })
+            .unwrap();
+        journal
+            .append(JournalEntryKind::Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "post-compact asst".to_string(),
+                }],
+                usage: None,
+                response_id: None,
+                stop_reason: None,
+            })
+            .unwrap();
+
+        let entries = Journal::read_all(&path).unwrap();
+        let messages = reconstruct_messages(&entries);
+
+        // Expect: [synthetic summary, post-compact user, post-compact asst]
+        assert_eq!(
+            messages.len(),
+            3,
+            "expected synthetic summary + 2 post-compact messages, got {}",
+            messages.len()
+        );
+        // First message = synthetic summary
+        assert_eq!(messages[0].role, Role::User);
+        let first_text = messages[0]
+            .content
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .unwrap();
+        assert!(first_text.contains("Prior conversation was compacted"));
+        assert!(first_text.contains("User asked question, assistant answered."));
+        // Second + third = post-compaction messages, verbatim
+        assert_eq!(messages[1].role, Role::User);
+        let msg1_text = messages[1]
+            .content
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(msg1_text, "post-compact user");
+        assert_eq!(messages[2].role, Role::Assistant);
+
+        // Critically: the pre-compaction messages should NOT appear anywhere.
+        for msg in &messages {
+            for block in &msg.content {
+                if let ContentBlock::Text { text } = block {
+                    assert!(
+                        !text.contains("first user msg"),
+                        "pre-compaction message should have been dropped, but found '{}'",
+                        text
+                    );
+                    assert!(
+                        !text.contains("first asst msg"),
+                        "pre-compaction message should have been dropped, but found '{}'",
+                        text
+                    );
+                    assert!(
+                        !text.contains("second user msg"),
+                        "pre-compaction message should have been dropped, but found '{}'",
+                        text
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_reconstruct_messages_respects_latest_compaction_when_multiple() {
+        // L4: journal has two Compaction entries. Only the LATEST one's
+        // cutoff should apply — and only its summary should be emitted.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("conversation.jsonl");
+        let mut journal = Journal::open(&path).unwrap();
+
+        journal
+            .append(JournalEntryKind::Init {
+                model: "m".to_string(),
+                provider: "p".to_string(),
+                system_prompt: "s".to_string(),
+                tools: vec![],
+                task_id: None,
+            })
+            .unwrap();
+        // seq 2: message
+        journal
+            .append(JournalEntryKind::Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "very early message".to_string(),
+                }],
+                usage: None,
+                response_id: None,
+                stop_reason: None,
+            })
+            .unwrap();
+        // seq 3: first compaction
+        journal
+            .append(JournalEntryKind::Compaction {
+                compacted_through_seq: 2,
+                summary: "FIRST SUMMARY".to_string(),
+                original_message_count: 1,
+                original_token_count: 10,
+            })
+            .unwrap();
+        // seq 4: message
+        journal
+            .append(JournalEntryKind::Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "middle message".to_string(),
+                }],
+                usage: None,
+                response_id: None,
+                stop_reason: None,
+            })
+            .unwrap();
+        // seq 5: second compaction
+        journal
+            .append(JournalEntryKind::Compaction {
+                compacted_through_seq: 4,
+                summary: "SECOND SUMMARY".to_string(),
+                original_message_count: 2,
+                original_token_count: 20,
+            })
+            .unwrap();
+        // seq 6: final message
+        journal
+            .append(JournalEntryKind::Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "latest message".to_string(),
+                }],
+                usage: None,
+                response_id: None,
+                stop_reason: None,
+            })
+            .unwrap();
+
+        let entries = Journal::read_all(&path).unwrap();
+        let messages = reconstruct_messages(&entries);
+
+        // Expect: [SECOND SUMMARY, "latest message"]
+        assert_eq!(messages.len(), 2);
+        let summary_text = messages[0]
+            .content
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .unwrap();
+        assert!(summary_text.contains("SECOND SUMMARY"));
+        assert!(
+            !summary_text.contains("FIRST SUMMARY"),
+            "older compaction summary should have been superseded"
+        );
+        let last_text = messages[1]
+            .content
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(last_text, "latest message");
     }
 
     #[test]

--- a/src/executor/native/resume.rs
+++ b/src/executor/native/resume.rs
@@ -1001,13 +1001,15 @@ impl ContextBudget {
                         } else {
                             new_content.push(ContentBlock::ToolResult {
                                 tool_use_id,
-                                content: "[tool result elided for context pressure]"
-                                    .to_string(),
+                                content: "[tool result elided for context pressure]".to_string(),
                                 is_error,
                             });
                         }
                     }
-                    ContentBlock::Thinking { thinking, reasoning_details } => {
+                    ContentBlock::Thinking {
+                        thinking,
+                        reasoning_details,
+                    } => {
                         // Keep thinking only in preserved-verbatim messages.
                         if preserve_verbatim {
                             new_content.push(ContentBlock::Thinking {
@@ -1016,9 +1018,7 @@ impl ContextBudget {
                             });
                         }
                     }
-                    ContentBlock::Text { text }
-                        if !preserve_verbatim && text.len() > 400 =>
-                    {
+                    ContentBlock::Text { text } if !preserve_verbatim && text.len() > 400 => {
                         let boundary = text.floor_char_boundary(400);
                         new_content.push(ContentBlock::Text {
                             text: format!("{}… [truncated]", &text[..boundary]),

--- a/src/executor/native/resume.rs
+++ b/src/executor/native/resume.rs
@@ -869,101 +869,83 @@ impl ContextBudget {
         )
     }
 
-    /// Aggressive variant of [`Self::emergency_compact`] used when a 400
-    /// context-too-long error has already fired.
-    ///
-    /// Differences from `emergency_compact`:
-    /// - Replaces ALL `ToolResult` blocks in older messages with a short
-    ///   stub (no 200-byte threshold).
-    /// - Strips `Thinking` blocks entirely from older messages.
-    /// - Truncates long `Text` blocks in older messages to 400 chars.
-    /// - Still preserves the last `keep_recent` messages verbatim so the
-    ///   model keeps its most recent context.
-    ///
-    /// The message count is unchanged by design (so tool_use/tool_result
-    /// pairing stays intact). The token reduction comes from shrinking
-    /// content within older messages.
-    pub fn hard_emergency_compact(messages: Vec<Message>, keep_recent: usize) -> Vec<Message> {
-        if messages.len() <= keep_recent {
-            return messages;
-        }
-        let split = messages.len().saturating_sub(keep_recent);
-        let mut compacted = Vec::with_capacity(messages.len());
-
-        for msg in &messages[..split] {
-            let mut new_content = Vec::new();
-            for block in &msg.content {
-                match block {
-                    ContentBlock::ToolResult {
-                        tool_use_id,
-                        is_error,
-                        ..
-                    } => {
-                        new_content.push(ContentBlock::ToolResult {
-                            tool_use_id: tool_use_id.clone(),
-                            content: "[tool result elided for context pressure]".to_string(),
-                            is_error: *is_error,
-                        });
-                    }
-                    ContentBlock::Thinking { .. } => {
-                        // Drop thinking entirely — it's not load-bearing for the model's decisions.
-                    }
-                    ContentBlock::Text { text } if text.len() > 400 => {
-                        let boundary = text.floor_char_boundary(400);
-                        new_content.push(ContentBlock::Text {
-                            text: format!("{}… [truncated]", &text[..boundary]),
-                        });
-                    }
-                    other => new_content.push(other.clone()),
+    /// Collect (msg_idx, block_idx) for every `ToolResult` block whose content
+    /// exceeds `size_threshold` bytes, walking messages in order.
+    fn locate_large_tool_results(
+        messages: &[Message],
+        size_threshold: usize,
+    ) -> Vec<(usize, usize)> {
+        let mut locations = Vec::new();
+        for (mi, msg) in messages.iter().enumerate() {
+            for (bi, block) in msg.content.iter().enumerate() {
+                if let ContentBlock::ToolResult { content, .. } = block
+                    && content.len() > size_threshold
+                {
+                    locations.push((mi, bi));
                 }
             }
-            compacted.push(Message {
-                role: msg.role,
-                content: new_content,
-            });
         }
-
-        compacted.extend_from_slice(&messages[split..]);
-        compacted
+        locations
     }
 
-    /// Perform emergency compaction: drop tool results from turns older than
-    /// the last `keep_recent` messages, replacing them with summaries.
-    pub fn emergency_compact(messages: Vec<Message>, keep_recent: usize) -> Vec<Message> {
-        if messages.len() <= keep_recent {
+    /// Select which tool-result locations to **keep verbatim**: the last
+    /// `keep_recent_tool_results` entries from a list in chronological order.
+    fn keep_set(
+        locations: &[(usize, usize)],
+        keep_recent_tool_results: usize,
+    ) -> std::collections::HashSet<(usize, usize)> {
+        let keep_count = keep_recent_tool_results.min(locations.len());
+        let start = locations.len() - keep_count;
+        locations[start..].iter().copied().collect()
+    }
+
+    /// Perform emergency compaction: walk ALL messages and shrink any
+    /// `ToolResult` block larger than 200 bytes, EXCEPT the last
+    /// `keep_recent_tool_results` of them, which are preserved verbatim as
+    /// the model's working memory.
+    ///
+    /// This is **position-independent by design** — the big content in a
+    /// chatty file-reading workload lives in recent positions (one tool call
+    /// per file), so a position-based "keep last N messages" rule would
+    /// protect the very content we need to shrink. By counting tool-result
+    /// occurrences instead of messages, we always compact the earliest tool
+    /// results first regardless of where they sit in the message vec.
+    ///
+    /// Message count is unchanged so tool_use/tool_result pairing stays
+    /// intact. Token reduction comes from shrinking `ToolResult::content`.
+    pub fn emergency_compact(
+        messages: Vec<Message>,
+        keep_recent_tool_results: usize,
+    ) -> Vec<Message> {
+        let locations = Self::locate_large_tool_results(&messages, 200);
+        if locations.is_empty() {
             return messages;
         }
-        let split = messages.len().saturating_sub(keep_recent);
+        let keep = Self::keep_set(&locations, keep_recent_tool_results);
 
-        let mut compacted = Vec::new();
-
-        // Compact older messages: strip large tool results
-        for msg in &messages[..split] {
-            let mut new_content = Vec::new();
-            for block in &msg.content {
+        let mut compacted = Vec::with_capacity(messages.len());
+        for (mi, msg) in messages.into_iter().enumerate() {
+            let mut new_content = Vec::with_capacity(msg.content.len());
+            for (bi, block) in msg.content.into_iter().enumerate() {
                 match block {
                     ContentBlock::ToolResult {
                         tool_use_id,
                         content,
                         is_error,
-                    } => {
-                        // Replace large tool results with a short summary
-                        let summary = if content.len() > 200 {
-                            format!(
-                                "[Tool result removed. Size: {} bytes. Preview: {}...]",
-                                content.len(),
-                                &content[..content.floor_char_boundary(100)]
-                            )
-                        } else {
-                            content.clone()
-                        };
+                    } if !keep.contains(&(mi, bi)) && content.len() > 200 => {
+                        let boundary = content.floor_char_boundary(100);
+                        let summary = format!(
+                            "[Tool result removed. Size: {} bytes. Preview: {}...]",
+                            content.len(),
+                            &content[..boundary]
+                        );
                         new_content.push(ContentBlock::ToolResult {
-                            tool_use_id: tool_use_id.clone(),
+                            tool_use_id,
                             content: summary,
-                            is_error: *is_error,
+                            is_error,
                         });
                     }
-                    other => new_content.push(other.clone()),
+                    other => new_content.push(other),
                 }
             }
             compacted.push(Message {
@@ -971,9 +953,85 @@ impl ContextBudget {
                 content: new_content,
             });
         }
+        compacted
+    }
 
-        // Keep recent messages verbatim
-        compacted.extend_from_slice(&messages[split..]);
+    /// Aggressive variant of [`Self::emergency_compact`] used after a
+    /// context-too-long API error has already fired. Differences:
+    ///
+    /// - ALL `ToolResult` blocks not in the keep set are replaced with a
+    ///   short stub (no 200-byte size threshold).
+    /// - `Thinking` blocks are stripped entirely from non-keep messages.
+    /// - `Text` blocks longer than 400 chars are truncated in non-keep
+    ///   messages.
+    ///
+    /// Like `emergency_compact`, this is position-independent: `keep_recent`
+    /// counts tool-result occurrences, not messages. The "non-keep messages"
+    /// are messages whose tool results would be shrunk — text/thinking in
+    /// those messages also gets pruned.
+    pub fn hard_emergency_compact(
+        messages: Vec<Message>,
+        keep_recent_tool_results: usize,
+    ) -> Vec<Message> {
+        let locations = Self::locate_large_tool_results(&messages, 0);
+        let keep = Self::keep_set(&locations, keep_recent_tool_results);
+
+        // Messages whose tool results will be kept verbatim — preserve their
+        // text/thinking too as part of the working memory.
+        let keep_msg_indices: std::collections::HashSet<usize> =
+            keep.iter().map(|(mi, _)| *mi).collect();
+
+        let mut compacted = Vec::with_capacity(messages.len());
+        for (mi, msg) in messages.into_iter().enumerate() {
+            let preserve_verbatim = keep_msg_indices.contains(&mi);
+            let mut new_content = Vec::with_capacity(msg.content.len());
+            for (bi, block) in msg.content.into_iter().enumerate() {
+                match block {
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        is_error,
+                        content,
+                    } => {
+                        if keep.contains(&(mi, bi)) {
+                            new_content.push(ContentBlock::ToolResult {
+                                tool_use_id,
+                                content,
+                                is_error,
+                            });
+                        } else {
+                            new_content.push(ContentBlock::ToolResult {
+                                tool_use_id,
+                                content: "[tool result elided for context pressure]"
+                                    .to_string(),
+                                is_error,
+                            });
+                        }
+                    }
+                    ContentBlock::Thinking { thinking, reasoning_details } => {
+                        // Keep thinking only in preserved-verbatim messages.
+                        if preserve_verbatim {
+                            new_content.push(ContentBlock::Thinking {
+                                thinking,
+                                reasoning_details,
+                            });
+                        }
+                    }
+                    ContentBlock::Text { text }
+                        if !preserve_verbatim && text.len() > 400 =>
+                    {
+                        let boundary = text.floor_char_boundary(400);
+                        new_content.push(ContentBlock::Text {
+                            text: format!("{}… [truncated]", &text[..boundary]),
+                        });
+                    }
+                    other => new_content.push(other),
+                }
+            }
+            compacted.push(Message {
+                role: msg.role,
+                content: new_content,
+            });
+        }
         compacted
     }
 }
@@ -1492,6 +1550,102 @@ mod tests {
         let msgs = user_messages(1, 400);
         assert_eq!(budget.estimate_tokens(&msgs), 100);
         assert_eq!(budget.effective_tokens(&msgs), 5_100);
+    }
+
+    #[test]
+    fn test_emergency_compact_shrinks_recent_position_tool_results() {
+        // Regression for the smoke-stress-compaction bug: a chatty
+        // file-reading workload puts big tool results in RECENT positions.
+        // The old message-position-based "keep last N messages" rule would
+        // protect them and compaction would reduce zero tokens. The new
+        // occurrence-based rule (keep last N TOOL RESULTS) should shrink
+        // earlier-occurrence tool results regardless of where they sit.
+        //
+        // Build a realistic 9-message layout:
+        //   0: user task
+        //   1: assistant (text + tool_use for read_file A)
+        //   2: user (tool_result with 10KB content)  ← old
+        //   3: assistant (text + tool_use for read_file B)
+        //   4: user (tool_result with 10KB content)  ← older-but-"recent" position
+        //   5: assistant (text + tool_use for read_file C)
+        //   6: user (tool_result with 10KB content)  ← most-recent position
+        //   7: assistant (text)
+        //   8: user (text)
+        let mut messages = Vec::new();
+        messages.push(Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: "Summarize all docs".to_string(),
+            }],
+        });
+        for i in 0..3 {
+            messages.push(Message {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::Text {
+                        text: format!("Reading file {}", i),
+                    },
+                    ContentBlock::ToolUse {
+                        id: format!("tu-{}", i),
+                        name: "read_file".to_string(),
+                        input: serde_json::json!({"path": format!("docs/{}.md", i)}),
+                    },
+                ],
+            });
+            messages.push(Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: format!("tu-{}", i),
+                    content: "x".repeat(10_000),
+                    is_error: false,
+                }],
+            });
+        }
+        messages.push(Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text {
+                text: "Now I'll write the summary".to_string(),
+            }],
+        });
+
+        let budget = ContextBudget::with_window_size(32_000);
+        let before = budget.estimate_tokens(&messages);
+
+        // keep_recent_tool_results=2 — should shrink the FIRST of 3 tool
+        // results (~10KB) while preserving the last 2 verbatim.
+        let after = ContextBudget::emergency_compact(messages.clone(), 2);
+        let after_tokens = budget.estimate_tokens(&after);
+        let delta = before.saturating_sub(after_tokens);
+
+        assert_eq!(after.len(), messages.len(), "message count preserved");
+        assert!(
+            delta >= 2000,
+            "compaction should shrink at least one 10KB tool result \
+             (~2500 tokens reduction expected), got delta={} (before={}, after={})",
+            delta,
+            before,
+            after_tokens,
+        );
+
+        // keep_recent_tool_results=1 — should shrink 2 of 3 tool results.
+        let aggressive = ContextBudget::emergency_compact(messages.clone(), 1);
+        let aggressive_tokens = budget.estimate_tokens(&aggressive);
+        assert!(
+            aggressive_tokens < after_tokens,
+            "keep_recent=1 should reduce more than keep_recent=2: {} vs {}",
+            aggressive_tokens,
+            after_tokens,
+        );
+
+        // keep_recent_tool_results=0 — should shrink ALL tool results.
+        let maximum = ContextBudget::emergency_compact(messages.clone(), 0);
+        let maximum_tokens = budget.estimate_tokens(&maximum);
+        assert!(
+            maximum_tokens < aggressive_tokens,
+            "keep_recent=0 should reduce more than keep_recent=1: {} vs {}",
+            maximum_tokens,
+            aggressive_tokens,
+        );
     }
 
     #[test]

--- a/src/executor/native/resume.rs
+++ b/src/executor/native/resume.rs
@@ -740,8 +740,8 @@ pub enum ContextPressureAction {
 /// The API budget is `system + tools + messages + max_tokens_reservation ≤ window_size`.
 /// [`ContextBudget::estimate_tokens`] only counts message content, so
 /// [`ContextBudget::check_pressure`] would underreport actual usage if used
-/// alone. The `overhead_tokens` field captures the fixed cost of system prompt
-/// + tool definitions + completion budget, computed once at agent init via
+/// alone. The `overhead_tokens` field captures the fixed cost of system prompt,
+/// tool definitions, and completion budget — computed once at agent init via
 /// [`estimate_agent_overhead`], so pressure checks reflect real API usage.
 #[derive(Debug, Clone)]
 pub struct ContextBudget {

--- a/src/executor/native/resume.rs
+++ b/src/executor/native/resume.rs
@@ -14,8 +14,30 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use super::client::{ContentBlock, Message, Role};
+use super::client::{ContentBlock, Message, Role, ToolDefinition};
 use super::journal::{JournalEntry, JournalEntryKind};
+
+/// Estimate the fixed overhead tokens the agent carries independent of
+/// message history: system prompt + serialized tool definitions + the
+/// completion reservation (`max_tokens`).
+///
+/// Used by [`ContextBudget::with_overhead`] to get accurate pressure
+/// thresholds, especially on small-context models where the overhead is
+/// a large fraction of the window.
+pub fn estimate_agent_overhead(
+    system_prompt: &str,
+    tool_defs: &[ToolDefinition],
+    max_tokens: u32,
+    chars_per_token: f64,
+) -> usize {
+    let system_chars = system_prompt.len();
+    let tool_chars: usize = tool_defs
+        .iter()
+        .map(|t| t.name.len() + t.description.len() + t.input_schema.to_string().len())
+        .sum();
+    let static_tokens = ((system_chars + tool_chars) as f64 / chars_per_token) as usize;
+    static_tokens + max_tokens as usize
+}
 
 /// Default budget: if the journal's estimated tokens exceed this percentage of
 /// the context window, compact older turns.
@@ -712,6 +734,15 @@ pub enum ContextPressureAction {
 ///
 /// The agent loop checks this after each turn to decide whether to warn,
 /// compact, or exit gracefully before hitting the API's hard limit.
+///
+/// # Overhead accounting
+///
+/// The API budget is `system + tools + messages + max_tokens_reservation ≤ window_size`.
+/// [`ContextBudget::estimate_tokens`] only counts message content, so
+/// [`ContextBudget::check_pressure`] would underreport actual usage if used
+/// alone. The `overhead_tokens` field captures the fixed cost of system prompt
+/// + tool definitions + completion budget, computed once at agent init via
+/// [`estimate_agent_overhead`], so pressure checks reflect real API usage.
 #[derive(Debug, Clone)]
 pub struct ContextBudget {
     /// Total context window size in tokens (from provider config).
@@ -724,6 +755,10 @@ pub struct ContextBudget {
     pub compact_threshold: f64,
     /// Fraction at which to trigger a clean exit (default 0.95).
     pub hard_limit: f64,
+    /// Fixed overhead tokens that count against the window but are NOT in
+    /// the `messages` vec: system prompt + tool definitions + completion
+    /// reservation (`max_tokens`). Typically set once at agent init.
+    pub overhead_tokens: usize,
 }
 
 impl Default for ContextBudget {
@@ -734,6 +769,7 @@ impl Default for ContextBudget {
             warning_threshold: 0.70,
             compact_threshold: 0.75,
             hard_limit: 0.95,
+            overhead_tokens: 0,
         }
     }
 }
@@ -760,7 +796,18 @@ impl ContextBudget {
             warning_threshold: warning,
             compact_threshold: compact,
             hard_limit: hard,
+            overhead_tokens: 0,
         }
+    }
+
+    /// Set the fixed overhead tokens (system prompt + tool defs + completion reservation).
+    ///
+    /// Compaction/pressure decisions use `message_tokens + overhead_tokens` against
+    /// `window_size`, so this must be set at agent init for accurate thresholds on
+    /// small-context models where the overhead is a large fraction of the window.
+    pub fn with_overhead(mut self, overhead_tokens: usize) -> Self {
+        self.overhead_tokens = overhead_tokens;
+        self
     }
 
     /// Estimate the current token count from a list of messages.
@@ -784,9 +831,18 @@ impl ContextBudget {
         (total_chars as f64 / self.chars_per_token) as usize
     }
 
+    /// Estimated tokens for messages PLUS the fixed overhead (system + tools + completion).
+    /// This is the value compared against `window_size` for pressure decisions.
+    pub fn effective_tokens(&self, messages: &[Message]) -> usize {
+        self.estimate_tokens(messages) + self.overhead_tokens
+    }
+
     /// Check context pressure and return the appropriate action.
+    ///
+    /// Uses [`Self::effective_tokens`] (messages + overhead) vs. `window_size`
+    /// so the ratio reflects actual API budget usage, not just message content.
     pub fn check_pressure(&self, messages: &[Message]) -> ContextPressureAction {
-        let tokens = self.estimate_tokens(messages);
+        let tokens = self.effective_tokens(messages);
         let ratio = tokens as f64 / self.window_size as f64;
 
         if ratio >= self.hard_limit {
@@ -800,15 +856,75 @@ impl ContextBudget {
         }
     }
 
-    /// Build the warning message injected at 80% threshold.
+    /// Build the warning message injected at the warning threshold.
     pub fn warning_message(&self, messages: &[Message]) -> String {
-        let tokens = self.estimate_tokens(messages);
-        let pct = (tokens as f64 / self.window_size as f64) * 100.0;
+        let msg_tokens = self.estimate_tokens(messages);
+        let effective = msg_tokens + self.overhead_tokens;
+        let pct = (effective as f64 / self.window_size as f64) * 100.0;
         format!(
-            "⚠️ CONTEXT PRESSURE WARNING: You're at {:.0}% context capacity ({} / {} estimated tokens). \
+            "⚠️ CONTEXT PRESSURE WARNING: You're at {:.0}% context capacity \
+             ({} messages + {} overhead = {} / {} estimated tokens). \
              Consider logging progress via `wg log` and completing the current subtask.",
-            pct, tokens, self.window_size
+            pct, msg_tokens, self.overhead_tokens, effective, self.window_size
         )
+    }
+
+    /// Aggressive variant of [`Self::emergency_compact`] used when a 400
+    /// context-too-long error has already fired.
+    ///
+    /// Differences from `emergency_compact`:
+    /// - Replaces ALL `ToolResult` blocks in older messages with a short
+    ///   stub (no 200-byte threshold).
+    /// - Strips `Thinking` blocks entirely from older messages.
+    /// - Truncates long `Text` blocks in older messages to 400 chars.
+    /// - Still preserves the last `keep_recent` messages verbatim so the
+    ///   model keeps its most recent context.
+    ///
+    /// The message count is unchanged by design (so tool_use/tool_result
+    /// pairing stays intact). The token reduction comes from shrinking
+    /// content within older messages.
+    pub fn hard_emergency_compact(messages: Vec<Message>, keep_recent: usize) -> Vec<Message> {
+        if messages.len() <= keep_recent {
+            return messages;
+        }
+        let split = messages.len().saturating_sub(keep_recent);
+        let mut compacted = Vec::with_capacity(messages.len());
+
+        for msg in &messages[..split] {
+            let mut new_content = Vec::new();
+            for block in &msg.content {
+                match block {
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        is_error,
+                        ..
+                    } => {
+                        new_content.push(ContentBlock::ToolResult {
+                            tool_use_id: tool_use_id.clone(),
+                            content: "[tool result elided for context pressure]".to_string(),
+                            is_error: *is_error,
+                        });
+                    }
+                    ContentBlock::Thinking { .. } => {
+                        // Drop thinking entirely — it's not load-bearing for the model's decisions.
+                    }
+                    ContentBlock::Text { text } if text.len() > 400 => {
+                        let boundary = text.floor_char_boundary(400);
+                        new_content.push(ContentBlock::Text {
+                            text: format!("{}… [truncated]", &text[..boundary]),
+                        });
+                    }
+                    other => new_content.push(other.clone()),
+                }
+            }
+            compacted.push(Message {
+                role: msg.role,
+                content: new_content,
+            });
+        }
+
+        compacted.extend_from_slice(&messages[split..]);
+        compacted
     }
 
     /// Perform emergency compaction: drop tool results from turns older than
@@ -1307,5 +1423,186 @@ mod tests {
         // Just below 128k should be medium tier
         let budget_med = ContextBudget::with_window_size(127_999);
         assert!((budget_med.warning_threshold - 0.60).abs() < 1e-10);
+    }
+
+    /// Helper: build N user messages, each with a text block of `chars_per_msg` chars.
+    fn user_messages(n: usize, chars_per_msg: usize) -> Vec<Message> {
+        (0..n)
+            .map(|_| Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "x".repeat(chars_per_msg),
+                }],
+            })
+            .collect()
+    }
+
+    /// Helper: build a message with one ToolResult block of `chars` chars.
+    fn tool_result_message(chars: usize, id: &str) -> Message {
+        Message {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                content: "y".repeat(chars),
+                is_error: false,
+            }],
+        }
+    }
+
+    #[test]
+    fn test_check_pressure_accounts_for_overhead() {
+        // 32k window, small-tier thresholds: compact at 0.65 → 20_800 tokens
+        // With 10k overhead, compaction should trigger at ~10_800 message tokens,
+        // not ~20_800 as it would without overhead accounting.
+        let budget = ContextBudget::with_window_size(32_000).with_overhead(10_000);
+
+        // 40_000 chars / 4 = 10_000 message tokens; + 10_000 overhead = 20_000 effective
+        // 20_000 / 32_000 = 0.625 → below compact_threshold (0.65), still Warning range.
+        let msgs = user_messages(1, 40_000);
+        match budget.check_pressure(&msgs) {
+            ContextPressureAction::Warning => {}
+            other => panic!("expected Warning at 62.5%, got {:?}", other),
+        }
+
+        // 48_000 chars / 4 = 12_000 msg tokens; + 10_000 overhead = 22_000 effective
+        // 22_000 / 32_000 = 0.6875 → above compact_threshold (0.65) → EmergencyCompaction
+        let msgs = user_messages(1, 48_000);
+        match budget.check_pressure(&msgs) {
+            ContextPressureAction::EmergencyCompaction => {}
+            other => panic!("expected EmergencyCompaction at 68.75%, got {:?}", other),
+        }
+
+        // Sanity: the same message volume with NO overhead is at 37.5% — well
+        // below the 55% warning threshold — so the old logic would have called
+        // this Ok and done nothing, letting the agent blow past real capacity.
+        let budget_no_overhead = ContextBudget::with_window_size(32_000);
+        match budget_no_overhead.check_pressure(&msgs) {
+            ContextPressureAction::Ok => {}
+            other => panic!(
+                "without overhead, 12k msg tokens / 32k = 37.5% should be Ok, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_effective_tokens_sums_messages_and_overhead() {
+        let budget = ContextBudget::with_window_size(100_000).with_overhead(5_000);
+        // 400 chars / 4 = 100 message tokens
+        let msgs = user_messages(1, 400);
+        assert_eq!(budget.estimate_tokens(&msgs), 100);
+        assert_eq!(budget.effective_tokens(&msgs), 5_100);
+    }
+
+    #[test]
+    fn test_hard_emergency_compact_reduces_more_than_soft() {
+        // 8 older messages, each with a 1000-char tool result, plus 3 recent messages.
+        let mut messages: Vec<Message> = (0..8)
+            .map(|i| tool_result_message(1000, &format!("tu-{}", i)))
+            .collect();
+        messages.extend(user_messages(3, 100));
+
+        let budget = ContextBudget::with_window_size(32_000);
+        let before_tokens = budget.estimate_tokens(&messages);
+
+        // Soft variant: keeps last 5, so only 6 older messages get their
+        // tool results shrunk (to ~150 chars each).
+        let soft = ContextBudget::emergency_compact(messages.clone(), 5);
+        let soft_tokens = budget.estimate_tokens(&soft);
+        assert_eq!(soft.len(), messages.len(), "message count preserved");
+        assert!(
+            soft_tokens < before_tokens,
+            "soft compact should reduce tokens: {} → {}",
+            before_tokens,
+            soft_tokens
+        );
+
+        // Hard variant with keep_recent=2: more messages get compacted AND
+        // the replacement stub is smaller ("[tool result elided...]").
+        let hard = ContextBudget::hard_emergency_compact(messages.clone(), 2);
+        let hard_tokens = budget.estimate_tokens(&hard);
+        assert_eq!(hard.len(), messages.len(), "message count preserved");
+        assert!(
+            hard_tokens < soft_tokens,
+            "hard compact should reduce more than soft: soft={}, hard={}",
+            soft_tokens,
+            hard_tokens
+        );
+    }
+
+    #[test]
+    fn test_hard_emergency_compact_strips_thinking_and_truncates_text() {
+        let mut messages = vec![
+            // Older message with thinking + long text
+            Message {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::Thinking {
+                        thinking: "a".repeat(2000),
+                        reasoning_details: None,
+                    },
+                    ContentBlock::Text {
+                        text: "b".repeat(2000),
+                    },
+                ],
+            },
+        ];
+        // Keep 1 recent message verbatim so the older message actually gets compacted.
+        messages.push(Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: "recent".to_string(),
+            }],
+        });
+
+        let hard = ContextBudget::hard_emergency_compact(messages, 1);
+
+        // Older message: thinking dropped, text truncated
+        let older = &hard[0];
+        let has_thinking = older
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::Thinking { .. }));
+        assert!(!has_thinking, "hard compact should strip thinking blocks");
+
+        let text_block = older
+            .content
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .expect("text block should still be present");
+        assert!(
+            text_block.len() < 2000,
+            "long text should be truncated, got {} chars",
+            text_block.len()
+        );
+        assert!(text_block.contains("[truncated]"));
+
+        // Recent message untouched
+        assert_eq!(hard[1].content.len(), 1);
+    }
+
+    #[test]
+    fn test_estimate_agent_overhead_accounts_for_all_sources() {
+        let system_prompt = "s".repeat(4000); // 4000 chars / 4 = 1000 tokens
+        let tool_defs = vec![ToolDefinition {
+            name: "bash".to_string(),
+            description: "d".repeat(200),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+        }];
+        let max_tokens = 2048_u32;
+
+        let overhead = estimate_agent_overhead(&system_prompt, &tool_defs, max_tokens, 4.0);
+
+        // system: 4000 chars, tool name: 4, tool desc: 200, schema: ~40
+        // static_tokens ≈ (4000 + 4 + 200 + 40) / 4 ≈ 1061
+        // total ≈ 1061 + 2048 = 3109
+        assert!(
+            overhead >= 2048 + 1000 && overhead <= 2048 + 1100,
+            "overhead should roughly sum system + tools + max_tokens, got {}",
+            overhead
+        );
     }
 }

--- a/src/executor/native/state_injection.rs
+++ b/src/executor/native/state_injection.rs
@@ -307,7 +307,10 @@ impl StateInjector {
             );
 
             if !output_tail.is_empty() {
-                update.push_str(&format!("\nOutput (last 20 lines):\n```\n{}\n```", output_tail));
+                update.push_str(&format!(
+                    "\nOutput (last 20 lines):\n```\n{}\n```",
+                    output_tail
+                ));
             }
 
             update.push_str("\n</context-update>");
@@ -834,7 +837,15 @@ mod tests {
         setup_workgraph(wg_dir, "my-task", &[]);
 
         // Create a running (non-terminal) job
-        create_bg_job(wg_dir, "job-1", "build", "cargo build", "running", None, None);
+        create_bg_job(
+            wg_dir,
+            "job-1",
+            "build",
+            "cargo build",
+            "running",
+            None,
+            None,
+        );
 
         let mut injector =
             StateInjector::new(wg_dir.to_path_buf(), "my-task".into(), "agent-1".into());
@@ -879,7 +890,10 @@ mod tests {
         // Should contain only last 20 lines (lines 6-25)
         assert!(text.contains("line 25"));
         assert!(text.contains("line 6"));
-        assert!(!text.contains("line 5\n"), "line 5 should be trimmed (only last 20 lines)");
+        assert!(
+            !text.contains("line 5\n"),
+            "line 5 should be trimmed (only last 20 lines)"
+        );
     }
 
     #[test]
@@ -948,7 +962,13 @@ mod tests {
         setup_workgraph(wg_dir, "my-task", &[]);
 
         create_bg_job(
-            wg_dir, "job-a", "first", "echo a", "completed", Some(0), Some("output a\n"),
+            wg_dir,
+            "job-a",
+            "first",
+            "echo a",
+            "completed",
+            Some(0),
+            Some("output a\n"),
         );
 
         let mut injector =
@@ -961,7 +981,13 @@ mod tests {
 
         // Now a second job completes
         create_bg_job(
-            wg_dir, "job-b", "second", "echo b", "completed", Some(0), Some("output b\n"),
+            wg_dir,
+            "job-b",
+            "second",
+            "echo b",
+            "completed",
+            Some(0),
+            Some("output b\n"),
         );
 
         // Should only report the new one
@@ -980,7 +1006,13 @@ mod tests {
 
         // Job with no log content (log file doesn't exist)
         create_bg_job(
-            wg_dir, "job-nolog", "no-output", "true", "completed", Some(0), None,
+            wg_dir,
+            "job-nolog",
+            "no-output",
+            "true",
+            "completed",
+            Some(0),
+            None,
         );
 
         let mut injector =

--- a/src/executor/native/tools/delegate.rs
+++ b/src/executor/native/tools/delegate.rs
@@ -64,7 +64,7 @@ impl DelegateTool {
         Self {
             workgraph_dir,
             working_dir,
-            config_max_turns: max_turns.min(MAX_ALLOWED_TURNS).max(1),
+            config_max_turns: max_turns.clamp(1, MAX_ALLOWED_TURNS),
             config_model: model.to_string(),
         }
     }
@@ -133,7 +133,7 @@ impl Tool for DelegateTool {
         let max_turns = input
             .get("max_turns")
             .and_then(|v| v.as_u64())
-            .map(|n| (n as usize).min(MAX_ALLOWED_TURNS).max(1))
+            .map(|n| (n as usize).clamp(1, MAX_ALLOWED_TURNS))
             .unwrap_or(self.config_max_turns);
 
         // Resolve model: config delegate_model > WG_MODEL env var > default

--- a/src/executor/native/tools/delegate.rs
+++ b/src/executor/native/tools/delegate.rs
@@ -10,11 +10,11 @@ use async_trait::async_trait;
 use serde_json::json;
 
 use super::{Tool, ToolOutput, ToolRegistry, truncate_for_tool, truncate_tool_output};
+#[cfg(test)]
+use crate::executor::native::client::Usage;
 use crate::executor::native::client::{
     ContentBlock, Message, MessagesRequest, MessagesResponse, Role, StopReason, ToolDefinition,
 };
-#[cfg(test)]
-use crate::executor::native::client::Usage;
 use crate::executor::native::provider::Provider;
 
 /// Maximum output chars for delegate results.
@@ -79,12 +79,13 @@ impl Tool for DelegateTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "delegate".to_string(),
-            description: "Delegate a subtask to a focused sub-agent that runs within your process. \
+            description:
+                "Delegate a subtask to a focused sub-agent that runs within your process. \
                 The sub-agent has its own conversation context (your context is not affected) and \
                 returns its result as text. Use this for focused queries like reading files, \
                 searching code, or answering specific questions that would benefit from a \
                 separate context window."
-                .to_string(),
+                    .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -110,7 +111,9 @@ impl Tool for DelegateTool {
     async fn execute(&self, input: &serde_json::Value) -> ToolOutput {
         let prompt = match input.get("prompt").and_then(|v| v.as_str()) {
             Some(p) if !p.trim().is_empty() => p,
-            Some(_) => return ToolOutput::error("Parameter 'prompt' must not be empty".to_string()),
+            Some(_) => {
+                return ToolOutput::error("Parameter 'prompt' must not be empty".to_string());
+            }
             None => return ToolOutput::error("Missing required parameter: prompt".to_string()),
         };
 
@@ -563,7 +566,11 @@ mod tests {
         let result = tool.execute(&input).await;
 
         assert!(result.is_error);
-        assert!(result.content.contains("Missing required parameter: prompt"));
+        assert!(
+            result
+                .content
+                .contains("Missing required parameter: prompt")
+        );
     }
 
     #[tokio::test]

--- a/src/executor/native/tools/mod.rs
+++ b/src/executor/native/tools/mod.rs
@@ -8,6 +8,7 @@ pub mod bg;
 pub mod delegate;
 pub mod file;
 pub mod file_cache;
+pub mod summarize;
 pub mod web_fetch;
 pub mod web_search;
 pub mod wg;
@@ -377,6 +378,15 @@ impl ToolRegistry {
             working_dir.to_path_buf(),
             config.delegate.delegate_max_turns,
             &config.delegate.delegate_model,
+        );
+
+        // Summarize tool (recursive map-reduce summarization). Uses the
+        // delegate model override if set, falling back to WG_MODEL env var
+        // at execute time.
+        summarize::register_summarize_tool(
+            &mut registry,
+            workgraph_dir.to_path_buf(),
+            config.delegate.delegate_model.clone(),
         );
 
         registry

--- a/src/executor/native/tools/summarize.rs
+++ b/src/executor/native/tools/summarize.rs
@@ -246,7 +246,11 @@ fn chunk_text(text: &str, chunk_chars: usize) -> Vec<String> {
 ///
 /// `depth` is the recursion level; bail at `MAX_RECURSION_DEPTH` to
 /// prevent runaway trees when summaries aren't shrinking fast enough.
-fn recursive_summarize<'a>(
+///
+/// This is exposed as `pub(crate)` because L3 compaction (in `agent.rs`)
+/// calls it directly on a serialized representation of the agent's own
+/// message history when the escalation ladder saturates.
+pub(crate) fn recursive_summarize<'a>(
     provider: &'a dyn Provider,
     text: &'a str,
     instruction: &'a str,
@@ -378,6 +382,153 @@ pub fn register_summarize_tool(
     model: String,
 ) {
     registry.register(Box::new(SummarizeTool::new(workgraph_dir, model)));
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// L3: Summarize-based compaction of an agent's own message history.
+// Used by `agent.rs` when the standard emergency_compact /
+// hard_emergency_compact ladder has saturated (repeated no-op fires at
+// the compact threshold).
+// ───────────────────────────────────────────────────────────────────────
+
+/// Number of recent messages to preserve verbatim when summarizing an
+/// agent's history. The summary captures older turns; these stay intact
+/// so the model keeps immediate working memory.
+const L3_KEEP_RECENT_MESSAGES: usize = 2;
+
+/// Instruction for the L3 history-summarization call. Designed to
+/// preserve decisions, facts discovered, and open threads — not
+/// verbatim text.
+const L3_HISTORY_SUMMARY_INSTRUCTION: &str = "\
+Summarize this agent conversation transcript. Preserve: \
+(1) the original task, \
+(2) key facts discovered (file contents, search results, command outputs), \
+(3) decisions made, \
+(4) any open questions or subtasks created, \
+(5) errors encountered and their resolution. \
+Omit: conversational filler, restated plans, tool-call echoing, \
+redundant observations. Use a structured format with sections.";
+
+/// Serialize a `Message` to a compact text representation suitable for
+/// inclusion in a summarization prompt.
+fn serialize_message_for_summary(msg: &Message) -> String {
+    let role = match msg.role {
+        Role::User => "USER",
+        Role::Assistant => "ASSISTANT",
+    };
+    let mut parts = Vec::new();
+    for block in &msg.content {
+        match block {
+            ContentBlock::Text { text } => {
+                parts.push(text.clone());
+            }
+            ContentBlock::Thinking { thinking, .. } => {
+                parts.push(format!("[thinking] {}", thinking));
+            }
+            ContentBlock::ToolUse { name, input, .. } => {
+                parts.push(format!("[tool_use {}] {}", name, input));
+            }
+            ContentBlock::ToolResult {
+                content, is_error, ..
+            } => {
+                let prefix = if *is_error {
+                    "[tool_result ERROR]"
+                } else {
+                    "[tool_result]"
+                };
+                parts.push(format!("{} {}", prefix, content));
+            }
+        }
+    }
+    format!("{}: {}", role, parts.join("\n"))
+}
+
+/// Compact an agent's message history via recursive summarization.
+///
+/// This is the L3 tier of the compaction escalation ladder. When
+/// `emergency_compact` and `hard_emergency_compact` can no longer reduce
+/// message tokens (the accumulation is in Text/Thinking/ToolUse content
+/// the model itself produced), this function:
+///
+/// 1. Splits `messages` into `older` (everything except the last
+///    `L3_KEEP_RECENT_MESSAGES`) and `recent` (the tail, kept verbatim).
+/// 2. Serializes `older` to a text transcript.
+/// 3. Invokes `recursive_summarize` to reduce the transcript to a
+///    bounded-size summary (recursing as needed for very long histories).
+/// 4. Returns a new message vec:
+///    `[User("PRIOR CONVERSATION SUMMARY: <summary>"), recent...]`
+///
+/// Like the other compaction functions this preserves tool_use/tool_result
+/// pairing in `recent`, and message count is replaced (not preserved) —
+/// this is a more aggressive intervention that explicitly drops the
+/// older-turn structure in exchange for a bounded-size replacement.
+///
+/// On failure (provider errors, empty summary) the original messages are
+/// returned unchanged — compaction is best-effort, never a blocker.
+pub async fn summarize_history_for_compaction(
+    provider: &dyn Provider,
+    messages: Vec<Message>,
+) -> Vec<Message> {
+    if messages.len() <= L3_KEEP_RECENT_MESSAGES + 1 {
+        // Not enough history to bother summarizing — the standard
+        // compact already handles small vecs.
+        return messages;
+    }
+
+    let split = messages.len() - L3_KEEP_RECENT_MESSAGES;
+    let older = &messages[..split];
+    let recent = &messages[split..];
+
+    let transcript: String = older
+        .iter()
+        .map(serialize_message_for_summary)
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n");
+
+    eprintln!(
+        "[summarize-l3] compacting {} older messages ({} bytes transcript), keeping {} recent",
+        older.len(),
+        transcript.len(),
+        recent.len()
+    );
+
+    let summary =
+        match recursive_summarize(provider, &transcript, L3_HISTORY_SUMMARY_INSTRUCTION, 0).await {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!(
+                    "[summarize-l3] recursive_summarize failed: {} — returning messages unchanged",
+                    e
+                );
+                return messages;
+            }
+        };
+
+    if summary.trim().is_empty() {
+        eprintln!("[summarize-l3] empty summary — returning messages unchanged");
+        return messages;
+    }
+
+    eprintln!(
+        "[summarize-l3] summary produced: {} bytes (from {} bytes transcript)",
+        summary.len(),
+        transcript.len()
+    );
+
+    // Build the new message vec: summary as a user-role context message,
+    // followed by the preserved recent messages verbatim.
+    let mut compacted = Vec::with_capacity(recent.len() + 1);
+    compacted.push(Message {
+        role: Role::User,
+        content: vec![ContentBlock::Text {
+            text: format!(
+                "PRIOR CONVERSATION SUMMARY (older turns compacted to reduce context pressure):\n\n{}",
+                summary
+            ),
+        }],
+    });
+    compacted.extend_from_slice(recent);
+    compacted
 }
 
 #[cfg(test)]

--- a/src/executor/native/tools/summarize.rs
+++ b/src/executor/native/tools/summarize.rs
@@ -1,0 +1,448 @@
+//! Summarize tool: recursive map-reduce summarization for arbitrarily-large text.
+//!
+//! Given a source (file path or inline text), produces a single focused
+//! summary via the following algorithm:
+//!
+//! 1. Refuse if input exceeds `max_input_bytes` (default 1 MiB).
+//! 2. If the input fits in a single model call (~40% of context window),
+//!    summarize directly and return.
+//! 3. Otherwise chunk the input on paragraph boundaries when possible,
+//!    summarize each chunk independently with an `instruction`-aware
+//!    focus prompt, concatenate the chunk summaries, and recurse.
+//! 4. Terminate at `MAX_RECURSION_DEPTH` or a single-chunk base case.
+//!
+//! This is the cornerstone primitive from the reliability action plan
+//! (L2): it lets agents reduce arbitrarily-large content hierarchically
+//! without ever loading more than a single chunk into context at once.
+//!
+//! Unlike `delegate` (which runs a general sub-agent with tools),
+//! `summarize` issues direct text-in/text-out LLM calls — no tool loop,
+//! no recursion into other tools. That makes it cheap and predictable.
+
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use serde_json::json;
+
+use super::{Tool, ToolOutput, truncate_tool_output};
+use crate::executor::native::client::{
+    ContentBlock, Message, MessagesRequest, Role, ToolDefinition,
+};
+use crate::executor::native::provider::Provider;
+
+/// Default hard ceiling on input size (bytes). Prevents accidental
+/// whole-codebase summarizations that would take forever.
+const DEFAULT_MAX_INPUT_BYTES: usize = 1_000_000;
+
+/// Max output tokens for each summarization LLM call.
+const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 1024;
+
+/// Tool-level output truncation (the tool result itself).
+const MAX_SUMMARIZE_OUTPUT_CHARS: usize = 8_000;
+
+/// Fraction of context window to use per chunk. Leaves headroom for
+/// system prompt + instruction + reasoning + completion.
+const CHUNK_CONTEXT_FRACTION: f64 = 0.40;
+
+/// Chars-per-token estimate for chunk sizing.
+const CHARS_PER_TOKEN: f64 = 4.0;
+
+/// Maximum recursion depth to prevent runaway trees if chunks don't shrink.
+const MAX_RECURSION_DEPTH: usize = 8;
+
+/// System prompt for summarization LLM calls. Intentionally terse — the
+/// focus instruction carries the task-specific guidance.
+const SUMMARIZE_SYSTEM_PROMPT: &str = "\
+You are a text summarization agent. Given a chunk of text and a focus \
+instruction, produce a concise summary that preserves the details the \
+instruction asks for. Return only the summary text — no preamble, no \
+commentary, no meta-discussion.";
+
+/// The summarize tool.
+pub struct SummarizeTool {
+    workgraph_dir: PathBuf,
+    /// Model override for summarization calls. Empty = use `WG_MODEL` env
+    /// var (set by the coordinator at spawn time).
+    model: String,
+}
+
+impl SummarizeTool {
+    pub fn new(workgraph_dir: PathBuf, model: String) -> Self {
+        Self {
+            workgraph_dir,
+            model,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for SummarizeTool {
+    fn name(&self) -> &str {
+        "summarize"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "summarize".to_string(),
+            description: "Recursively summarize a large text source via map-reduce. \
+                Reads from a file path or inline text, chunks it to fit the model's \
+                context window, summarizes each chunk independently with your focus \
+                instruction, then merges — recursing if the merged summaries are still \
+                too large. Use this when a source is too big to read directly (large \
+                files, long logs, big tool outputs). Each level runs as direct text \
+                LLM calls with no tool loop, so it's cheap and predictable."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "source": {
+                        "type": "string",
+                        "description": "Either a file path (relative or absolute) or inline text. If the string resolves to an existing file on disk, the file is loaded; otherwise the string itself is treated as the input text."
+                    },
+                    "instruction": {
+                        "type": "string",
+                        "description": "Focus instruction — what to preserve in the summary. E.g. 'extract public function signatures', 'focus on error handling', 'list the section headings'. Defaults to a generic 'summarize the text' if not provided."
+                    },
+                    "max_input_bytes": {
+                        "type": "integer",
+                        "description": "Hard ceiling on input size in bytes (default 1000000 = 1 MB). Sources larger than this are rejected to prevent runaway cost."
+                    }
+                },
+                "required": ["source"]
+            }),
+        }
+    }
+
+    async fn execute(&self, input: &serde_json::Value) -> ToolOutput {
+        // 1. Parse input
+        let source = match input.get("source").and_then(|v| v.as_str()) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                return ToolOutput::error(
+                    "Missing or empty required parameter: source".to_string(),
+                );
+            }
+        };
+        let instruction = input
+            .get("instruction")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Summarize the text.");
+        let max_input_bytes = input
+            .get("max_input_bytes")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as usize)
+            .unwrap_or(DEFAULT_MAX_INPUT_BYTES);
+
+        // 2. Load content — file path or inline
+        let content = {
+            let as_path = Path::new(source);
+            if as_path.exists() && as_path.is_file() {
+                match std::fs::read_to_string(as_path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return ToolOutput::error(format!(
+                            "Failed to read source file '{}': {}",
+                            source, e
+                        ));
+                    }
+                }
+            } else {
+                source.to_string()
+            }
+        };
+
+        if content.len() > max_input_bytes {
+            return ToolOutput::error(format!(
+                "Input exceeds max_input_bytes: {} > {} (raise max_input_bytes to allow larger inputs)",
+                content.len(),
+                max_input_bytes
+            ));
+        }
+
+        // 3. Create provider
+        let model = if !self.model.is_empty() {
+            self.model.clone()
+        } else {
+            std::env::var("WG_MODEL")
+                .ok()
+                .filter(|m| !m.is_empty())
+                .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string())
+        };
+
+        let provider =
+            match crate::executor::native::provider::create_provider(&self.workgraph_dir, &model) {
+                Ok(p) => p,
+                Err(e) => {
+                    return ToolOutput::error(format!(
+                        "Failed to create provider for summarize: {}",
+                        e
+                    ));
+                }
+            };
+
+        eprintln!(
+            "[summarize] starting: model={}, input_bytes={}, instruction='{}'",
+            model,
+            content.len(),
+            instruction
+        );
+
+        // 4. Recursive summarize
+        match recursive_summarize(provider.as_ref(), &content, instruction, 0).await {
+            Ok(summary) => {
+                let truncated = truncate_tool_output(&summary, MAX_SUMMARIZE_OUTPUT_CHARS);
+                ToolOutput::success(truncated)
+            }
+            Err(e) => ToolOutput::error(format!("Summarize failed: {}", e)),
+        }
+    }
+}
+
+/// Estimate how many chars of input fit in one summarization LLM call,
+/// leaving headroom for system prompt, instruction, reasoning, and output.
+fn chunk_size_chars(window_size: usize) -> usize {
+    ((window_size as f64) * CHUNK_CONTEXT_FRACTION * CHARS_PER_TOKEN) as usize
+}
+
+/// Split `text` into chunks of approximately `chunk_chars` bytes each.
+/// Prefers to break on paragraph boundaries (`\n\n`) within the final 20%
+/// of each chunk. Falls back to char-boundary truncation otherwise.
+fn chunk_text(text: &str, chunk_chars: usize) -> Vec<String> {
+    if text.len() <= chunk_chars {
+        return vec![text.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    let mut pos = 0;
+
+    while pos < text.len() {
+        let target_end = (pos + chunk_chars).min(text.len());
+        let end = text.floor_char_boundary(target_end);
+
+        let break_pt = if end == text.len() {
+            end
+        } else {
+            // Prefer a paragraph boundary in the last 20% of the chunk.
+            let min_break = pos + (chunk_chars * 4 / 5);
+            if min_break < end {
+                text[min_break..end]
+                    .rfind("\n\n")
+                    .map(|i| min_break + i + 2)
+                    .unwrap_or(end)
+            } else {
+                end
+            }
+        };
+
+        chunks.push(text[pos..break_pt].to_string());
+        pos = break_pt;
+    }
+
+    chunks
+}
+
+/// Recursively summarize text via map-reduce.
+///
+/// `depth` is the recursion level; bail at `MAX_RECURSION_DEPTH` to
+/// prevent runaway trees when summaries aren't shrinking fast enough.
+fn recursive_summarize<'a>(
+    provider: &'a dyn Provider,
+    text: &'a str,
+    instruction: &'a str,
+    depth: usize,
+) -> Pin<Box<dyn std::future::Future<Output = Result<String, String>> + Send + 'a>> {
+    Box::pin(async move {
+        if depth >= MAX_RECURSION_DEPTH {
+            return Err(format!(
+                "Max recursion depth ({}) exceeded — summaries are not shrinking. \
+                 Input may be pathologically long or chunk_size too large.",
+                MAX_RECURSION_DEPTH
+            ));
+        }
+
+        let window_size = provider.context_window();
+        let chunk_chars = chunk_size_chars(window_size);
+
+        // Base case: fits in one call.
+        if text.len() <= chunk_chars {
+            eprintln!(
+                "[summarize] depth={}: single call ({} bytes, window={})",
+                depth,
+                text.len(),
+                window_size
+            );
+            return summarize_chunk(provider, text, instruction).await;
+        }
+
+        // Recursive case: chunk, map, reduce.
+        let chunks = chunk_text(text, chunk_chars);
+        eprintln!(
+            "[summarize] depth={}: {} chunks from {} bytes (chunk_chars={})",
+            depth,
+            chunks.len(),
+            text.len(),
+            chunk_chars
+        );
+
+        // Map: summarize each chunk independently.
+        let mut chunk_summaries = Vec::with_capacity(chunks.len());
+        for (i, chunk) in chunks.iter().enumerate() {
+            let chunk_instruction = format!(
+                "This is part {} of {} of a larger document. {}",
+                i + 1,
+                chunks.len(),
+                instruction
+            );
+            let summary = summarize_chunk(provider, chunk, &chunk_instruction).await?;
+            eprintln!(
+                "[summarize] depth={} chunk {}/{}: {} → {} bytes",
+                depth,
+                i + 1,
+                chunks.len(),
+                chunk.len(),
+                summary.len()
+            );
+            chunk_summaries.push(summary);
+        }
+
+        // Reduce: merge chunk summaries.
+        let merged = chunk_summaries.join("\n\n---\n\n");
+
+        if merged.len() <= chunk_chars {
+            // Final merge pass.
+            let merge_instruction = format!(
+                "These are {} partial summaries of a larger document. Merge them into \
+                 one coherent, non-redundant summary. {}",
+                chunks.len(),
+                instruction
+            );
+            return summarize_chunk(provider, &merged, &merge_instruction).await;
+        }
+
+        // Merged summaries still too large — recurse.
+        eprintln!(
+            "[summarize] depth={}: merged summaries still too large ({} bytes), recursing",
+            depth,
+            merged.len()
+        );
+        recursive_summarize(provider, &merged, instruction, depth + 1).await
+    })
+}
+
+/// Issue a single summarization LLM call. Text-in/text-out, no tools.
+async fn summarize_chunk(
+    provider: &dyn Provider,
+    text: &str,
+    instruction: &str,
+) -> Result<String, String> {
+    let prompt = format!("Instruction: {}\n\n---\n\n{}", instruction, text);
+    let request = MessagesRequest {
+        model: provider.model().to_string(),
+        max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        system: Some(SUMMARIZE_SYSTEM_PROMPT.to_string()),
+        messages: vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text { text: prompt }],
+        }],
+        tools: vec![],
+        stream: false,
+    };
+
+    let response = provider
+        .send(&request)
+        .await
+        .map_err(|e| format!("API error in summarize call: {}", e))?;
+
+    let text: String = response
+        .content
+        .iter()
+        .filter_map(|b| match b {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if text.trim().is_empty() {
+        return Err("Empty summary response from provider".to_string());
+    }
+
+    Ok(text)
+}
+
+/// Register the summarize tool in the given registry.
+pub fn register_summarize_tool(
+    registry: &mut super::ToolRegistry,
+    workgraph_dir: PathBuf,
+    model: String,
+) {
+    registry.register(Box::new(SummarizeTool::new(workgraph_dir, model)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chunk_size_chars_scales_with_window() {
+        // At 32k window: 32000 * 0.40 * 4.0 = 51200 chars
+        let small = chunk_size_chars(32_000);
+        // At 200k window: 200000 * 0.40 * 4.0 = 320000 chars
+        let large = chunk_size_chars(200_000);
+        assert!(large > small);
+        assert_eq!(small, 51_200);
+        assert_eq!(large, 320_000);
+    }
+
+    #[test]
+    fn test_chunk_text_short_input_single_chunk() {
+        let text = "hello world";
+        let chunks = chunk_text(text, 100);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], text);
+    }
+
+    #[test]
+    fn test_chunk_text_long_input_splits_on_paragraph() {
+        let para1 = "A".repeat(400);
+        let para2 = "B".repeat(400);
+        let para3 = "C".repeat(400);
+        let text = format!("{}\n\n{}\n\n{}", para1, para2, para3);
+        // Chunk size 500 → should split roughly at paragraph boundaries.
+        let chunks = chunk_text(&text, 500);
+        assert!(chunks.len() >= 2, "expected multiple chunks, got {}", chunks.len());
+
+        // Concatenation should reconstruct the original (no chars lost).
+        let recombined: String = chunks.join("");
+        assert_eq!(recombined, text);
+    }
+
+    #[test]
+    fn test_chunk_text_long_input_no_paragraphs_falls_back_to_char_boundary() {
+        let text = "x".repeat(2500);
+        let chunks = chunk_text(&text, 1000);
+        assert!(chunks.len() >= 3);
+        let recombined: String = chunks.join("");
+        assert_eq!(recombined, text);
+    }
+
+    #[test]
+    fn test_chunk_text_respects_char_boundaries() {
+        // Text with multi-byte chars at chunk boundary positions
+        let text = "héllo wörld ".repeat(100);
+        let chunks = chunk_text(&text, 50);
+        let recombined: String = chunks.join("");
+        assert_eq!(recombined, text);
+    }
+
+    #[test]
+    fn test_tool_definition_has_source_required() {
+        let tool = SummarizeTool::new(PathBuf::from("/tmp"), String::new());
+        let def = tool.definition();
+        assert_eq!(def.name, "summarize");
+        let schema = def.input_schema.as_object().unwrap();
+        let required = schema.get("required").unwrap().as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("source")));
+    }
+}

--- a/src/executor/native/tools/summarize.rs
+++ b/src/executor/native/tools/summarize.rs
@@ -411,7 +411,11 @@ mod tests {
         let text = format!("{}\n\n{}\n\n{}", para1, para2, para3);
         // Chunk size 500 → should split roughly at paragraph boundaries.
         let chunks = chunk_text(&text, 500);
-        assert!(chunks.len() >= 2, "expected multiple chunks, got {}", chunks.len());
+        assert!(
+            chunks.len() >= 2,
+            "expected multiple chunks, got {}",
+            chunks.len()
+        );
 
         // Concatenation should reconstruct the original (no chars lost).
         let recombined: String = chunks.join("");

--- a/src/executor/native/tools/web_fetch.rs
+++ b/src/executor/native/tools/web_fetch.rs
@@ -99,11 +99,7 @@ impl Tool for WebFetchTool {
         };
 
         if !response.status().is_success() {
-            return ToolOutput::error(format!(
-                "HTTP {} fetching {}",
-                response.status(),
-                url_str
-            ));
+            return ToolOutput::error(format!("HTTP {} fetching {}", response.status(), url_str));
         }
 
         let html = match response.text().await {

--- a/src/executor/native/tools/wg.rs
+++ b/src/executor/native/tools/wg.rs
@@ -261,7 +261,9 @@ impl Tool for WgAddTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "wg_add".to_string(),
-            description: "Create a new task in the workgraph.".to_string(),
+            description: "Create a new task in the workgraph. Supports subtask delegation \
+                (block current task until child completes) and cron scheduling."
+                .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -284,6 +286,14 @@ impl Tool for WgAddTool {
                     "skills": {
                         "type": "string",
                         "description": "Comma-separated skills"
+                    },
+                    "subtask": {
+                        "type": "boolean",
+                        "description": "If true, treat as a blocking subtask of the current task. The current task is parked (Waiting) until this child completes. Requires WG_TASK_ID to be set in the agent environment."
+                    },
+                    "cron": {
+                        "type": "string",
+                        "description": "5-field cron expression (e.g. '*/5 * * * *' for every 5 minutes, '0 2 * * *' for daily at 2am). Creates a calendar-scheduled task that fires periodically instead of on dependency completion."
                     }
                 },
                 "required": ["title"]
@@ -303,6 +313,11 @@ impl Tool for WgAddTool {
         let after_str = input.get("after").and_then(|v| v.as_str()).unwrap_or("");
         let tags_str = input.get("tags").and_then(|v| v.as_str()).unwrap_or("");
         let skills_str = input.get("skills").and_then(|v| v.as_str()).unwrap_or("");
+        let is_subtask = input
+            .get("subtask")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let cron_expr = input.get("cron").and_then(|v| v.as_str());
 
         let after: Vec<String> = after_str
             .split(',')
@@ -320,11 +335,58 @@ impl Tool for WgAddTool {
             .filter(|s| !s.is_empty())
             .collect();
 
+        // --subtask: requires WG_TASK_ID to identify the parent task.
+        let subtask_parent_id: Option<String> = if is_subtask {
+            match std::env::var("WG_TASK_ID") {
+                Ok(pid) if !pid.is_empty() => Some(pid),
+                _ => {
+                    return ToolOutput::error(
+                        "subtask=true requires WG_TASK_ID to be set in the agent environment \
+                         (the in-process wg_add tool uses it to identify the parent task). \
+                         This should be set automatically when spawned by the coordinator."
+                            .to_string(),
+                    );
+                }
+            }
+        } else {
+            None
+        };
+
+        // --cron: parse expression and compute next fire time up-front so
+        // invalid cron rejects the task creation cleanly.
+        let (cron_schedule, cron_enabled, next_cron_fire) = if let Some(expr) = cron_expr {
+            match crate::cron::parse_cron_expression(expr) {
+                Ok(schedule) => {
+                    let next_fire = crate::cron::calculate_next_fire(&schedule, Utc::now());
+                    (
+                        Some(expr.to_string()),
+                        true,
+                        next_fire.map(|dt| dt.to_rfc3339()),
+                    )
+                }
+                Err(e) => {
+                    return ToolOutput::error(format!(
+                        "Invalid cron expression '{}': {}",
+                        expr, e
+                    ));
+                }
+            }
+        } else {
+            (None, false, None)
+        };
+
         let (graph, path) = match load_workgraph(&self.dir) {
             Ok(g) => g,
             Err(e) => return ToolOutput::error(e),
         };
-        let effective_after = default_parent_after(&graph, &after);
+        // For subtask, we bypass the default-parent injection because the
+        // parent handles the blocking relationship via wait_condition, not
+        // via the normal after-dependency mechanism.
+        let effective_after = if is_subtask {
+            after.clone()
+        } else {
+            default_parent_after(&graph, &after)
+        };
 
         // Generate a unique task ID from title
         let mut task_id = generate_id(title);
@@ -336,8 +398,10 @@ impl Tool for WgAddTool {
             counter += 1;
         }
 
-        // Determine initial status
-        let initial_status = if effective_after.is_empty() {
+        // Determine initial status. Subtasks always start Open so the
+        // coordinator can immediately dispatch them — the parent's
+        // wait_condition is what enforces blocking.
+        let initial_status = if is_subtask || effective_after.is_empty() {
             Status::Open
         } else {
             // Check if all dependencies are done
@@ -363,6 +427,10 @@ impl Tool for WgAddTool {
             tags,
             skills,
             created_at: Some(Utc::now().to_rfc3339()),
+            cron_schedule,
+            cron_enabled,
+            next_cron_fire,
+            unplaced: is_subtask,
             ..Default::default()
         };
 
@@ -381,6 +449,83 @@ impl Tool for WgAddTool {
         }) {
             Ok(_) => {}
             Err(e) => return ToolOutput::error(format!("Failed to save graph: {}", e)),
+        }
+
+        // --subtask: park the parent with a wait_condition for this child.
+        if let Some(ref parent_id) = subtask_parent_id {
+            let child_id = task_id.clone();
+            let parent_id_s = parent_id.clone();
+            let mut wait_error: Option<String> = None;
+
+            match modify_graph(&path, |graph| {
+                let parent = match graph.get_task(&parent_id_s) {
+                    Some(t) => t,
+                    None => {
+                        wait_error = Some(format!(
+                            "Parent task '{}' not found (WG_TASK_ID is stale?)",
+                            parent_id_s
+                        ));
+                        return false;
+                    }
+                };
+                if parent.status != Status::InProgress {
+                    wait_error = Some(format!(
+                        "Cannot set subtask wait on parent '{}': status is '{}', expected 'in-progress'",
+                        parent_id_s, parent.status
+                    ));
+                    return false;
+                }
+                let parent = graph.get_task_mut(&parent_id_s).expect("verified above");
+                parent.status = Status::Waiting;
+                parent.wait_condition = Some(crate::graph::WaitSpec::Any(vec![
+                    crate::graph::WaitCondition::TaskStatus {
+                        task_id: child_id.clone(),
+                        status: Status::Done,
+                    },
+                    crate::graph::WaitCondition::TaskStatus {
+                        task_id: child_id.clone(),
+                        status: Status::Failed,
+                    },
+                ]));
+                parent.log.push(crate::graph::LogEntry {
+                    timestamp: Utc::now().to_rfc3339(),
+                    actor: parent.assigned.clone(),
+                    user: Some(crate::current_user()),
+                    message: format!(
+                        "Agent parked. Waiting for subtask '{}' to complete.",
+                        child_id
+                    ),
+                });
+                true
+            }) {
+                Ok(_) => {}
+                Err(e) => {
+                    return ToolOutput::error(format!(
+                        "Created task '{}' but failed to park parent: {}",
+                        task_id_clone, e
+                    ));
+                }
+            }
+            if let Some(msg) = wait_error {
+                return ToolOutput::error(format!(
+                    "Created task '{}' but failed to park parent: {}",
+                    task_id_clone, msg
+                ));
+            }
+
+            return ToolOutput::success(format!(
+                "Created subtask: {} (parent '{}' parked until child completes)",
+                task_id_clone, parent_id
+            ));
+        }
+
+        // --cron: mention the schedule in the success message so the agent
+        // can verify it was accepted.
+        if let Some(expr) = cron_expr {
+            return ToolOutput::success(format!(
+                "Created cron task: {} (schedule: '{}')",
+                task_id_clone, expr
+            ));
         }
 
         ToolOutput::success(format!("Created task: {}", task_id_clone))
@@ -710,8 +855,8 @@ mod tests {
     use std::sync::{Mutex, OnceLock};
 
     use serde_json::json;
-    use workgraph::graph::{Node, Task, WorkGraph};
-    use workgraph::parser::{load_graph, save_graph};
+    use crate::graph::{Node, Task, WorkGraph};
+    use crate::parser::{load_graph, save_graph};
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/src/executor/native/tools/wg.rs
+++ b/src/executor/native/tools/wg.rs
@@ -365,10 +365,7 @@ impl Tool for WgAddTool {
                     )
                 }
                 Err(e) => {
-                    return ToolOutput::error(format!(
-                        "Invalid cron expression '{}': {}",
-                        expr, e
-                    ));
+                    return ToolOutput::error(format!("Invalid cron expression '{}': {}", expr, e));
                 }
             }
         } else {
@@ -854,9 +851,9 @@ mod tests {
     use super::*;
     use std::sync::{Mutex, OnceLock};
 
-    use serde_json::json;
     use crate::graph::{Node, Task, WorkGraph};
     use crate::parser::{load_graph, save_graph};
+    use serde_json::json;
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -475,9 +475,9 @@ fn main() -> Result<()> {
             allow_phantom,
             allow_cycle,
         ),
-        // Commands::Reprioritize { id, priority } => {
-        //     commands::reprioritize::run(&workgraph_dir, &id, &priority)
-        // }
+        Commands::Reprioritize { id, priority } => {
+            commands::reprioritize::run(&workgraph_dir, &id, &priority)
+        }
         Commands::Done {
             id,
             converged,
@@ -2518,9 +2518,7 @@ fn main() -> Result<()> {
         },
         cli::Commands::Openrouter { command } => {
             commands::openrouter::run(&workgraph_dir, &command, cli.json)
-        } // cli::Commands::Reprioritize { id, priority } => {
-          //     commands::reprioritize::run(&workgraph_dir, &id, &priority)
-          // },
+        }
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -28,10 +28,8 @@ pub fn is_time_ready(task: &Task) -> bool {
     // Invalid timestamp = treat as ready (don't block)
 
     // Cron gate: if cron-enabled, only ready when due
-    if task.cron_enabled {
-        if !crate::cron::is_cron_due(task, now) {
-            return false;
-        }
+    if task.cron_enabled && !crate::cron::is_cron_due(task, now) {
+        return false;
     }
 
     true

--- a/src/service/chat_compactor.rs
+++ b/src/service/chat_compactor.rs
@@ -96,17 +96,16 @@ pub fn should_compact(workgraph_dir: &Path, coordinator_id: u32) -> bool {
 /// Resolution order: model registry entry → endpoint config → 200k default.
 fn resolve_chat_compactor_context_window(config: &Config) -> u64 {
     let resolved = config.resolve_model_for_role(DispatchRole::ChatCompactor);
-    if let Some(ref entry) = resolved.registry_entry {
-        if entry.context_window > 0 {
-            return entry.context_window;
-        }
+    if let Some(ref entry) = resolved.registry_entry
+        && entry.context_window > 0
+    {
+        return entry.context_window;
     }
-    if let Some(ref ep_name) = resolved.endpoint {
-        if let Some(ep) = config.llm_endpoints.find_by_name(ep_name) {
-            if let Some(cw) = ep.context_window {
-                return cw;
-            }
-        }
+    if let Some(ref ep_name) = resolved.endpoint
+        && let Some(ep) = config.llm_endpoints.find_by_name(ep_name)
+        && let Some(cw) = ep.context_window
+    {
+        return cw;
     }
     200_000
 }

--- a/src/service/compactor.rs
+++ b/src/service/compactor.rs
@@ -124,17 +124,16 @@ fn count_ops(workgraph_dir: &Path) -> usize {
 /// Resolution order: model registry entry → endpoint config → 200k default.
 fn resolve_compactor_context_window(config: &Config) -> u64 {
     let resolved = config.resolve_model_for_role(DispatchRole::Compactor);
-    if let Some(ref entry) = resolved.registry_entry {
-        if entry.context_window > 0 {
-            return entry.context_window;
-        }
+    if let Some(ref entry) = resolved.registry_entry
+        && entry.context_window > 0
+    {
+        return entry.context_window;
     }
-    if let Some(ref ep_name) = resolved.endpoint {
-        if let Some(ep) = config.llm_endpoints.find_by_name(ep_name) {
-            if let Some(cw) = ep.context_window {
-                return cw;
-            }
-        }
+    if let Some(ref ep_name) = resolved.endpoint
+        && let Some(ep) = config.llm_endpoints.find_by_name(ep_name)
+        && let Some(cw) = ep.context_window
+    {
+        return cw;
     }
     200_000
 }

--- a/src/service/executor.rs
+++ b/src/service/executor.rs
@@ -197,31 +197,32 @@ Use `wg add` to create what comes next.\n";
 pub const AUTOPOIETIC_GUIDANCE: &str = "\
 ## Task Decomposition
 
-You are encouraged to create new tasks as you discover work. \
-The coordinator will dispatch them automatically.
+Fanout is a tool, not a default. Always attempt direct implementation first. \
+The coordinator will dispatch any subtasks you create automatically.
 
-### When to decompose vs implement directly
+### DEFAULT: Implement directly
+Start by doing the work yourself. Only switch to decomposition after assessing complexity.
 
-**Difficulty is not the same as decomposability.** If a task is hard but single-scope, \
-attempt it directly — do not decompose just because it seems challenging.
-
-Decompose when the task has **genuinely independent parts** that benefit from parallel work:
-
-1. **Decompose** the task into sub-tasks that would produce the same output
-2. **Create** those sub-tasks using `wg add` with `--after {{task_id}}` dependencies
-3. **Let** those sub-tasks run and complete (the coordinator dispatches them)
-4. **Complete** your parent task based on the sub-task results
-
-### Good reasons to decompose
-- Your task has 3+ independent parts that could run in parallel
+### Fan out when:
+- 3+ independent files/components need changes that can genuinely run in parallel
+- You hit context pressure: re-reading files you already read, losing track of changes
+- The task has natural parallelism (e.g., 3 separate test files, N independent modules)
 - You discover a bug, missing doc, or needed refactor outside your scope
-- A prerequisite doesn't exist yet and needs to be created first
-- Your task is too large for a single agent session
 
-### Bad reasons to decompose (implement directly instead)
-- The task seems hard or unfamiliar — attempt it first
-- You're unsure if you can satisfy verification — try and let verification judge
-- The constraints seem conflicting — try your best interpretation
+### Stay inline when:
+- The task is straightforward, even if it touches multiple files sequentially
+- Each step depends on the previous (sequential work doesn't parallelize)
+- Simple fixes, config changes, small features
+- The task is hard but single-scope — difficulty alone is NOT a reason to decompose
+- Decomposition overhead would exceed the work itself
+
+### If you decompose:
+- Each subtask MUST list its file scope — **NO two subtasks may modify the same file**
+- Subtask descriptions should include \"Implement directly — do not decompose further\"
+- ALWAYS include an integrator at join points: \
+`wg add 'Integrate' --after part-a,part-b`
+- ALWAYS use `--after {{task_id}}` for dependencies
+- Log your decision: `wg log {{task_id}} \"FANOUT_DECISION: decompose — <reason>\"`
 
 ### How to decompose
 - **Fan out parallel work**: \
@@ -442,28 +443,37 @@ pub fn build_decomposition_guidance(
             ));
         }
         TaskComplexity::MultiStep => {
-            parts.push(
+            parts.push(format!(
                 "This appears to be a **multi-step task**. Consider decomposing with dependencies.\n\
                  \n\
-                 ### When to decompose\n\
-                 Decompose when the task has **genuinely independent parts** that benefit from \
-                 parallel work. Difficulty alone is NOT a reason to decompose — if a task is \
-                 hard but single-scope, attempt it directly first.\n\
+                 ### DEFAULT: Attempt direct implementation first\n\
+                 Even for multi-step tasks, start by implementing directly. Fanout is a tool, not a \
+                 default — overkill fanout on manageable tasks wastes tokens and adds coordination friction.\n\
                  \n\
-                 If you do decompose:\n\
-                 1. **Decompose** the task into sub-tasks that would produce the same output\n\
-                 2. **Create** those sub-tasks using `wg add` with `--after {task_id}` dependencies\n\
-                 3. **Let** those sub-tasks run and complete (the coordinator dispatches them)\n\
-                 4. **Complete** your parent task based on the sub-task results\n\
+                 ### Fan out when:\n\
+                 - 3+ independent files/components need changes that can genuinely run in parallel\n\
+                 - You hit context pressure: re-reading files you already read, losing track of changes\n\
+                 - The task has natural parallelism (e.g., 3 separate test files, N independent modules)\n\
+                 - Your turn count exceeds 25 with no test progress\n\
                  \n\
-                 When creating subtasks, ALWAYS use `--after` to express dependencies. \
-                 Flat task lists without dependency edges are an anti-pattern — they run \
-                 in arbitrary order and produce race conditions.\n\
+                 ### Stay inline when:\n\
+                 - The task is straightforward, even if it touches multiple files sequentially\n\
+                 - Each step depends on the previous (sequential work doesn't parallelize)\n\
+                 - Simple fixes, config changes, small features\n\
+                 - The task is hard but single-scope — difficulty alone is NOT a reason to decompose\n\
+                 \n\
+                 ### If you decompose:\n\
+                 - Each subtask MUST list its file scope in the description — **NO two subtasks may modify the same file**\n\
+                 - Subtask descriptions should include \"Implement directly — do not decompose further\"\n\
+                 - Always include a verify/integration task at the end: \
+                 `wg add 'Integrate' --after part-a,part-b`\n\
+                 - ALWAYS use `--after` to express dependencies. \
+                 Flat task lists without dependency edges are an anti-pattern.\n\
+                 - Log your decision: `wg log {task_id} \"FANOUT_DECISION: decompose — <reason>\"`\n\
                  \n\
                  ### Decomposition Templates\n\
                  Choose the pattern that best fits your task:"
-                    .to_string(),
-            );
+            ));
             parts.push(DECOMP_TEMPLATE_PIPELINE.replace("{{task_id}}", task_id));
             parts.push(DECOMP_TEMPLATE_FAN_OUT.replace("{{task_id}}", task_id));
             parts.push(DECOMP_TEMPLATE_ITERATE.replace("{{task_id}}", task_id));
@@ -2920,8 +2930,8 @@ args = ["--custom-flag"]
             "Static guidance should NOT contain adaptive classification"
         );
         assert!(
-            prompt.contains("You are encouraged to create new tasks"),
-            "Static guidance should contain original AUTOPOIETIC_GUIDANCE text"
+            prompt.contains("Fanout is a tool, not a default"),
+            "Static guidance should contain AUTOPOIETIC_GUIDANCE text"
         );
     }
 

--- a/src/service/executor.rs
+++ b/src/service/executor.rs
@@ -528,6 +528,21 @@ You share a working tree with other agents. Follow these rules strictly:
 - **Don't touch others' changes.** If `git status` shows files you didn't modify, do not stage, commit, stash, or reset them.
 - **Handle locks gracefully.** `.git/index.lock` or cargo target locks mean another agent is working. Wait 2-3 seconds and retry. Don't delete lock files.\n";
 
+/// Worktree isolation warning for agents running in wg-managed worktrees.
+/// Prevents agents from calling EnterWorktree/ExitWorktree which escapes the wg worktree.
+pub const WORKTREE_ISOLATION_SECTION: &str = "\
+## CRITICAL: Worktree Isolation
+
+You are running inside a **workgraph-managed worktree**. Your working directory is already isolated.
+
+**NEVER use the `EnterWorktree` or `ExitWorktree` tools.** Using them will:
+1. Create a SECOND worktree in `.claude/worktrees/`, abandoning this one
+2. Switch your session CWD away from the workgraph branch
+3. Cause ALL your commits to go to the wrong branch
+4. Result in your work being LOST — the merge-back will find no commits
+
+If you see these tools available, **ignore them completely**. Workgraph already provides full git isolation.\n";
+
 /// Message polling instructions for agents.
 /// Contains {{task_id}} placeholder for variable substitution.
 pub const MESSAGE_POLLING_SECTION: &str = "\
@@ -871,6 +886,9 @@ pub fn build_prompt(vars: &TemplateVars, scope: ContextScope, ctx: &ScopeContext
     if scope >= ContextScope::Task {
         parts.push(vars.apply(REQUIRED_WORKFLOW_SECTION));
         parts.push(GIT_HYGIENE_SECTION.to_string());
+        if vars.in_worktree {
+            parts.push(WORKTREE_ISOLATION_SECTION.to_string());
+        }
         parts.push(vars.apply(MESSAGE_POLLING_SECTION));
 
         // Task+ scope: Telegram escalation (when configured)
@@ -970,6 +988,8 @@ pub struct TemplateVars {
     pub has_failed_deps: bool,
     /// Info about failed dependencies for triage prompt injection
     pub failed_deps_info: String,
+    /// True when the agent is running in a wg-managed worktree
+    pub in_worktree: bool,
 }
 
 impl TemplateVars {
@@ -1043,6 +1063,7 @@ impl TemplateVars {
             max_task_depth: guardrails.max_task_depth,
             has_failed_deps: false,
             failed_deps_info: String::new(),
+            in_worktree: false,
         }
     }
 

--- a/src/service/executor.rs
+++ b/src/service/executor.rs
@@ -652,7 +652,7 @@ results. Use instead of shelling out to curl+scraping.
 stripped, code blocks and tables preserved). Use instead of `bash: curl $URL` which \
 gives you raw HTML.
 
-### Delegation (focused sub-agent with its own context)
+### Delegation and summarization (push work out of your context)
 
 - `delegate(prompt, exec_mode?, max_turns?)` — spawn a focused in-process sub-agent \
 with its own conversation context. **The sub-agent's token usage does NOT count \
@@ -661,6 +661,16 @@ queries that would otherwise bloat your own context window: \"read src/X.rs and 
 its public functions\", \"find all callers of Y\", \"summarize the tests in tests/Z/\". \
 `exec_mode=light` (default) gives read-only tools; `exec_mode=full` gives the full \
 set minus `delegate` itself. `max_turns` caps the sub-agent at 5 (default) to 20 turns.
+
+- `summarize(source, instruction?, max_input_bytes?)` — recursively summarize a \
+**large text source** via map-reduce. Takes a file path OR inline text, chunks it \
+to fit the model's context, summarizes each chunk independently with your \
+instruction, then merges — recursing on the merged summaries if they're still \
+too large. Use this when a source is too big to read directly: long log files, \
+big text dumps, transcripts, large documents. Unlike `delegate`, `summarize` \
+issues direct text-in/text-out LLM calls with no tool loop — cheap, predictable, \
+and able to handle sources that would otherwise require many turns of manual \
+chunking. Hard ceiling 1 MB by default (raisable via `max_input_bytes`).
 
 ### Workgraph task management (in-process, no CLI spawn)
 

--- a/src/service/executor.rs
+++ b/src/service/executor.rs
@@ -603,38 +603,78 @@ const WG_CONTEXT_HINT: &str = "\
 - Use `wg context` to view the current task's full context
 - Use `wg list` to see all tasks and their statuses\n";
 
-/// Native executor file-tool guidance. Injected into the prompt only when
-/// the executor is `native`, since these tool names (`read_file`,
-/// `write_file`, `edit_file`, `grep`, `glob`) are specific to the native
+/// Native executor tool guidance. Injected into the prompt only when the
+/// executor is `native`, since these tool names are specific to the native
 /// executor's in-process tool registry — claude/amplifier/etc. have
-/// different names (Read/Edit/Write) provided by their own runtimes.
+/// different names provided by their own runtimes.
 ///
-/// The goal is to push models away from bash-based file manipulation
-/// (echo/cat/heredoc/sed), which is fragile across shell escaping rules
-/// for multi-line content, and toward the dedicated tools which take
-/// structured JSON input and return structured results.
+/// The goal is to make the full native toolset visible in the system
+/// prompt narrative, not just as API tool definitions. Models — especially
+/// smaller ones with strong bash training priors — otherwise default to
+/// shell-based workarounds for problems that have better first-class tools
+/// (echo/heredoc for file creation, sed for editing, curl for web access,
+/// polling loops for async work, etc.).
 pub const NATIVE_FILE_TOOLS_SECTION: &str = "\
-## Native Executor File Tools
+## Native Executor Tools
 
-You have dedicated file tools. **Prefer these over bash equivalents** — they are \
-more reliable (no shell escaping) and return structured results.
+You have a rich in-process toolset. **Prefer the dedicated tool over a bash \
+equivalent whenever one exists.** Bash is for things without a dedicated tool.
 
-- `read_file(path, offset?, limit?)` — read a file or a slice of it. Use instead of \
-`cat`/`head`/`tail`.
-- `write_file(path, content)` — create or overwrite a file. Use instead of `echo >`, \
-`cat <<EOF`, or any bash heredoc. **Shell escaping of multi-line content is fragile \
-and breaks on quotes, newlines, and special characters** — this is the single most \
-common cause of failed file creation.
-- `edit_file(path, old_string, new_string)` — surgical in-place replacement. Use \
-instead of `sed -i`. `old_string` must appear exactly once; include surrounding \
+### File operations (no shell escaping, structured results)
+
+- `read_file(path, offset?, limit?)` — read a file or a slice. Replaces `cat`/`head`/`tail`.
+- `write_file(path, content)` — create or overwrite a file. Replaces `echo >` and \
+heredocs. **Shell escaping of multi-line content is fragile — this is the #1 cause \
+of failed file creation.** Never use bash for new-file creation.
+- `edit_file(path, old_string, new_string)` — surgical in-place replacement. \
+Replaces `sed -i`. `old_string` must appear exactly once; include surrounding \
 context when needed to make it unique.
-- `grep(pattern, path?, ...)` — search file contents. Use instead of `grep -r`.
-- `glob(pattern)` — find files by name pattern. Use instead of `find` or shell globbing.
+- `grep(pattern, path?, ...)` — search file contents. Replaces `grep -r`.
+- `glob(pattern)` — find files by name pattern. Replaces `find` and shell globbing.
 
-Use `bash` for everything else: running programs (tests, builds, scripts), system \
-inspection (`ps`, `df`, `env`), piped operations, or anything that inherently needs \
-shell execution. **Never use bash for file creation or in-place editing of existing \
-files** — use the dedicated tools above.
+### Running programs
+
+- `bash(command)` — **synchronous** shell execution. Use for tests, builds, \
+system inspection, and quick one-shots. Outputs >2KB are channeled to disk \
+automatically (see below).
+- `bg(action, ...)` — **background/detached** execution for long-running commands \
+(cargo build, test suites, servers) that would otherwise block your turn loop. \
+Actions: `run`, `list`, `status`, `output`, `kill`, `delete`. Completion \
+notifications inject into your next turn automatically. **Use `bg` — never \
+`bash: nohup X &` or `while sleep; do check; done` — for anything longer than a \
+few seconds.**
+
+### Web access (structured content, no HTML parsing)
+
+- `web_search(query, max_results?)` — search the web, get ranked title/URL/snippet \
+results. Use instead of shelling out to curl+scraping.
+- `web_fetch(url)` — fetch a page and get clean markdown (navigation/ads/scripts \
+stripped, code blocks and tables preserved). Use instead of `bash: curl $URL` which \
+gives you raw HTML.
+
+### Delegation (focused sub-agent with its own context)
+
+- `delegate(prompt, exec_mode?, max_turns?)` — spawn a focused in-process sub-agent \
+with its own conversation context. **The sub-agent's token usage does NOT count \
+against your context** — only its final result text does. Use this for focused \
+queries that would otherwise bloat your own context window: \"read src/X.rs and list \
+its public functions\", \"find all callers of Y\", \"summarize the tests in tests/Z/\". \
+`exec_mode=light` (default) gives read-only tools; `exec_mode=full` gives the full \
+set minus `delegate` itself. `max_turns` caps the sub-agent at 5 (default) to 20 turns.
+
+### Workgraph task management (in-process, no CLI spawn)
+
+- `wg_show(task_id)`, `wg_list()`, `wg_log(task_id, message)` — inspect and \
+annotate tasks.
+- `wg_add(title, description?, after?, tags?, skills?)` — create follow-up tasks \
+(e.g., \"Verify: ...\" after your current task for fan-out).
+- `wg_done(task_id)`, `wg_fail(task_id, reason)`, `wg_artifact(task_id, path)` — \
+lifecycle operations.
+
+Prefer these over `bash: wg show ...` — they take structured input and return \
+structured results. For advanced flags not in the tool schemas \
+(`--subtask` for blocking subtask, `--cron \"expr\"` for scheduled tasks), fall \
+back to `bash: wg add --subtask ...` or `bash: wg add --cron ...`.
 
 ### Channeled tool outputs
 
@@ -644,6 +684,19 @@ conversation with a compact handle plus a short preview. The raw bytes are alway
 on disk — do NOT re-fetch from the original source. To read more from a channeled \
 output, use either `read_file` with `offset`/`limit` on the handle path, or `bash` \
 for text slicing (`sed -n 'A,Bp'`, `grep -n`, `wc -l`, `head`, `tail`).
+
+### Anti-patterns — DO NOT do these
+
+- `echo \"...\" > file` → use `write_file`
+- `cat <<EOF > file ... EOF` → use `write_file`
+- `sed -i 's/a/b/' file` → use `edit_file`
+- `find . -name '*.rs'` → use `glob` with `**/*.rs`
+- `grep -r foo src/` → use `grep`
+- `curl $URL | lynx -dump` → use `web_fetch`
+- `nohup long_command &` / `tmux new-session` → use `bg run`
+- `while ! ls output; do sleep 5; done` → use `bg` with status checks
+- Reading a whole huge file into context when you only need a slice → use \
+`read_file(offset, limit)` or `delegate` to a sub-agent
 ";
 
 /// Default workgraph usage guide for non-Claude models.

--- a/src/service/executor.rs
+++ b/src/service/executor.rs
@@ -603,6 +603,49 @@ const WG_CONTEXT_HINT: &str = "\
 - Use `wg context` to view the current task's full context
 - Use `wg list` to see all tasks and their statuses\n";
 
+/// Native executor file-tool guidance. Injected into the prompt only when
+/// the executor is `native`, since these tool names (`read_file`,
+/// `write_file`, `edit_file`, `grep`, `glob`) are specific to the native
+/// executor's in-process tool registry — claude/amplifier/etc. have
+/// different names (Read/Edit/Write) provided by their own runtimes.
+///
+/// The goal is to push models away from bash-based file manipulation
+/// (echo/cat/heredoc/sed), which is fragile across shell escaping rules
+/// for multi-line content, and toward the dedicated tools which take
+/// structured JSON input and return structured results.
+pub const NATIVE_FILE_TOOLS_SECTION: &str = "\
+## Native Executor File Tools
+
+You have dedicated file tools. **Prefer these over bash equivalents** — they are \
+more reliable (no shell escaping) and return structured results.
+
+- `read_file(path, offset?, limit?)` — read a file or a slice of it. Use instead of \
+`cat`/`head`/`tail`.
+- `write_file(path, content)` — create or overwrite a file. Use instead of `echo >`, \
+`cat <<EOF`, or any bash heredoc. **Shell escaping of multi-line content is fragile \
+and breaks on quotes, newlines, and special characters** — this is the single most \
+common cause of failed file creation.
+- `edit_file(path, old_string, new_string)` — surgical in-place replacement. Use \
+instead of `sed -i`. `old_string` must appear exactly once; include surrounding \
+context when needed to make it unique.
+- `grep(pattern, path?, ...)` — search file contents. Use instead of `grep -r`.
+- `glob(pattern)` — find files by name pattern. Use instead of `find` or shell globbing.
+
+Use `bash` for everything else: running programs (tests, builds, scripts), system \
+inspection (`ps`, `df`, `env`), piped operations, or anything that inherently needs \
+shell execution. **Never use bash for file creation or in-place editing of existing \
+files** — use the dedicated tools above.
+
+### Channeled tool outputs
+
+When any tool returns more than ~2KB, the full output is saved to \
+`.workgraph/agents/<agent-id>/tool-outputs/NNNNN.log` and replaced in your \
+conversation with a compact handle plus a short preview. The raw bytes are always \
+on disk — do NOT re-fetch from the original source. To read more from a channeled \
+output, use either `read_file` with `offset`/`limit` on the handle path, or `bash` \
+for text slicing (`sed -n 'A,Bp'`, `grep -n`, `wc -l`, `head`, `tail`).
+";
+
 /// Default workgraph usage guide for non-Claude models.
 ///
 /// Injected into the prompt when the executor is non-Claude (native) so that models
@@ -775,6 +818,11 @@ pub struct ScopeContext {
     pub decomp_guidance: bool,
     /// Whether Telegram escalation is configured and available (task+ scope)
     pub telegram_available: bool,
+    /// Whether to inject the native-executor file-tool guidance section.
+    /// Set when the spawning executor is `native` so the model learns it
+    /// has `read_file`/`write_file`/`edit_file`/`grep`/`glob` available
+    /// and should prefer them over bash equivalents.
+    pub native_file_tools: bool,
 }
 
 /// Build a scope-aware prompt for built-in executors.
@@ -880,6 +928,14 @@ pub fn build_prompt(vars: &TemplateVars, scope: ContextScope, ctx: &ScopeContext
             "## Workgraph Usage Guide\n\n{}",
             ctx.wg_guide_content
         ));
+    }
+
+    // Task+ scope: native-executor file-tool guidance. Teaches the model
+    // that it has dedicated read_file/write_file/edit_file/grep/glob tools
+    // and should prefer them over bash equivalents (echo/cat/heredoc/sed).
+    // This is foundational — place it near the top of the guidance stack.
+    if scope >= ContextScope::Task && ctx.native_file_tools {
+        parts.push(NATIVE_FILE_TOOLS_SECTION.to_string());
     }
 
     // Task+ scope: workflow sections (with {{task_id}} substitution)

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -91,6 +91,35 @@ impl AgentEntry {
         )
     }
 
+    /// Strict liveness check — the agent is considered *live* if and
+    /// only if ALL of the following hold:
+    ///
+    /// 1. The status is alive (`Starting | Working | Idle`), AND
+    /// 2. The underlying process exists (PID is valid and running), AND
+    /// 3. The last heartbeat is fresh (within `heartbeat_timeout_secs`).
+    ///
+    /// This is the invariant used by worktree cleanup paths: a worktree
+    /// is safe to remove only when its owning agent is **not** live by
+    /// this definition. The status-only `is_alive()` check is too loose
+    /// because an agent can crash with the registry still reporting
+    /// `Working` — leaving its worktree incorrectly protected forever.
+    /// Conversely, just-process-alive is also too loose because a
+    /// zombie/orphan process can exist with stale heartbeat long after
+    /// real work stopped.
+    pub fn is_live(&self, heartbeat_timeout_secs: u64) -> bool {
+        if !self.is_alive() {
+            return false;
+        }
+        if !super::is_process_alive(self.pid) {
+            return false;
+        }
+        match self.seconds_since_heartbeat() {
+            Some(secs) if secs >= 0 && (secs as u64) <= heartbeat_timeout_secs => true,
+            // Invalid timestamp, future-dated heartbeat, or stale: not live.
+            _ => false,
+        }
+    }
+
     /// Calculate uptime in seconds from started_at to now
     pub fn uptime_secs(&self) -> Option<i64> {
         let started = DateTime::parse_from_rfc3339(&self.started_at).ok()?;
@@ -538,6 +567,107 @@ mod tests {
         let registry = AgentRegistry::new();
         assert!(registry.agents.is_empty());
         assert_eq!(registry.next_agent_id, 1);
+    }
+
+    #[test]
+    fn test_is_live_requires_all_three_invariants() {
+        // Unix: use a PID that cannot exist (the reaper's PID-0 trick:
+        // on Linux pid 0 is invalid for `kill(pid, 0)`, returning ESRCH.
+        // We use a more portable approach — pick a PID very unlikely to
+        // be alive, then verify the check fails.
+
+        // Case 1: status Done + fresh heartbeat + any PID → NOT live
+        // (is_alive() fails first)
+        let entry = AgentEntry {
+            id: "agent-test".to_string(),
+            pid: std::process::id(), // our own PID — definitely alive
+            task_id: "t".to_string(),
+            executor: "claude".to_string(),
+            started_at: Utc::now().to_rfc3339(),
+            last_heartbeat: Utc::now().to_rfc3339(),
+            status: AgentStatus::Done,
+            output_file: "/tmp/out".to_string(),
+            model: None,
+            completed_at: None,
+        };
+        assert!(!entry.is_live(300), "Done status should not be live");
+
+        // Case 2: status Working + fresh heartbeat + own PID → LIVE
+        let entry = AgentEntry {
+            id: "agent-test".to_string(),
+            pid: std::process::id(),
+            task_id: "t".to_string(),
+            executor: "claude".to_string(),
+            started_at: Utc::now().to_rfc3339(),
+            last_heartbeat: Utc::now().to_rfc3339(),
+            status: AgentStatus::Working,
+            output_file: "/tmp/out".to_string(),
+            model: None,
+            completed_at: None,
+        };
+        assert!(
+            entry.is_live(300),
+            "Working status + own PID + fresh heartbeat should be live"
+        );
+
+        // Case 3: status Working + own PID + STALE heartbeat → NOT live
+        // (3600 seconds ago, timeout 300)
+        let stale_heartbeat = (Utc::now() - chrono::Duration::seconds(3600)).to_rfc3339();
+        let entry = AgentEntry {
+            id: "agent-test".to_string(),
+            pid: std::process::id(),
+            task_id: "t".to_string(),
+            executor: "claude".to_string(),
+            started_at: Utc::now().to_rfc3339(),
+            last_heartbeat: stale_heartbeat,
+            status: AgentStatus::Working,
+            output_file: "/tmp/out".to_string(),
+            model: None,
+            completed_at: None,
+        };
+        assert!(
+            !entry.is_live(300),
+            "stale heartbeat should fail liveness even if status+process ok"
+        );
+
+        // Case 4: status Working + fresh heartbeat + DEFINITELY DEAD PID → NOT live
+        // PID 0x7FFF_FFFE is extremely unlikely to be in use (near PID_MAX)
+        let entry = AgentEntry {
+            id: "agent-test".to_string(),
+            pid: 0x7FFF_FFFE,
+            task_id: "t".to_string(),
+            executor: "claude".to_string(),
+            started_at: Utc::now().to_rfc3339(),
+            last_heartbeat: Utc::now().to_rfc3339(),
+            status: AgentStatus::Working,
+            output_file: "/tmp/out".to_string(),
+            model: None,
+            completed_at: None,
+        };
+        assert!(
+            !entry.is_live(300),
+            "dead PID should fail liveness even if status+heartbeat ok"
+        );
+
+        // Case 5: timeout of 0 → even a just-written heartbeat may fail.
+        // Use a heartbeat 1 second ago with timeout 0 → not live.
+        let past = (Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
+        let entry = AgentEntry {
+            id: "agent-test".to_string(),
+            pid: std::process::id(),
+            task_id: "t".to_string(),
+            executor: "claude".to_string(),
+            started_at: Utc::now().to_rfc3339(),
+            last_heartbeat: past,
+            status: AgentStatus::Working,
+            output_file: "/tmp/out".to_string(),
+            model: None,
+            completed_at: None,
+        };
+        assert!(
+            !entry.is_live(0),
+            "timeout=0 should reject even 1-second-old heartbeat"
+        );
     }
 
     #[test]

--- a/src/tui/viz_viewer/state.rs
+++ b/src/tui/viz_viewer/state.rs
@@ -6284,11 +6284,7 @@ impl VizApp {
                 let model = coord_state
                     .as_ref()
                     .and_then(|s| s.model_override.clone())
-                    .or_else(|| {
-                        coord_state
-                            .as_ref()
-                            .and_then(|s| s.model.clone())
-                    })
+                    .or_else(|| coord_state.as_ref().and_then(|s| s.model.clone()))
                     .or_else(|| config.coordinator.model.clone())
                     .or_else(|| {
                         Some(

--- a/terminal-bench/RESEARCH-FANOUT-GUIDANCE.md
+++ b/terminal-bench/RESEARCH-FANOUT-GUIDANCE.md
@@ -1,0 +1,346 @@
+# Research: Agent Fanout Guidance and TB Prompt Injection
+
+**Task:** tb-research-fanout
+**Date:** 2026-04-14
+
+---
+
+## 1. Agent System Prompt / Context Injection Architecture
+
+### 1.1 Prompt Assembly Entry Point
+
+**File:** `src/service/executor.rs:762` — `build_prompt()`
+
+This is the main function that assembles the complete agent prompt. It takes `TemplateVars`, a `ContextScope` (clean/task/graph/full), and a `ScopeContext`, then concatenates sections in a defined order:
+
+1. System awareness preamble (full scope only)
+2. Skills preamble
+3. Task assignment header
+4. Agent identity (from agency system)
+5. Task details (ID, title, description)
+6. Pattern keywords glossary (conditional)
+7. Verification criteria
+8. Discovered test files (task+ scope)
+9. Tags/skills info (task+ scope)
+10. Context from dependencies
+11. Triage mode (if failed deps)
+12. Previous attempt context (on retry)
+13. Queued messages (task+ scope)
+14. Downstream awareness (task+ scope)
+15. Loop info
+16. WG usage guide (task+ scope, non-Claude models)
+17. **REQUIRED_WORKFLOW_SECTION** (task+ scope)
+18. **GIT_HYGIENE_SECTION** (task+ scope)
+19. **MESSAGE_POLLING_SECTION** (task+ scope)
+20. Telegram escalation (task+ scope, if configured)
+21. **ETHOS_SECTION** ("The Graph is Alive") (task+ scope)
+22. **DECOMPOSITION GUIDANCE** (task+ scope — adaptive or static)
+23. **RESEARCH_HINTS_SECTION** (task+ scope)
+24. **GRAPH_PATTERNS_SECTION** (task+ scope)
+25. **REUSABLE_FUNCTIONS_SECTION** (task+ scope)
+26. **CRITICAL_WG_CLI_SECTION** (task+ scope)
+27. Additional context (task+ scope)
+28. Graph summary / CLAUDE.md (graph/full scope)
+
+### 1.2 Tiered Knowledge Guide (Non-Claude Models)
+
+**File:** `src/commands/spawn/context.rs:644-815` — `build_tiered_guide()`
+
+Three tiers based on model context window:
+- **Essential** (8KB, line 667): Core agent guide with decision framework
+- **Core** (16KB, line 792): Essential + communication + graph patterns
+- **Full** (40KB, line 805): Core + agency system + advanced patterns
+
+The Essential guide at lines 672-788 contains the foundational fanout guidance that ALL agents see:
+- "Decision Framework: When to Decompose vs Implement" (lines 689-702)
+- "Decomposition Pattern Templates" (lines 704-731)
+- Pipeline, Fan-Out-Merge, Iterate-Until-Pass patterns
+
+### 1.3 Key Fanout Instruction Sections
+
+#### ETHOS_SECTION (`src/service/executor.rs:174-192`)
+"The Graph is Alive" — encourages agents to grow the graph:
+- "Task too large? → Fan out independent parts as parallel subtasks"
+- "Prerequisite missing? → wg add..."
+- "Follow-up needed? → wg add..."
+
+#### Static AUTOPOIETIC_GUIDANCE (`src/service/executor.rs:197-259`)
+Injected when `decomp_guidance = false`:
+- "When to decompose vs implement directly"
+- Good/bad reasons to decompose
+- How to decompose (fan-out, pipeline, synthesis patterns)
+- Guardrails: {{max_child_tasks}} and {{max_task_depth}} placeholders
+- "When NOT to decompose"
+
+#### Adaptive build_decomposition_guidance() (`src/service/executor.rs:419-505`)
+Injected when `decomp_guidance = true` (default):
+- Classifies task as ATOMIC or MULTI-STEP based on description signals
+- ATOMIC tasks: "Implement directly without decomposition" + escape hatch
+- MULTI-STEP tasks: Full decomposition templates + patterns
+- Both get: validation criteria guidance + guardrails + "when NOT to decompose"
+
+---
+
+## 2. TB-Specific Prompt Injection
+
+### 2.1 Condition G Meta-Prompts (TB-specific)
+
+**File:** `terminal-bench/wg/adapter.py:515-563` — `CONDITION_G_META_PROMPT`
+
+The ORIGINAL Condition G meta-prompt forces unconditional decomposition:
+```
+"You are a graph architect. You do NOT implement solutions yourself."
+"DO NOT write code. DO NOT modify files. Only create wg tasks."
+```
+
+This is prepended to the task instruction when `autopoietic=True` in the condition config (line 790).
+
+**File:** `terminal-bench/wg/adapter.py:583-638` — `CONDITION_G_SMART_META_PROMPT`
+
+The SMART fanout replacement (used when `smart_fanout=True`):
+- Try-first approach: "Strategy 1 — Direct Implementation (default)"
+- Triage criteria: word count, file count, test count thresholds
+- Mid-task switching: can switch to decomposition if context pressure detected
+- Hard constraints: max 4 subtasks, max 1 level deep, no shared files
+
+### 2.2 Prompt Injection Path in adapter.py
+
+**File:** `terminal-bench/wg/adapter.py:784-797`
+
+```python
+if cfg.get("autopoietic"):
+    if cfg.get("smart_fanout"):
+        meta = CONDITION_G_SMART_META_PROMPT.replace("{seed_task_id}", task_id)
+    else:
+        meta = CONDITION_G_META_PROMPT.replace("{seed_task_id}", task_id)
+    if verify_cmd:
+        meta += f"\n## Test command\n..."
+```
+
+The meta-prompt is prepended to the task instruction, which then becomes the task description that the wg agent system sees. This means the meta-prompt lands in `vars.task_description` in `build_prompt()`, and the agent sees BOTH:
+1. The TB meta-prompt (from adapter.py, in the description)
+2. The wg decomposition guidance (from AUTOPOIETIC_GUIDANCE or build_decomposition_guidance, injected by build_prompt)
+
+**This is a key tension**: The wg system's decomposition guidance says "default to implementing directly," but the TB Condition G meta-prompt says "DO NOT write code." They conflict.
+
+### 2.3 Coordinator Heartbeat (TB-related)
+
+**File:** `src/commands/service/coordinator_agent.rs:383-441`
+
+The coordinator's autonomous heartbeat prompts are used for TB Condition G Phase 3. They inject time awareness:
+```
+[AUTONOMOUS HEARTBEAT] Tick #{tick_number} at {timestamp}
+Time elapsed: {elapsed}s | Budget remaining: {remaining_display}
+```
+
+Phase guidance varies:
+- Early: "Confirm task graph structure, verify agents are spawning..."
+- Mid: "Assess agent progress..."
+- Late: "WRAP-UP MODE — under 5 minutes remain..."
+
+---
+
+## 3. Guardrails Configuration and Enforcement
+
+### 3.1 Config Knobs
+
+**File:** `src/config.rs:430-478` — `GuardrailsConfig`
+
+| Config Key | Default | Purpose |
+|------------|---------|---------|
+| `max_child_tasks_per_agent` | 10 | Max tasks a single agent can create via `wg add` |
+| `max_task_depth` | 8 | Max depth of task dependency chains |
+| `max_triage_attempts` | 3 | Max times a task can be requeued via failed-dep triage |
+| `decomp_guidance` | true | Whether to use adaptive (true) or static (false) decomposition guidance |
+
+### 3.2 Enforcement: Per-Agent Task Creation Limit
+
+**File:** `src/commands/add.rs:275-293`
+
+Enforced at `wg add` time when `WG_AGENT_ID` env var is set:
+```rust
+let count = count_agent_created_tasks(dir, agent_id);
+if count >= max_child {
+    anyhow::bail!("Agent {} has already created {}/{} tasks...");
+}
+```
+
+Uses the provenance log to count how many `add_task` operations the agent has performed.
+
+### 3.3 Enforcement: Task Depth Limit
+
+**File:** `src/commands/add.rs:394-412`
+
+Enforced at `wg add` time when `--after` is specified:
+```rust
+let max_parent_depth = effective_after.iter()
+    .map(|parent_id| graph.task_depth(parent_id))
+    .max().unwrap_or(0);
+let new_depth = max_parent_depth + 1;
+if new_depth > max_depth {
+    anyhow::bail!("Task would be at depth {} (max: {})...");
+}
+```
+
+**File:** `src/graph.rs:1456-1492` — `task_depth()`
+
+Depth computed recursively with memoization and cycle detection. Depth = longest path from any root task.
+
+### 3.4 Guardrail Values in Agent Prompts
+
+**File:** `src/service/executor.rs:1032-1033`
+
+TemplateVars gets populated from config:
+```rust
+max_child_tasks: guardrails.max_child_tasks_per_agent,
+max_task_depth: guardrails.max_task_depth,
+```
+
+These appear in the agent prompt via either:
+- `AUTOPOIETIC_GUIDANCE` template: `{{max_child_tasks}}` and `{{max_task_depth}}` placeholders (line 252-253)
+- `build_decomposition_guidance()`: formatted directly into the string (lines 491-492)
+
+---
+
+## 4. Adaptive Decomposition Intelligence
+
+### 4.1 Task Complexity Classification
+
+**File:** `src/service/executor.rs:263-375` — `classify_task_complexity()`
+
+Two-class scoring heuristic:
+
+**ATOMIC signals** (lines 273-293): "single function", "fix bug in", "one file", "typo", "rename", "hotfix", "quick fix", etc.
+
+**MULTI-STEP signals** (lines 296-328): "build pipeline", "multiple files", "end-to-end", "refactor", "implement feature", "pipeline", "first,", "second,", "then", etc.
+
+**Scoring**: Count signal matches in description (case-insensitive). Also checks for 3+ bullet items as a multi-step signal. Ties go to multi-step. Default for no matches: >200 chars = multi-step, ≤200 chars = atomic.
+
+### 4.2 Pattern Keywords Detection
+
+**File:** `src/service/executor.rs:645-694`
+
+Trigger keywords: "autopoietic", "self-organizing", "committee", "discussion", "deliberation", "swarm", "fork-join", "fan-out", "parallel", "loop", "cycle", "iterate", "research", "investigate", "audit"
+
+When detected in the task description, the `PATTERN_KEYWORDS_GLOSSARY` is injected (line 792-794) explaining expected behavior for each pattern.
+
+---
+
+## 5. Existing Fanout Heuristics and Conditions
+
+### 5.1 In the WG System (src/)
+
+1. **Adaptive decomposition** (`decomp_guidance=true`): Classifies task as atomic/multi-step and tailors guidance
+2. **Pattern keywords**: Detects organizational patterns in task descriptions and injects glossary
+3. **Hard guardrails**: max_child_tasks_per_agent=10, max_task_depth=8 (enforced at `wg add`)
+4. **Tiered knowledge**: Different guide detail levels based on model context window size
+5. **Decision framework** (in essential guide): "Implement Directly If" / "Decompose If" criteria
+
+### 5.2 In the TB System (terminal-bench/)
+
+1. **CONDITION_G_META_PROMPT**: Forces unconditional decomposition ("DO NOT write code")
+2. **CONDITION_G_SMART_META_PROMPT**: Try-first with triage criteria (word count, file count, test count)
+3. **Architect bundle** (line 570-576): Restricts tool access to read-only + wg commands
+4. **Heartbeat system**: Time-aware coordination prompts
+
+### 5.3 Prior Research (Existing Analysis Documents)
+
+- `terminal-bench/TB-CONDITION-G-FANOUT-ANALYSIS.md`: Full analysis showing 72% of tasks harmed by unconditional decomposition; break-even at ~45% context utilization + multi-phase structure
+- `terminal-bench/DESIGN-smart-fanout-calculus.md`: Complete design for smart fanout with decision function, meta-prompt, and validation plan
+
+---
+
+## 6. Recommendations for Balanced Heuristic
+
+### 6.1 Current State Summary
+
+The WG system already has reasonable decomposition guidance:
+- The adaptive classifier (`classify_task_complexity`) tries to discourage decomposition for atomic tasks
+- The essential guide has a clear "Implement Directly If / Decompose If" framework
+- Hard guardrails (10 tasks, depth 8) prevent runaway decomposition
+
+But there are gaps:
+- **No context-pressure signal**: Agents can't detect when they're approaching context limits
+- **No mid-task switching**: The guidance is pre-task only; no support for "try then decompose"
+- **No explicit file-scope constraint**: Nothing prevents parallel subtasks from modifying the same files
+- **No subtask depth prohibition**: Workers can re-decompose (creating depth>1 chains)
+- **TB tension**: The TB meta-prompt overrides the wg guidance for Condition G
+
+### 6.2 What Agents Currently See vs What They Should See
+
+**BEFORE (current agent prompt for a typical task):**
+```
+## Task Decomposition
+
+This appears to be a **multi-step task**. Consider decomposing with dependencies.
+
+### When to decompose
+Decompose when the task has genuinely independent parts...
+[full templates for pipeline, fan-out, iterate]
+
+### Guardrails
+- You can create up to **10** subtasks per session
+- Task chains have a maximum depth of **8** levels
+```
+
+No mention of: trying direct implementation first, context pressure detection, file-scope constraints, or depth-1 prohibition for workers.
+
+**AFTER (recommended additions):**
+```
+## Task Decomposition
+
+This appears to be a **multi-step task**. Consider decomposing with dependencies.
+
+### DEFAULT: Attempt direct implementation first
+Even for multi-step tasks, start by implementing directly. Only switch to
+decomposition if you observe:
+- Context pressure (re-reading files you already read, losing track of changes)
+- The task has 3+ truly independent sub-problems on different files
+- Your turn count exceeds 25 with no test progress
+
+### If you decompose
+- Create at most 4 subtasks
+- Each subtask must list its file scope — NO two subtasks may modify the same file
+- Workers must NOT create their own subtasks (add "Implement directly" to descriptions)
+- Always include a verify/integration task at the end
+- Log your decision: wg log <task-id> "FANOUT_DECISION: decompose — <reason>"
+```
+
+### 6.3 File Paths That Need Modification
+
+| File | Lines | Change Needed |
+|------|-------|---------------|
+| `src/service/executor.rs:197-259` | AUTOPOIETIC_GUIDANCE static | Add try-first language, file-scope constraint, depth-1 prohibition |
+| `src/service/executor.rs:419-505` | build_decomposition_guidance() | Enhance MULTI-STEP guidance with try-first, context-pressure detection, file-scope |
+| `src/service/executor.rs:273-328` | ATOMIC/MULTI_STEP signals | Consider adding more signals or adjusting thresholds |
+| `src/commands/spawn/context.rs:689-702` | Essential guide decision framework | Add file-scope and depth-1 constraints |
+| `src/config.rs:430-451` | GuardrailsConfig | Consider adding `max_subtask_depth` (default: 1) and `require_file_scope` (default: true) |
+| `terminal-bench/wg/adapter.py:515-563` | CONDITION_G_META_PROMPT | Already has smart replacement; ensure smart_fanout is default for G |
+| `terminal-bench/wg/adapter.py:583-638` | CONDITION_G_SMART_META_PROMPT | Already good; may need tuning after wg-side changes |
+
+---
+
+## Source References
+
+| Source | Path | Key Content |
+|--------|------|-------------|
+| Prompt assembly | `src/service/executor.rs:762-885` | `build_prompt()` — main prompt construction |
+| Static decomp guidance | `src/service/executor.rs:197-259` | `AUTOPOIETIC_GUIDANCE` constant |
+| Adaptive decomp guidance | `src/service/executor.rs:419-505` | `build_decomposition_guidance()` function |
+| Task complexity classifier | `src/service/executor.rs:263-375` | `classify_task_complexity()` with signal lists |
+| Pattern keywords | `src/service/executor.rs:645-694` | Trigger keywords + glossary injection |
+| Guardrails config | `src/config.rs:430-478` | `GuardrailsConfig` struct |
+| Per-agent limit enforcement | `src/commands/add.rs:275-293` | `count_agent_created_tasks()` check |
+| Depth limit enforcement | `src/commands/add.rs:394-412` | `task_depth()` check |
+| Depth computation | `src/graph.rs:1456-1492` | `task_depth()` recursive with memoization |
+| Essential guide | `src/commands/spawn/context.rs:667-788` | `build_essential_guide()` |
+| Tiered guide | `src/commands/spawn/context.rs:644-815` | `build_tiered_guide()` |
+| TemplateVars | `src/service/executor.rs:946-963` | Guardrail values plumbing |
+| TB Condition G prompt | `terminal-bench/wg/adapter.py:515-563` | Original "always decompose" meta-prompt |
+| TB Smart fanout prompt | `terminal-bench/wg/adapter.py:583-638` | Try-first smart meta-prompt |
+| TB prompt injection | `terminal-bench/wg/adapter.py:784-797` | Where meta-prompt meets task description |
+| Coordinator heartbeat | `src/commands/service/coordinator_agent.rs:383-441` | Time-aware heartbeat prompts |
+| Prior fanout analysis | `terminal-bench/TB-CONDITION-G-FANOUT-ANALYSIS.md` | Full performance analysis |
+| Smart fanout design | `terminal-bench/DESIGN-smart-fanout-calculus.md` | Decision function + validation plan |
+| Ethos section | `src/service/executor.rs:174-192` | "The Graph is Alive" |
+| Graph patterns section | `src/service/executor.rs:122-141` | Vocabulary + golden rules |

--- a/tests/integration_context_scope.rs
+++ b/tests/integration_context_scope.rs
@@ -491,6 +491,7 @@ fn test_pattern_glossary_included_when_keywords_present() {
         max_task_depth: 8,
         has_failed_deps: false,
         failed_deps_info: String::new(),
+        in_worktree: false,
     };
     let ctx = ScopeContext::default();
     let prompt = build_prompt(&vars, ContextScope::Clean, &ctx);
@@ -542,6 +543,7 @@ fn test_pattern_glossary_excluded_when_no_keywords() {
         max_task_depth: 8,
         has_failed_deps: false,
         failed_deps_info: String::new(),
+        in_worktree: false,
     };
     let ctx = ScopeContext::default();
     let prompt = build_prompt(&vars, ContextScope::Clean, &ctx);
@@ -549,5 +551,65 @@ fn test_pattern_glossary_excluded_when_no_keywords() {
     assert!(
         !prompt.contains("## Pattern Keywords"),
         "Prompt should NOT include pattern glossary when description has no keywords"
+    );
+}
+
+#[test]
+fn test_worktree_isolation_section_included_when_in_worktree() {
+    let vars = TemplateVars {
+        task_id: "wt-task".into(),
+        task_title: "Worktree task".into(),
+        task_description: "A task running in a worktree".into(),
+        task_context: "No dependencies".into(),
+        task_identity: String::new(),
+        working_dir: String::new(),
+        skills_preamble: String::new(),
+        model: String::new(),
+        task_loop_info: String::new(),
+        task_verify: None,
+        max_child_tasks: 10,
+        max_task_depth: 8,
+        has_failed_deps: false,
+        failed_deps_info: String::new(),
+        in_worktree: true,
+    };
+    let ctx = ScopeContext::default();
+    let prompt = build_prompt(&vars, ContextScope::Task, &ctx);
+
+    assert!(
+        prompt.contains("CRITICAL: Worktree Isolation"),
+        "Prompt should include worktree isolation warning when in_worktree is true"
+    );
+    assert!(
+        prompt.contains("NEVER use the `EnterWorktree` or `ExitWorktree` tools"),
+        "Prompt should warn against EnterWorktree"
+    );
+}
+
+#[test]
+fn test_worktree_isolation_section_excluded_when_not_in_worktree() {
+    let vars = TemplateVars {
+        task_id: "no-wt-task".into(),
+        task_title: "Normal task".into(),
+        task_description: "A task not in a worktree".into(),
+        task_context: "No dependencies".into(),
+        task_identity: String::new(),
+        working_dir: String::new(),
+        skills_preamble: String::new(),
+        model: String::new(),
+        task_loop_info: String::new(),
+        task_verify: None,
+        max_child_tasks: 10,
+        max_task_depth: 8,
+        has_failed_deps: false,
+        failed_deps_info: String::new(),
+        in_worktree: false,
+    };
+    let ctx = ScopeContext::default();
+    let prompt = build_prompt(&vars, ContextScope::Task, &ctx);
+
+    assert!(
+        !prompt.contains("CRITICAL: Worktree Isolation"),
+        "Prompt should NOT include worktree isolation warning when not in worktree"
     );
 }

--- a/tests/integration_cron_dispatch.rs
+++ b/tests/integration_cron_dispatch.rs
@@ -178,8 +178,14 @@ fn cron_task_resets_after_done() {
     assert!(result, "reset_cron_task should return true");
     assert_eq!(task.status, Status::Open, "Status should be Open");
     assert!(task.assigned.is_none(), "assigned should be cleared");
-    assert!(task.completed_at.is_none(), "completed_at should be cleared");
-    assert!(task.last_cron_fire.is_some(), "last_cron_fire should be set");
+    assert!(
+        task.completed_at.is_none(),
+        "completed_at should be cleared"
+    );
+    assert!(
+        task.last_cron_fire.is_some(),
+        "last_cron_fire should be set"
+    );
     assert!(
         task.next_cron_fire.is_some(),
         "next_cron_fire should be set for future dispatch"
@@ -227,8 +233,14 @@ fn list_cron_filter_shows_only_cron_tasks() {
 
     // List all tasks → both should appear
     let output_all = wg_ok(&wg_dir, &["list"]);
-    assert!(output_all.contains("cron-1"), "All list should contain cron task");
-    assert!(output_all.contains("normal-1"), "All list should contain normal task");
+    assert!(
+        output_all.contains("cron-1"),
+        "All list should contain cron task"
+    );
+    assert!(
+        output_all.contains("normal-1"),
+        "All list should contain normal task"
+    );
 
     // List with --cron → only cron task
     let output_cron = wg_ok(&wg_dir, &["list", "--cron"]);
@@ -270,7 +282,11 @@ fn list_cron_filter_json() {
     let json: serde_json::Value = serde_json::from_str(&output).expect("Should be valid JSON");
     let arr = json.as_array().expect("Should be array");
 
-    assert_eq!(arr.len(), 1, "Should have exactly 1 cron task in JSON output");
+    assert_eq!(
+        arr.len(),
+        1,
+        "Should have exactly 1 cron task in JSON output"
+    );
     assert_eq!(arr[0]["id"], "cj1");
     assert_eq!(arr[0]["cron_enabled"], true);
     assert!(arr[0].get("cron_schedule").is_some());
@@ -292,7 +308,10 @@ fn edit_cron_set_schedule() {
 
     let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("e1").unwrap();
-    assert!(task.cron_enabled, "cron_enabled should be true after edit --cron");
+    assert!(
+        task.cron_enabled,
+        "cron_enabled should be true after edit --cron"
+    );
     assert_eq!(
         task.cron_schedule.as_deref(),
         Some("0 0 9 * * *"),
@@ -322,7 +341,10 @@ fn edit_cron_clear_schedule() {
 
     let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("ec1").unwrap();
-    assert!(!task.cron_enabled, "cron_enabled should be false after clearing");
+    assert!(
+        !task.cron_enabled,
+        "cron_enabled should be false after clearing"
+    );
     assert!(
         task.cron_schedule.is_none(),
         "cron_schedule should be None after clearing"

--- a/tests/integration_multiple_compaction.rs
+++ b/tests/integration_multiple_compaction.rs
@@ -21,7 +21,9 @@ use tempfile::TempDir;
 use workgraph::config::{Config, DispatchRole, ModelRegistryEntry, Tier};
 use workgraph::executor::native::client::{ContentBlock, Message, Role};
 use workgraph::executor::native::journal::{Journal, JournalEntryKind};
-use workgraph::executor::native::resume::{ContextBudget, ContextPressureAction, ResumeConfig, load_resume_data};
+use workgraph::executor::native::resume::{
+    ContextBudget, ContextPressureAction, ResumeConfig, load_resume_data,
+};
 use workgraph::service::chat_compactor::ChatCompactorState;
 use workgraph::service::compactor::{self, CompactorState};
 
@@ -286,10 +288,7 @@ fn test_compaction_error_recovery_across_cycles() {
 
     let state = CompactorState::load(dir);
     assert_eq!(state.error_count, 3, "Should have 3 accumulated errors");
-    assert_eq!(
-        state.compaction_count, 0,
-        "No successful compactions yet"
-    );
+    assert_eq!(state.compaction_count, 0, "No successful compactions yet");
 
     // Simulate a successful compaction that resets error count
     let mut state = CompactorState::load(dir);
@@ -299,7 +298,10 @@ fn test_compaction_error_recovery_across_cycles() {
     state.save(dir).unwrap();
 
     let recovered = CompactorState::load(dir);
-    assert_eq!(recovered.error_count, 0, "Error count should reset on success");
+    assert_eq!(
+        recovered.error_count, 0,
+        "Error count should reset on success"
+    );
     assert_eq!(recovered.compaction_count, 1);
 }
 
@@ -440,7 +442,10 @@ fn test_multiple_compaction_preserves_tool_info() {
         .unwrap()
         .expect("Should load tool-heavy journal");
 
-    assert!(resume.was_compacted, "Tool-heavy journal should be compacted");
+    assert!(
+        resume.was_compacted,
+        "Tool-heavy journal should be compacted"
+    );
     assert_valid_alternation(&resume.messages);
 
     // The compaction summary should mention tools that were used
@@ -783,12 +788,17 @@ fn test_multiple_emergency_compaction_cycles() {
 
         eprintln!(
             "Emergency compact cycle {}: {} -> {} messages",
-            cycle, before_count, messages.len()
+            cycle,
+            before_count,
+            messages.len()
         );
     }
 
     // After 3 cycles, we should still have valid messages
-    assert!(messages.len() >= 2, "Should have at least 2 messages after 3 cycles");
+    assert!(
+        messages.len() >= 2,
+        "Should have at least 2 messages after 3 cycles"
+    );
 }
 
 /// Test emergency compaction with mixed content (text + tool use + tool results).
@@ -1001,7 +1011,11 @@ fn test_resume_compaction_adapts_to_context_window() {
         !resume_large.was_compacted,
         "200k window should not trigger compaction for 25 pairs"
     );
-    assert_eq!(resume_large.messages.len(), 50, "Should have all 50 messages");
+    assert_eq!(
+        resume_large.messages.len(),
+        50,
+        "Should have all 50 messages"
+    );
 
     // With a medium context window (8k): should compact
     let config_medium = ResumeConfig {
@@ -1153,9 +1167,32 @@ fn test_context_md_across_cycles() {
     let wg_dir = setup_wg(&tmp);
 
     // Add some tasks to the graph
-    wg_ok(&wg_dir, &["add", "Setup infrastructure", "--id", "infra-init"]);
-    wg_ok(&wg_dir, &["add", "Implement auth", "--id", "auth-impl", "--after", "infra-init"]);
-    wg_ok(&wg_dir, &["add", "Write tests", "--id", "write-tests", "--after", "auth-impl"]);
+    wg_ok(
+        &wg_dir,
+        &["add", "Setup infrastructure", "--id", "infra-init"],
+    );
+    wg_ok(
+        &wg_dir,
+        &[
+            "add",
+            "Implement auth",
+            "--id",
+            "auth-impl",
+            "--after",
+            "infra-init",
+        ],
+    );
+    wg_ok(
+        &wg_dir,
+        &[
+            "add",
+            "Write tests",
+            "--id",
+            "write-tests",
+            "--after",
+            "auth-impl",
+        ],
+    );
 
     // Simulate compaction cycle 1: write fake context.md
     let context_path = compactor::context_md_path(&wg_dir);
@@ -1238,8 +1275,12 @@ fn test_compactor_model_resolution_openai() {
     let mut config = Config::default();
 
     // Configure compactor to use an OpenAI-compatible model
-    config.models.set_model(DispatchRole::Compactor, "gpt-4o-mini");
-    config.models.set_provider(DispatchRole::Compactor, "openai");
+    config
+        .models
+        .set_model(DispatchRole::Compactor, "gpt-4o-mini");
+    config
+        .models
+        .set_provider(DispatchRole::Compactor, "openai");
 
     let resolved = config.resolve_model_for_role(DispatchRole::Compactor);
     assert_eq!(resolved.model, "gpt-4o-mini");
@@ -1251,8 +1292,12 @@ fn test_compactor_model_resolution_openai() {
 fn test_chat_compactor_model_resolution_openrouter() {
     let mut config = Config::default();
 
-    config.models.set_model(DispatchRole::ChatCompactor, "deepseek/deepseek-chat");
-    config.models.set_provider(DispatchRole::ChatCompactor, "openrouter");
+    config
+        .models
+        .set_model(DispatchRole::ChatCompactor, "deepseek/deepseek-chat");
+    config
+        .models
+        .set_provider(DispatchRole::ChatCompactor, "openrouter");
 
     let resolved = config.resolve_model_for_role(DispatchRole::ChatCompactor);
     assert_eq!(resolved.model, "deepseek/deepseek-chat");
@@ -1286,18 +1331,46 @@ fn smoke_multiple_compaction_cycles_openrouter() {
     wg_ok(
         &wg_dir,
         &[
-            "endpoint", "add", "test-openrouter",
-            "--provider", "openrouter",
-            "--url", "https://openrouter.ai/api/v1",
-            "--key-env", "OPENROUTER_API_KEY",
+            "endpoint",
+            "add",
+            "test-openrouter",
+            "--provider",
+            "openrouter",
+            "--url",
+            "https://openrouter.ai/api/v1",
+            "--key-env",
+            "OPENROUTER_API_KEY",
         ],
     );
     wg_ok(&wg_dir, &["endpoint", "set-default", "test-openrouter"]);
 
     // Add tasks to create graph state for compaction
-    wg_ok(&wg_dir, &["add", "Research context windows", "--id", "research-ctx"]);
-    wg_ok(&wg_dir, &["add", "Implement dynamic sizing", "--id", "impl-sizing", "--after", "research-ctx"]);
-    wg_ok(&wg_dir, &["add", "Write integration tests", "--id", "write-tests", "--after", "impl-sizing"]);
+    wg_ok(
+        &wg_dir,
+        &["add", "Research context windows", "--id", "research-ctx"],
+    );
+    wg_ok(
+        &wg_dir,
+        &[
+            "add",
+            "Implement dynamic sizing",
+            "--id",
+            "impl-sizing",
+            "--after",
+            "research-ctx",
+        ],
+    );
+    wg_ok(
+        &wg_dir,
+        &[
+            "add",
+            "Write integration tests",
+            "--id",
+            "write-tests",
+            "--after",
+            "impl-sizing",
+        ],
+    );
 
     // Configure the compactor to use a cheap OpenRouter model
     let config_path = wg_dir.join("config.toml");
@@ -1350,9 +1423,11 @@ provider = "openrouter"
         // Verify state was updated
         let state = CompactorState::load(&wg_dir);
         assert_eq!(
-            state.compaction_count, u64::from(cycle),
+            state.compaction_count,
+            u64::from(cycle),
             "Cycle {}: compaction count should be {}",
-            cycle, cycle
+            cycle,
+            cycle
         );
         assert_eq!(
             state.error_count, 0,

--- a/tests/integration_native_executor_async_web.rs
+++ b/tests/integration_native_executor_async_web.rs
@@ -103,35 +103,32 @@ async fn web_fetch_tool_fetches_html_returns_markdown() {
     // Serve a simple HTML page
     let server = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
-        let _ = tokio::time::timeout(
-            Duration::from_secs(2),
-            async {
-                use tokio::io::{AsyncReadExt, AsyncWriteExt};
-                let mut s = stream;
-                let mut buf = vec![0u8; 4096];
-                let _ = s.read(&mut buf).await;
-                let response = concat!(
-                    "HTTP/1.1 200 OK\r\n",
-                    "Content-Type: text/html\r\n",
-                    "Connection: close\r\n",
-                    "\r\n",
-                    "<html><head><title>Test Page</title></head>",
-                    "<body>",
-                    "<article>",
-                    "<h1>Hello World</h1>",
-                    "<p>This is the main content of the test page. It has enough text ",
-                    "that readability should be able to extract it properly. The content ",
-                    "discusses integration testing for the native executor.</p>",
-                    "<p>Second paragraph with more meaningful content about how web fetch ",
-                    "converts HTML into clean markdown output.</p>",
-                    "</article>",
-                    "<footer>Footer noise</footer>",
-                    "</body></html>",
-                );
-                s.write_all(response.as_bytes()).await.unwrap();
-                s.shutdown().await.ok();
-            },
-        )
+        let _ = tokio::time::timeout(Duration::from_secs(2), async {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let mut s = stream;
+            let mut buf = vec![0u8; 4096];
+            let _ = s.read(&mut buf).await;
+            let response = concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "Content-Type: text/html\r\n",
+                "Connection: close\r\n",
+                "\r\n",
+                "<html><head><title>Test Page</title></head>",
+                "<body>",
+                "<article>",
+                "<h1>Hello World</h1>",
+                "<p>This is the main content of the test page. It has enough text ",
+                "that readability should be able to extract it properly. The content ",
+                "discusses integration testing for the native executor.</p>",
+                "<p>Second paragraph with more meaningful content about how web fetch ",
+                "converts HTML into clean markdown output.</p>",
+                "</article>",
+                "<footer>Footer noise</footer>",
+                "</body></html>",
+            );
+            s.write_all(response.as_bytes()).await.unwrap();
+            s.shutdown().await.ok();
+        })
         .await;
     });
 
@@ -182,9 +179,7 @@ async fn web_fetch_error_on_empty_url() {
     let tmp = TempDir::new().unwrap();
     let registry = ToolRegistry::default_all(tmp.path(), &std::env::current_dir().unwrap());
 
-    let output = registry
-        .execute("web_fetch", &json!({"url": ""}))
-        .await;
+    let output = registry.execute("web_fetch", &json!({"url": ""})).await;
     assert!(output.is_error, "Should error on empty URL");
     assert!(output.content.contains("empty"));
 }
@@ -209,7 +204,10 @@ async fn web_fetch_custom_config_applies() {
 
     let defs = registry.definitions();
     let has_web_fetch = defs.iter().any(|d| d.name == "web_fetch");
-    assert!(has_web_fetch, "web_fetch should be in the registry with custom config");
+    assert!(
+        has_web_fetch,
+        "web_fetch should be in the registry with custom config"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -459,12 +457,14 @@ async fn delegate_tool_input_validation() {
     // Missing prompt
     let output = registry.execute("delegate", &json!({})).await;
     assert!(output.is_error);
-    assert!(output.content.contains("Missing required parameter: prompt"));
+    assert!(
+        output
+            .content
+            .contains("Missing required parameter: prompt")
+    );
 
     // Empty prompt
-    let output = registry
-        .execute("delegate", &json!({"prompt": "  "}))
-        .await;
+    let output = registry.execute("delegate", &json!({"prompt": "  "})).await;
     assert!(output.is_error);
     assert!(output.content.contains("must not be empty"));
 

--- a/tests/integration_reap_kill_tree.rs
+++ b/tests/integration_reap_kill_tree.rs
@@ -213,10 +213,23 @@ fn test_reap_after_kill_tree_cleans_dead_agents() {
 
     // Verify post-reap: only the alive agent remains
     let post = load_registry(&wg_dir);
-    assert_eq!(post.agents.len(), 1, "Expected only 1 alive agent after reap");
-    assert!(post.get_agent(&a3).is_some(), "Alive agent should still be in registry");
-    assert!(post.get_agent(&a1).is_none(), "Dead agent a1 should have been reaped");
-    assert!(post.get_agent(&a2).is_none(), "Dead agent a2 should have been reaped");
+    assert_eq!(
+        post.agents.len(),
+        1,
+        "Expected only 1 alive agent after reap"
+    );
+    assert!(
+        post.get_agent(&a3).is_some(),
+        "Alive agent should still be in registry"
+    );
+    assert!(
+        post.get_agent(&a1).is_none(),
+        "Dead agent a1 should have been reaped"
+    );
+    assert!(
+        post.get_agent(&a2).is_none(),
+        "Dead agent a2 should have been reaped"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -337,7 +350,11 @@ fn test_kill_tree_dry_run_no_side_effects() {
 
     // Verify registry unchanged
     let post_reg = load_registry(&wg_dir);
-    assert_eq!(post_reg.agents.len(), 1, "Registry should be unchanged after dry run");
+    assert_eq!(
+        post_reg.agents.len(),
+        1,
+        "Registry should be unchanged after dry run"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -368,7 +385,11 @@ fn test_reap_dry_run_no_side_effects() {
 
     // Registry should be unchanged
     let post = load_registry(&wg_dir);
-    assert_eq!(post.agents.len(), 2, "Registry should be unchanged after reap --dry-run");
+    assert_eq!(
+        post.agents.len(),
+        2,
+        "Registry should be unchanged after reap --dry-run"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -449,7 +470,11 @@ fn test_kill_tree_json_output() {
 
     let output = wg_cmd(&wg_dir, &["kill", "--tree", "task-a", "--force", "--json"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(output.status.success(), "kill --tree --json failed: {}", stdout);
+    assert!(
+        output.status.success(),
+        "kill --tree --json failed: {}",
+        stdout
+    );
 
     // Parse JSON output
     let json: serde_json::Value = serde_json::from_str(&stdout)
@@ -474,7 +499,11 @@ fn test_kill_tree_dry_run_json_output() {
         &["kill", "--tree", "task-a", "--dry-run", "--json"],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(output.status.success(), "kill --tree --dry-run --json failed: {}", stdout);
+    assert!(
+        output.status.success(),
+        "kill --tree --dry-run --json failed: {}",
+        stdout
+    );
 
     let json: serde_json::Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|e| panic!("Invalid JSON output: {}\n{}", e, stdout));
@@ -531,9 +560,7 @@ fn test_reap_older_than_filter() {
     let old_id = registry.register_agent(999999999, "task-a", "claude", "/dev/null");
     registry.set_status(&old_id, AgentStatus::Dead);
     if let Some(agent) = registry.get_agent_mut(&old_id) {
-        agent.completed_at = Some(
-            (chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339(),
-        );
+        agent.completed_at = Some((chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339());
     }
     // Agent that "died" 5 seconds ago — should NOT be reaped with --older-than 1h
     let recent_id = registry.register_agent(999999998, "task-b", "claude", "/dev/null");

--- a/tests/integration_subtask.rs
+++ b/tests/integration_subtask.rs
@@ -47,11 +47,7 @@ fn wg_binary() -> PathBuf {
     path
 }
 
-fn wg_cmd_env(
-    wg_dir: &Path,
-    args: &[&str],
-    env: &[(&str, &str)],
-) -> std::process::Output {
+fn wg_cmd_env(wg_dir: &Path, args: &[&str], env: &[(&str, &str)]) -> std::process::Output {
     let mut cmd = Command::new(wg_binary());
     cmd.arg("--dir")
         .arg(wg_dir)
@@ -355,10 +351,10 @@ fn subtask_coordinator_resumes_parent_on_child_failed() {
         did_change
     });
 
-    assert!(did_change, "Wait condition should be satisfied when child fails");
-    let graph = load_graph(&gp).unwrap();
-    assert_eq!(
-        graph.get_task("parent-task").unwrap().status,
-        Status::Open
+    assert!(
+        did_change,
+        "Wait condition should be satisfied when child fails"
     );
+    let graph = load_graph(&gp).unwrap();
+    assert_eq!(graph.get_task("parent-task").unwrap().status, Status::Open);
 }

--- a/tests/integration_worktree.rs
+++ b/tests/integration_worktree.rs
@@ -344,7 +344,11 @@ fn test_worktree_full_lifecycle() {
     );
 
     let output = Command::new("git")
-        .args(["commit", "-m", "feat: lifecycle-test (agent-lifecycle)\n\nSquash-merged from worktree branch"])
+        .args([
+            "commit",
+            "-m",
+            "feat: lifecycle-test (agent-lifecycle)\n\nSquash-merged from worktree branch",
+        ])
         .current_dir(&project_root)
         .env("GIT_AUTHOR_NAME", "Test")
         .env("GIT_AUTHOR_EMAIL", "test@test.com")
@@ -462,20 +466,19 @@ fn test_worktree_workgraph_symlink_lifecycle() {
     // Manually create the .workgraph symlink (as create_worktree in spawn/worktree.rs does)
     let symlink_path = wt_dir.join(".workgraph");
     let wg_canonical = wg_dir.canonicalize().expect("Failed to canonicalize");
-    std::os::unix::fs::symlink(&wg_canonical, &symlink_path)
-        .expect("Failed to create symlink");
+    std::os::unix::fs::symlink(&wg_canonical, &symlink_path).expect("Failed to create symlink");
 
     // Verify symlink works — agent can read graph.jsonl through it
-    let content =
-        std::fs::read_to_string(symlink_path.join("graph.jsonl")).expect("Failed to read through symlink");
-    assert!(content.contains("test"), "Should read graph through symlink");
+    let content = std::fs::read_to_string(symlink_path.join("graph.jsonl"))
+        .expect("Failed to read through symlink");
+    assert!(
+        content.contains("test"),
+        "Should read graph through symlink"
+    );
 
     // Agent writes to .workgraph through symlink (e.g., logging)
-    std::fs::write(
-        symlink_path.join("test_log.txt"),
-        "agent log entry",
-    )
-    .expect("Failed to write through symlink");
+    std::fs::write(symlink_path.join("test_log.txt"), "agent log entry")
+        .expect("Failed to write through symlink");
 
     // Verify the write went to the real .workgraph
     assert!(
@@ -664,9 +667,11 @@ fn test_worktree_process_cwd_in_worktree() {
     );
 
     // Read the symlink target and verify it points to the worktree
-    let actual_cwd = std::fs::read_link(proc_cwd_path)
-        .expect("Failed to read /proc/pid/cwd symlink");
-    let wt_canonical = wt_dir.canonicalize().expect("Failed to canonicalize worktree dir");
+    let actual_cwd =
+        std::fs::read_link(proc_cwd_path).expect("Failed to read /proc/pid/cwd symlink");
+    let wt_canonical = wt_dir
+        .canonicalize()
+        .expect("Failed to canonicalize worktree dir");
     assert_eq!(
         actual_cwd, wt_canonical,
         "Process CWD should be the worktree directory.\nExpected: {:?}\nActual: {:?}",
@@ -724,7 +729,11 @@ fn test_worktree_main_dir_unmodified_during_agent_work() {
     // Simulate agent work in worktree: create files, modify existing file
     std::fs::write(wt_dir.join("new_feature.rs"), "fn feature() {}").unwrap();
     std::fs::write(wt_dir.join("data.json"), r#"{"key": "value"}"#).unwrap();
-    std::fs::write(wt_dir.join("src/main.rs"), "fn main() { println!(\"modified\"); }").unwrap();
+    std::fs::write(
+        wt_dir.join("src/main.rs"),
+        "fn main() { println!(\"modified\"); }",
+    )
+    .unwrap();
 
     // Stage and commit in the worktree
     Command::new("git")
@@ -890,7 +899,10 @@ fn test_worktree_kill_running_process_cleanup() {
     );
 
     // Worktree should still exist (kill doesn't clean it up automatically)
-    assert!(wt_dir.exists(), "Worktree should still exist after process kill");
+    assert!(
+        wt_dir.exists(),
+        "Worktree should still exist after process kill"
+    );
 
     // Now simulate the cleanup that the wrapper script would do
     // (remove symlink, force-remove worktree, delete branch)
@@ -1420,10 +1432,7 @@ for i in $(seq 1 100); do [ -f {signal_dir}/continue ] && break; sleep 0.1; done
         .output()
         .unwrap();
     let worktree_list = String::from_utf8_lossy(&output.stdout);
-    let wt_lines: Vec<&str> = worktree_list
-        .lines()
-        .filter(|l| !l.is_empty())
-        .collect();
+    let wt_lines: Vec<&str> = worktree_list.lines().filter(|l| !l.is_empty()).collect();
     assert_eq!(
         wt_lines.len(),
         1,

--- a/tests/prompt_snapshots.rs
+++ b/tests/prompt_snapshots.rs
@@ -87,6 +87,7 @@ fn test_template_vars() -> TemplateVars {
         max_task_depth: 8,
         has_failed_deps: false,
         failed_deps_info: String::new(),
+        in_worktree: false,
     }
 }
 

--- a/tests/snapshots/prompt_snapshots__build_prompt_full.snap
+++ b/tests/snapshots/prompt_snapshots__build_prompt_full.snap
@@ -171,16 +171,27 @@ The coordinator dispatches anything you add. You don't need permission.
 
 This appears to be a **multi-step task**. Consider decomposing with dependencies.
 
-### When to decompose
-Decompose when the task has **genuinely independent parts** that benefit from parallel work. Difficulty alone is NOT a reason to decompose — if a task is hard but single-scope, attempt it directly first.
+### DEFAULT: Attempt direct implementation first
+Even for multi-step tasks, start by implementing directly. Fanout is a tool, not a default — overkill fanout on manageable tasks wastes tokens and adds coordination friction.
 
-If you do decompose:
-1. **Decompose** the task into sub-tasks that would produce the same output
-2. **Create** those sub-tasks using `wg add` with `--after {task_id}` dependencies
-3. **Let** those sub-tasks run and complete (the coordinator dispatches them)
-4. **Complete** your parent task based on the sub-task results
+### Fan out when:
+- 3+ independent files/components need changes that can genuinely run in parallel
+- You hit context pressure: re-reading files you already read, losing track of changes
+- The task has natural parallelism (e.g., 3 separate test files, N independent modules)
+- Your turn count exceeds 25 with no test progress
 
-When creating subtasks, ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern — they run in arbitrary order and produce race conditions.
+### Stay inline when:
+- The task is straightforward, even if it touches multiple files sequentially
+- Each step depends on the previous (sequential work doesn't parallelize)
+- Simple fixes, config changes, small features
+- The task is hard but single-scope — difficulty alone is NOT a reason to decompose
+
+### If you decompose:
+- Each subtask MUST list its file scope in the description — **NO two subtasks may modify the same file**
+- Subtask descriptions should include "Implement directly — do not decompose further"
+- Always include a verify/integration task at the end: `wg add 'Integrate' --after part-a,part-b`
+- ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern.
+- Log your decision: `wg log test-task-123 "FANOUT_DECISION: decompose — <reason>"`
 
 ### Decomposition Templates
 Choose the pattern that best fits your task:

--- a/tests/snapshots/prompt_snapshots__build_prompt_graph.snap
+++ b/tests/snapshots/prompt_snapshots__build_prompt_graph.snap
@@ -160,16 +160,27 @@ The coordinator dispatches anything you add. You don't need permission.
 
 This appears to be a **multi-step task**. Consider decomposing with dependencies.
 
-### When to decompose
-Decompose when the task has **genuinely independent parts** that benefit from parallel work. Difficulty alone is NOT a reason to decompose — if a task is hard but single-scope, attempt it directly first.
+### DEFAULT: Attempt direct implementation first
+Even for multi-step tasks, start by implementing directly. Fanout is a tool, not a default — overkill fanout on manageable tasks wastes tokens and adds coordination friction.
 
-If you do decompose:
-1. **Decompose** the task into sub-tasks that would produce the same output
-2. **Create** those sub-tasks using `wg add` with `--after {task_id}` dependencies
-3. **Let** those sub-tasks run and complete (the coordinator dispatches them)
-4. **Complete** your parent task based on the sub-task results
+### Fan out when:
+- 3+ independent files/components need changes that can genuinely run in parallel
+- You hit context pressure: re-reading files you already read, losing track of changes
+- The task has natural parallelism (e.g., 3 separate test files, N independent modules)
+- Your turn count exceeds 25 with no test progress
 
-When creating subtasks, ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern — they run in arbitrary order and produce race conditions.
+### Stay inline when:
+- The task is straightforward, even if it touches multiple files sequentially
+- Each step depends on the previous (sequential work doesn't parallelize)
+- Simple fixes, config changes, small features
+- The task is hard but single-scope — difficulty alone is NOT a reason to decompose
+
+### If you decompose:
+- Each subtask MUST list its file scope in the description — **NO two subtasks may modify the same file**
+- Subtask descriptions should include "Implement directly — do not decompose further"
+- Always include a verify/integration task at the end: `wg add 'Integrate' --after part-a,part-b`
+- ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern.
+- Log your decision: `wg log test-task-123 "FANOUT_DECISION: decompose — <reason>"`
 
 ### Decomposition Templates
 Choose the pattern that best fits your task:

--- a/tests/snapshots/prompt_snapshots__build_prompt_task.snap
+++ b/tests/snapshots/prompt_snapshots__build_prompt_task.snap
@@ -160,16 +160,27 @@ The coordinator dispatches anything you add. You don't need permission.
 
 This appears to be a **multi-step task**. Consider decomposing with dependencies.
 
-### When to decompose
-Decompose when the task has **genuinely independent parts** that benefit from parallel work. Difficulty alone is NOT a reason to decompose — if a task is hard but single-scope, attempt it directly first.
+### DEFAULT: Attempt direct implementation first
+Even for multi-step tasks, start by implementing directly. Fanout is a tool, not a default — overkill fanout on manageable tasks wastes tokens and adds coordination friction.
 
-If you do decompose:
-1. **Decompose** the task into sub-tasks that would produce the same output
-2. **Create** those sub-tasks using `wg add` with `--after {task_id}` dependencies
-3. **Let** those sub-tasks run and complete (the coordinator dispatches them)
-4. **Complete** your parent task based on the sub-task results
+### Fan out when:
+- 3+ independent files/components need changes that can genuinely run in parallel
+- You hit context pressure: re-reading files you already read, losing track of changes
+- The task has natural parallelism (e.g., 3 separate test files, N independent modules)
+- Your turn count exceeds 25 with no test progress
 
-When creating subtasks, ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern — they run in arbitrary order and produce race conditions.
+### Stay inline when:
+- The task is straightforward, even if it touches multiple files sequentially
+- Each step depends on the previous (sequential work doesn't parallelize)
+- Simple fixes, config changes, small features
+- The task is hard but single-scope — difficulty alone is NOT a reason to decompose
+
+### If you decompose:
+- Each subtask MUST list its file scope in the description — **NO two subtasks may modify the same file**
+- Subtask descriptions should include "Implement directly — do not decompose further"
+- Always include a verify/integration task at the end: `wg add 'Integrate' --after part-a,part-b`
+- ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern.
+- Log your decision: `wg log test-task-123 "FANOUT_DECISION: decompose — <reason>"`
 
 ### Decomposition Templates
 Choose the pattern that best fits your task:

--- a/tests/snapshots/prompt_snapshots__build_prompt_with_loop.snap
+++ b/tests/snapshots/prompt_snapshots__build_prompt_with_loop.snap
@@ -164,16 +164,27 @@ The coordinator dispatches anything you add. You don't need permission.
 
 This appears to be a **multi-step task**. Consider decomposing with dependencies.
 
-### When to decompose
-Decompose when the task has **genuinely independent parts** that benefit from parallel work. Difficulty alone is NOT a reason to decompose — if a task is hard but single-scope, attempt it directly first.
+### DEFAULT: Attempt direct implementation first
+Even for multi-step tasks, start by implementing directly. Fanout is a tool, not a default — overkill fanout on manageable tasks wastes tokens and adds coordination friction.
 
-If you do decompose:
-1. **Decompose** the task into sub-tasks that would produce the same output
-2. **Create** those sub-tasks using `wg add` with `--after {task_id}` dependencies
-3. **Let** those sub-tasks run and complete (the coordinator dispatches them)
-4. **Complete** your parent task based on the sub-task results
+### Fan out when:
+- 3+ independent files/components need changes that can genuinely run in parallel
+- You hit context pressure: re-reading files you already read, losing track of changes
+- The task has natural parallelism (e.g., 3 separate test files, N independent modules)
+- Your turn count exceeds 25 with no test progress
 
-When creating subtasks, ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern — they run in arbitrary order and produce race conditions.
+### Stay inline when:
+- The task is straightforward, even if it touches multiple files sequentially
+- Each step depends on the previous (sequential work doesn't parallelize)
+- Simple fixes, config changes, small features
+- The task is hard but single-scope — difficulty alone is NOT a reason to decompose
+
+### If you decompose:
+- Each subtask MUST list its file scope in the description — **NO two subtasks may modify the same file**
+- Subtask descriptions should include "Implement directly — do not decompose further"
+- Always include a verify/integration task at the end: `wg add 'Integrate' --after part-a,part-b`
+- ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern.
+- Log your decision: `wg log test-task-123 "FANOUT_DECISION: decompose — <reason>"`
 
 ### Decomposition Templates
 Choose the pattern that best fits your task:

--- a/tests/snapshots/prompt_snapshots__build_prompt_with_verify.snap
+++ b/tests/snapshots/prompt_snapshots__build_prompt_with_verify.snap
@@ -167,16 +167,27 @@ The coordinator dispatches anything you add. You don't need permission.
 
 This appears to be a **multi-step task**. Consider decomposing with dependencies.
 
-### When to decompose
-Decompose when the task has **genuinely independent parts** that benefit from parallel work. Difficulty alone is NOT a reason to decompose — if a task is hard but single-scope, attempt it directly first.
+### DEFAULT: Attempt direct implementation first
+Even for multi-step tasks, start by implementing directly. Fanout is a tool, not a default — overkill fanout on manageable tasks wastes tokens and adds coordination friction.
 
-If you do decompose:
-1. **Decompose** the task into sub-tasks that would produce the same output
-2. **Create** those sub-tasks using `wg add` with `--after {task_id}` dependencies
-3. **Let** those sub-tasks run and complete (the coordinator dispatches them)
-4. **Complete** your parent task based on the sub-task results
+### Fan out when:
+- 3+ independent files/components need changes that can genuinely run in parallel
+- You hit context pressure: re-reading files you already read, losing track of changes
+- The task has natural parallelism (e.g., 3 separate test files, N independent modules)
+- Your turn count exceeds 25 with no test progress
 
-When creating subtasks, ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern — they run in arbitrary order and produce race conditions.
+### Stay inline when:
+- The task is straightforward, even if it touches multiple files sequentially
+- Each step depends on the previous (sequential work doesn't parallelize)
+- Simple fixes, config changes, small features
+- The task is hard but single-scope — difficulty alone is NOT a reason to decompose
+
+### If you decompose:
+- Each subtask MUST list its file scope in the description — **NO two subtasks may modify the same file**
+- Subtask descriptions should include "Implement directly — do not decompose further"
+- Always include a verify/integration task at the end: `wg add 'Integrate' --after part-a,part-b`
+- ALWAYS use `--after` to express dependencies. Flat task lists without dependency edges are an anti-pattern.
+- Log your decision: `wg log test-task-123 "FANOUT_DECISION: decompose — <reason>"`
 
 ### Decomposition Templates
 Choose the pattern that best fits your task:

--- a/worktree-canary.txt
+++ b/worktree-canary.txt
@@ -1,0 +1,1 @@
+worktree survived

--- a/worktree-collision-research.md
+++ b/worktree-collision-research.md
@@ -1,0 +1,149 @@
+# Research: Worktree Collision Between wg and Claude Code
+
+## Root Cause: Two Collision Mechanisms
+
+### Mechanism 1: Agent-Initiated Worktree Escape (Primary)
+
+Claude Code agents running inside wg worktrees call the `EnterWorktree` tool, creating a SECOND worktree in `.claude/worktrees/` and switching the session's working directory away from the wg worktree. This is the primary cause of "lost worktree" incidents.
+
+**Evidence — every affected agent called EnterWorktree:**
+- `agent-16720`: `EnterWorktree(name="nex-delegate")` → `.claude/worktrees/nex-delegate`
+- `agent-16729`: `EnterWorktree(name="nex-config-bundles-recovery")` → `.claude/worktrees/nex-config-bundles-recovery`
+- `agent-16733`: `EnterWorktree(name="agent-16733")` → `.claude/worktrees/agent-16733`
+- `agent-16759`: `EnterWorktree(name="chat-endpoint-flag")` → `.claude/worktrees/chat-endpoint-flag`
+- `agent-16763`: `EnterWorktree(name="fix-compaction-output-budget")` → `.claude/worktrees/fix-compaction-output-budget`
+
+**Why Claude Code allows this:** The `EnterWorktree` tool's "Must not already be in a worktree" check only verifies Claude Code's own session state (was `EnterWorktree` already called in this session?), NOT whether the CWD is inside an existing git worktree. So agents already inside wg worktrees pass this check.
+
+**Consequence chain:**
+1. Agent starts in `.wg-worktrees/agent-XXXXX` on branch `wg/agent-XXXXX/task-id`
+2. Agent calls `EnterWorktree` → session CWD moves to `.claude/worktrees/<name>` on branch `worktree-<name>`
+3. All subsequent file edits and commits go to the wrong branch in the wrong directory
+4. When agent exits, wg wrapper script checks for commits on `wg/agent-XXXXX/task-id` → finds none
+5. Merge-back does nothing, work is stranded in `.claude/worktrees/<name>`
+6. wg's cleanup removes the now-empty wg worktree directory (partially — `target/` may remain)
+
+### Mechanism 2: Git Metadata Name Collision (agent-16733 only)
+
+When the Claude Code worktree has the **same directory basename** as the wg worktree, git's internal worktree metadata gets corrupted.
+
+**How git names worktree metadata:**
+Git uses the worktree directory's basename as the key in `.git/worktrees/`:
+- wg's `.wg-worktrees/agent-16733` → `.git/worktrees/agent-16733`
+- Claude Code's `.claude/worktrees/agent-16733` → `.git/worktrees/agent-16733`
+
+In testing, git auto-deduplicates by appending numbers (e.g., `agent-167331`). However, in agent-16733's case, the current state shows:
+```
+$ cat .git/worktrees/agent-16733/gitdir
+/home/erik/workgraph/.claude/worktrees/agent-16733/.git
+```
+
+This points to Claude Code's worktree, meaning the wg worktree's `.git` pointer was severed. This may have happened through a sequence involving cleanup/prune between the two worktree creations.
+
+## Additional Contributing Factors
+
+### git gc --auto runs git worktree prune
+
+Agent-16760 (which did NOT call `EnterWorktree`) showed `git gc --auto` running during its session:
+```
+Auto packing the repository in background for optimum performance.
+```
+
+Since git 2.15+, `git gc` includes `git worktree prune`, which removes entries whose directories no longer exist. If another agent's wg worktree directory was temporarily removed during cleanup, a concurrent `git gc --auto` would prune its metadata.
+
+### wg's own cleanup calls git worktree prune
+
+Every `remove_worktree` call in `src/commands/spawn/worktree.rs:107-111` runs `git worktree prune` after removing a specific worktree. This global prune affects ALL stale worktree entries, not just the one being removed. If any worktree directory was temporarily missing during this window, its entry would be pruned.
+
+### Wrapper script cleanup is force-remove
+
+The wg wrapper script (`src/commands/spawn/execution.rs:1251-1255`) runs:
+```bash
+git -C "$WG_PROJECT_ROOT" worktree remove --force "$WG_WORKTREE_PATH" 2>/dev/null
+```
+This is expected cleanup, but if the agent already moved to a Claude Code worktree, it removes the (now-abandoned) wg worktree. The `target/` directory may survive because it was recreated by cargo after the worktree content was removed.
+
+## Verify Architecture Question
+
+Per user message #3, the `--verify` system compounds the worktree problem:
+1. Worktree gets damaged/abandoned
+2. Verify runs `cargo test` in the broken worktree
+3. Test fails (of course — the code isn't there)
+4. 3 failures = circuit breaker auto-fails the task
+
+Additionally, concurrent agents running `cargo test` cause resource contention (ports, temp files, lockfiles), leading to spurious verify failures even without worktree issues.
+
+**Recommendation:** If verification is retained, it should run AFTER merge-back into the main branch, not in the agent's worktree. This avoids both the broken-worktree and resource-contention issues. However, the FLIP/eval pipeline may be a better fit for quality gating, since it operates post-merge and is designed for multi-agent workflows.
+
+## Proposed Fix Approaches
+
+### Fix 1: Prevent EnterWorktree in wg worktrees (Best — address root cause)
+
+Set an environment variable when spawning agents in wg worktrees:
+```rust
+cmd.env("CLAUDE_CODE_DISABLE_WORKTREES", "1");
+```
+
+Or add to the agent's CLAUDE.md / prompt instructions:
+```
+CRITICAL: Do NOT use EnterWorktree. You are already in an isolated worktree managed by workgraph.
+```
+
+The env var approach is more reliable since it prevents the tool at the system level rather than relying on the LLM following instructions.
+
+**Check if Claude Code respects any env var to disable `EnterWorktree`.** If not, the prompt-based approach is the fallback.
+
+### Fix 2: Prompt injection (immediate mitigation)
+
+Add to the wg agent prompt template (in `src/commands/spawn/execution.rs` or the executor context injection):
+```
+NEVER use the EnterWorktree or ExitWorktree tools. Your working directory is already isolated by workgraph. Using EnterWorktree will cause you to lose your worktree and all uncommitted work.
+```
+
+This is less reliable than Fix 1 but can be deployed immediately.
+
+### Fix 3: Detect and prevent at wg level
+
+Before merge-back, check if the agent changed CWD away from the wg worktree:
+```bash
+if [ "$(pwd)" != "$WG_WORKTREE_PATH" ]; then
+    echo "[wrapper] WARNING: Agent changed CWD from worktree, attempting recovery"
+    cd "$WG_WORKTREE_PATH"
+fi
+```
+
+Also, verify the `.git` file still exists in the worktree before running merge-back. If it's gone, log the issue and skip the merge (the work was done elsewhere).
+
+### Fix 4: Remove global git worktree prune
+
+Change `remove_worktree` in `src/commands/spawn/worktree.rs` and `src/commands/service/worktree.rs` to NOT run `git worktree prune` after each removal. Instead, let git's natural gc handle pruning. This prevents collateral damage to other agents' worktree entries during cleanup.
+
+The current code (spawn/worktree.rs:107-111):
+```rust
+// Prune stale worktree entries
+let _ = Command::new("git")
+    .args(["worktree", "prune"])
+    .current_dir(project_root)
+    .output();
+```
+
+Should be removed or made conditional on a "no other agents alive" check.
+
+## Affected Code Paths
+
+| File | Line | Issue |
+|------|------|-------|
+| `src/commands/spawn/worktree.rs:107-111` | `git worktree prune` after every removal | Global prune can damage other agents' worktrees |
+| `src/commands/spawn/worktree.rs:38` | Pre-create cleanup calls `remove_worktree` | Triggers global prune |
+| `src/commands/service/worktree.rs:208-218` | `git worktree prune` in service cleanup | Same issue |
+| `src/commands/service/worktree.rs:672-678` | `git worktree prune` in orphan cleanup | Same issue |
+| `src/commands/spawn/execution.rs:1251-1255` | Wrapper script force-removes worktree | Expected, but races with Claude Code |
+| `src/commands/cleanup.rs:839-858` | Nightly cleanup runs `git worktree prune` | Acceptable (not during active agents) |
+
+## Recommended Fix Priority
+
+1. **Immediate:** Add "never use EnterWorktree" to agent prompt (Fix 2) — deploy in minutes
+2. **Short-term:** Set env var to disable Claude Code worktrees (Fix 1) — if supported
+3. **Short-term:** Remove global `git worktree prune` from per-agent cleanup (Fix 4)
+4. **Medium-term:** Add worktree integrity check to wrapper script (Fix 3)
+5. **Consider:** Move verify to post-merge or replace with FLIP/eval


### PR DESCRIPTION
## Summary
- Fixes two native-executor context-pressure bugs that caused qwen3-coder-30b agents to repeatedly hit API 400 context-too-long errors on a 32k-window model and fail mid-task.
- `ContextBudget::check_pressure` now accounts for system prompt + tool definitions + completion reservation, so compaction thresholds reflect actual API budget usage instead of only message-content length.
- New `hard_emergency_compact` variant drops ALL tool results (not just >200 bytes) in older turns, strips thinking blocks, truncates long text; called from the streaming-400 retry path with `keep_recent=2` and a halved `max_tokens` reservation.

## Why this matters

On a 32k model with ~5k system prompt + ~5k tool definitions + 8k completion reservation, the actual budget available for messages is ~14k — but the old `check_pressure` compared message-only tokens against a `compact_threshold` of 65% of the full 32k (~21k). Compaction therefore fired at effective ~100% capacity, i.e. too late to help. When the streaming call got a 400, the old `emergency_compact` only touched tool results >200 bytes in older messages, kept the last 5 verbatim, and retried with the full 8k `max_tokens` still reserved — so retries hit the same 400.

Repeated incidents today on our `fix-worktree-fundamental` task:
```
[openai-client] Capping max_tokens from 16384 to 8192 (context_window=32768)
...
[native-agent] Context too long error — attempting emergency compaction and retry
[native-agent] Emergency compacted: 151 → 151 messages
[native-agent] Retry after compaction also failed — clean exit
Error: API error 400: Requested token count exceeds the model's maximum context length of 32768 tokens. You requested a total of 32777 tokens: 24585 tokens from the input messages and 8192 tokens for the completion.
```

Note the 9-token overage while max_tokens still reserves 8192 — halving max_tokens alone would have resolved this retry.

## Changes
- `src/executor/native/resume.rs`
  - `ContextBudget` gains `overhead_tokens: usize` + `.with_overhead()` builder
  - New `effective_tokens()` = `estimate_tokens() + overhead_tokens`
  - `check_pressure` and `warning_message` use `effective_tokens`
  - New `hard_emergency_compact(messages, keep_recent)` associated fn
  - New `estimate_agent_overhead(system_prompt, tool_defs, max_tokens, chars_per_token)` helper
- `src/executor/native/agent.rs`
  - `AgentLoop::with_tool_support` computes overhead at init via `estimate_agent_overhead` and attaches via `.with_overhead()`
  - Streaming-400 retry path calls `hard_emergency_compact(messages, 2)` (was soft variant with 5) AND uses `retry_max_tokens = max(max_tokens/2, 1024)` (was full max_tokens)
  - Both compaction log lines now report token deltas (not the misleading message count)

## Test coverage
5 new unit tests in `resume.rs`:
- `test_check_pressure_accounts_for_overhead` — budget with 10k overhead on 32k window triggers compaction at lower message-token counts than the overhead-less baseline
- `test_effective_tokens_sums_messages_and_overhead`
- `test_hard_emergency_compact_reduces_more_than_soft` — on a workload with 8 older 1KB tool-result messages + 3 recent, hard compact reduces tokens strictly more than soft compact
- `test_hard_emergency_compact_strips_thinking_and_truncates_text`
- `test_estimate_agent_overhead_accounts_for_all_sources`

Full native executor suite: **254/254 passing** (`cargo test --lib executor::native`).

## Test plan
- [x] `cargo build` clean
- [x] `cargo build --release` clean
- [x] `cargo test --lib executor::native` green (254/254)
- [ ] End-to-end: run a real native+qwen3 task against a local sglang lambda01 endpoint in a fresh `.workgraph/` environment and verify proactive compaction fires at the right threshold (and that any 400 retries actually succeed now)

The E2E verification is being set up in a separate clean workgraph environment as a follow-up to this PR — the local `.workgraph/` in this repo is too noisy to use for a controlled test.