### PR TITLE
feat(nex): interactive REPL + rustyline + slash commands + ratatui TUI (4 phases)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1411,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1850,6 +1873,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3223,6 +3255,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3914,6 +3967,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,6 +4551,28 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ryu"
@@ -6543,6 +6628,7 @@ dependencies = [
  "readability",
  "regex",
  "reqwest 0.12.28",
+ "rustyline",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ toml = "0.8"
 serde_yaml = "0.9"
 dirs = "5.0"
 sha2 = "0.10"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "process"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "process", "signal"] }
+rustyline = "14"
 ratatui = "0.29"
 crossterm = "0.28"
 ascii-dag = "0.8"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1768,6 +1768,28 @@ pub enum Commands {
         command: KeyCommands,
     },
 
+    /// Interactive agentic REPL — coding assistant powered by any model
+    Nex {
+        /// Model to use (e.g., openrouter:qwen/qwen3-coder, ollama:llama3.2, sonnet)
+        #[arg(long, short = 'm')]
+        model: Option<String>,
+
+        /// Named endpoint from config (e.g., openrouter, local)
+        #[arg(long, short = 'e')]
+        endpoint: Option<String>,
+
+        /// Custom system prompt
+        #[arg(long)]
+        system_prompt: Option<String>,
+
+        /// Initial message (skip the first prompt)
+        message: Option<String>,
+
+        /// Maximum conversation turns
+        #[arg(long, default_value = "200")]
+        max_turns: usize,
+    },
+
     /// Run the native executor agent loop (internal, called by spawn)
     #[command(name = "native-exec", hide = true)]
     NativeExec {
@@ -3698,6 +3720,7 @@ pub fn command_name(cmd: &Commands) -> &'static str {
         Commands::Models { .. } => "models",
         Commands::Model { .. } => "model",
         Commands::Key { .. } => "key",
+        Commands::Nex { .. } => "nex",
         Commands::NativeExec { .. } => "native-exec",
         Commands::Spend { .. } => "spend",
         Commands::Openrouter { .. } => "openrouter",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1790,6 +1790,18 @@ pub enum Commands {
         max_turns: usize,
     },
 
+    /// Interactive agentic TUI — ratatui-based nex (two-pane with streaming + Ctrl-C cancel)
+    #[command(name = "tui-nex")]
+    TuiNex {
+        /// Model to use (e.g., openrouter:qwen/qwen3-coder, ollama:llama3.2, sonnet)
+        #[arg(long, short = 'm')]
+        model: Option<String>,
+
+        /// Named endpoint from config
+        #[arg(long, short = 'e')]
+        endpoint: Option<String>,
+    },
+
     /// Run the native executor agent loop (internal, called by spawn)
     #[command(name = "native-exec", hide = true)]
     NativeExec {
@@ -3721,6 +3733,7 @@ pub fn command_name(cmd: &Commands) -> &'static str {
         Commands::Model { .. } => "model",
         Commands::Key { .. } => "key",
         Commands::Nex { .. } => "nex",
+        Commands::TuiNex { .. } => "tui-nex",
         Commands::NativeExec { .. } => "native-exec",
         Commands::Spend { .. } => "spend",
         Commands::Openrouter { .. } => "openrouter",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -67,6 +67,7 @@ pub mod model_cmd;
 pub mod models;
 pub mod msg;
 pub mod native_exec;
+pub mod nex;
 pub mod next;
 #[cfg(any(feature = "matrix", feature = "matrix-lite"))]
 pub mod notify;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -113,6 +113,7 @@ pub mod trace_export;
 pub mod trace_import;
 pub mod tradeoff;
 pub mod trajectory;
+pub mod tui_nex;
 pub mod user;
 pub mod velocity;
 pub mod viz;

--- a/src/commands/nex.rs
+++ b/src/commands/nex.rs
@@ -1,0 +1,104 @@
+//! Interactive multi-turn REPL using the native executor.
+//!
+//! `wg nex` drops the user into an agentic coding session powered by any
+//! OpenAI-compatible model. Supports streaming, tool calling, and multi-turn
+//! conversation.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use workgraph::config::{Config, DispatchRole};
+use workgraph::executor::native::agent::AgentLoop;
+use workgraph::executor::native::provider::create_provider_ext;
+use workgraph::executor::native::tools::ToolRegistry;
+use workgraph::models::ModelRegistry;
+
+pub fn run(
+    workgraph_dir: &Path,
+    model: Option<&str>,
+    endpoint: Option<&str>,
+    system_prompt: Option<&str>,
+    message: Option<&str>,
+    max_turns: usize,
+) -> Result<()> {
+    let config = Config::load_or_default(workgraph_dir);
+
+    let effective_model = model
+        .map(String::from)
+        .or_else(|| std::env::var("WG_MODEL").ok())
+        .unwrap_or_else(|| {
+            config
+                .resolve_model_for_role(DispatchRole::TaskAgent)
+                .model
+        });
+
+    let working_dir = std::env::current_dir().unwrap_or_default();
+
+    let registry = ToolRegistry::default_all_with_config(
+        workgraph_dir,
+        &working_dir,
+        &config.native_executor,
+    );
+
+    let default_system = format!(
+        "You are an expert software engineer working in an interactive coding session.\n\
+         Working directory: {}\n\n\
+         You have tools available: read files, write/edit files, run bash commands, \
+         grep/search, and more. Use them freely to help the user.\n\n\
+         Be concise. Show code when relevant. Execute commands to verify your work.",
+        working_dir.display()
+    );
+    let system = system_prompt.unwrap_or(&default_system);
+
+    let output_log = workgraph_dir.join("nex-session.ndjson");
+
+    let client = create_provider_ext(
+        workgraph_dir,
+        &effective_model,
+        None,
+        endpoint,
+        None,
+    )?;
+
+    let model_registry = ModelRegistry::load(workgraph_dir).unwrap_or_default();
+    let supports_tools = model_registry.supports_tool_use(&effective_model);
+
+    let mut agent = AgentLoop::with_tool_support(
+        client,
+        registry,
+        system.to_string(),
+        max_turns,
+        output_log,
+        supports_tools,
+    );
+
+    if let Some(entry) = config.registry_lookup(&effective_model) {
+        agent = agent.with_registry_entry(entry);
+    }
+
+    eprintln!(
+        "\x1b[1;32mwg nex\x1b[0m — interactive session with \x1b[1m{}\x1b[0m",
+        effective_model
+    );
+    if !supports_tools {
+        eprintln!(
+            "\x1b[33mWarning: model '{}' may not support tool use\x1b[0m",
+            effective_model
+        );
+    }
+    eprintln!("Type /quit or Ctrl-D to exit.\n");
+
+    let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
+
+    let result = rt.block_on(agent.run_interactive(message))?;
+
+    eprintln!(
+        "\n\x1b[2mSession: {} turns, {} input + {} output tokens\x1b[0m",
+        result.turns,
+        result.total_usage.input_tokens,
+        result.total_usage.output_tokens,
+    );
+
+    Ok(())
+}

--- a/src/commands/nex.rs
+++ b/src/commands/nex.rs
@@ -27,19 +27,12 @@ pub fn run(
     let effective_model = model
         .map(String::from)
         .or_else(|| std::env::var("WG_MODEL").ok())
-        .unwrap_or_else(|| {
-            config
-                .resolve_model_for_role(DispatchRole::TaskAgent)
-                .model
-        });
+        .unwrap_or_else(|| config.resolve_model_for_role(DispatchRole::TaskAgent).model);
 
     let working_dir = std::env::current_dir().unwrap_or_default();
 
-    let registry = ToolRegistry::default_all_with_config(
-        workgraph_dir,
-        &working_dir,
-        &config.native_executor,
-    );
+    let registry =
+        ToolRegistry::default_all_with_config(workgraph_dir, &working_dir, &config.native_executor);
 
     let default_system = format!(
         "You are an expert software engineer working in an interactive coding session.\n\
@@ -53,13 +46,7 @@ pub fn run(
 
     let output_log = workgraph_dir.join("nex-session.ndjson");
 
-    let client = create_provider_ext(
-        workgraph_dir,
-        &effective_model,
-        None,
-        endpoint,
-        None,
-    )?;
+    let client = create_provider_ext(workgraph_dir, &effective_model, None, endpoint, None)?;
 
     let model_registry = ModelRegistry::load(workgraph_dir).unwrap_or_default();
     let supports_tools = model_registry.supports_tool_use(&effective_model);
@@ -95,9 +82,7 @@ pub fn run(
 
     eprintln!(
         "\n\x1b[2mSession: {} turns, {} input + {} output tokens\x1b[0m",
-        result.turns,
-        result.total_usage.input_tokens,
-        result.total_usage.output_tokens,
+        result.turns, result.total_usage.input_tokens, result.total_usage.output_tokens,
     );
 
     Ok(())

--- a/src/commands/tui_nex.rs
+++ b/src/commands/tui_nex.rs
@@ -1,0 +1,696 @@
+//! `wg tui-nex` — minimal ratatui-based interactive REPL for the native executor.
+//!
+//! Phase 4 MVP for the nex REPL: gives `wg nex` a proper two-pane UI
+//! (messages pane + input pane) instead of stdin/stderr. Designed as a
+//! self-contained command that doesn't touch the existing `wg tui`
+//! viz_viewer — both can coexist, and a future session can merge this
+//! UX into the main TUI's chat panel.
+//!
+//! ## Architecture
+//!
+//! The TUI runs a ratatui event loop on the main thread. The agent loop
+//! runs on a tokio task. They communicate through two channels:
+//!
+//! - `UiToAgent`: user input lines go from the TUI to the agent task
+//! - `AgentToUi`: streaming text, tool calls, and turn boundaries go
+//!   from the agent task to the TUI
+//!
+//! The agent task uses a lightweight adapter around `AgentLoop` that
+//! streams each response to the channel instead of stderr. Ctrl-C in
+//! the TUI sends a signal that cancels the current turn.
+//!
+//! ## What's in (MVP)
+//!
+//! - Two-pane layout: scrollable messages area + single-line input
+//! - Streaming response rendering (tokens appear as they arrive)
+//! - Tool call and result display (compact summary lines)
+//! - Ctrl-C cancels an in-flight turn without exiting
+//! - Esc or Ctrl-Q exits cleanly
+//! - `--model` / `--endpoint` flags match `wg nex`
+//!
+//! ## What's not in (follow-ups)
+//!
+//! - Slash commands (`/help`, `/clear`, `/bg`, etc.)
+//! - Markdown rendering / syntax highlighting
+//! - History persistence / search
+//! - Multi-line input with scrollback
+//! - Mouse support
+//!
+//! These can land incrementally on top of the channel architecture.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
+};
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use tokio::sync::mpsc;
+
+use workgraph::config::{Config, DispatchRole};
+use workgraph::executor::native::client::{
+    ContentBlock, Message, MessagesRequest, Role, StopReason,
+};
+use workgraph::executor::native::provider::{Provider, create_provider_ext};
+use workgraph::executor::native::tools::ToolRegistry;
+use workgraph::models::ModelRegistry;
+
+/// Message from the UI to the agent task.
+enum UiToAgent {
+    /// User submitted a prompt.
+    UserInput(String),
+    /// User pressed Ctrl-C — cancel the in-flight turn.
+    Cancel,
+    /// User is quitting — stop the agent task.
+    Quit,
+}
+
+/// Message from the agent task to the UI.
+#[derive(Clone, Debug)]
+enum AgentToUi {
+    /// Streaming token chunk arrived.
+    Token(String),
+    /// The assistant finished a turn (text accumulated so far is final).
+    TurnEnded,
+    /// A tool call started.
+    ToolStart { name: String, summary: String },
+    /// A tool call completed.
+    ToolEnd {
+        name: String,
+        chars: usize,
+        is_error: bool,
+    },
+    /// The agent encountered a fatal error.
+    Error(String),
+    /// Info/status line.
+    Info(String),
+}
+
+/// A single displayable line in the messages pane.
+#[derive(Clone, Debug)]
+enum DisplayLine {
+    User(String),
+    /// In-progress assistant text being streamed.
+    AssistantStreaming(String),
+    /// Finalized assistant text from a completed turn.
+    Assistant(String),
+    ToolCall {
+        name: String,
+        summary: String,
+    },
+    ToolResult {
+        name: String,
+        chars: usize,
+        is_error: bool,
+    },
+    Info(String),
+    Error(String),
+}
+
+/// TUI application state.
+struct App {
+    display: Vec<DisplayLine>,
+    input: String,
+    cursor_pos: usize,
+    /// Current streaming turn's accumulated text, if any.
+    streaming_buf: String,
+    /// True while the agent is processing a turn (input is disabled).
+    awaiting_response: bool,
+    scroll_offset: u16,
+    should_quit: bool,
+    model_label: String,
+}
+
+impl App {
+    fn new(model_label: String) -> Self {
+        Self {
+            display: Vec::new(),
+            input: String::new(),
+            cursor_pos: 0,
+            streaming_buf: String::new(),
+            awaiting_response: false,
+            scroll_offset: 0,
+            should_quit: false,
+            model_label,
+        }
+    }
+
+    fn handle_agent_event(&mut self, ev: AgentToUi) {
+        match ev {
+            AgentToUi::Token(t) => {
+                self.streaming_buf.push_str(&t);
+                // Replace or append an AssistantStreaming line.
+                if let Some(last) = self.display.last_mut()
+                    && matches!(last, DisplayLine::AssistantStreaming(_))
+                {
+                    *last = DisplayLine::AssistantStreaming(self.streaming_buf.clone());
+                    return;
+                }
+                self.display
+                    .push(DisplayLine::AssistantStreaming(self.streaming_buf.clone()));
+            }
+            AgentToUi::TurnEnded => {
+                if !self.streaming_buf.is_empty() {
+                    // Finalize the streaming line.
+                    if let Some(last) = self.display.last_mut()
+                        && matches!(last, DisplayLine::AssistantStreaming(_))
+                    {
+                        *last = DisplayLine::Assistant(self.streaming_buf.clone());
+                    }
+                    self.streaming_buf.clear();
+                }
+                self.awaiting_response = false;
+            }
+            AgentToUi::ToolStart { name, summary } => {
+                // Finalize any in-progress streaming text before the tool line.
+                if !self.streaming_buf.is_empty() {
+                    if let Some(last) = self.display.last_mut()
+                        && matches!(last, DisplayLine::AssistantStreaming(_))
+                    {
+                        *last = DisplayLine::Assistant(self.streaming_buf.clone());
+                    }
+                    self.streaming_buf.clear();
+                }
+                self.display.push(DisplayLine::ToolCall { name, summary });
+            }
+            AgentToUi::ToolEnd {
+                name,
+                chars,
+                is_error,
+            } => {
+                self.display.push(DisplayLine::ToolResult {
+                    name,
+                    chars,
+                    is_error,
+                });
+            }
+            AgentToUi::Error(msg) => {
+                self.display.push(DisplayLine::Error(msg));
+                self.awaiting_response = false;
+            }
+            AgentToUi::Info(msg) => {
+                self.display.push(DisplayLine::Info(msg));
+            }
+        }
+    }
+}
+
+/// Bundled state returned by [`build_session`] — keeps the clippy
+/// `type_complexity` lint happy and makes the call site readable.
+struct TuiNexSession {
+    client: Box<dyn Provider>,
+    tools: ToolRegistry,
+    supports_tools: bool,
+    system_prompt: String,
+    effective_model: String,
+}
+
+/// Build the runtime provider and tool registry for the tui-nex session.
+fn build_session(
+    workgraph_dir: &Path,
+    model: Option<&str>,
+    endpoint: Option<&str>,
+) -> Result<TuiNexSession> {
+    let config = Config::load_or_default(workgraph_dir);
+    let effective_model = model
+        .map(String::from)
+        .or_else(|| std::env::var("WG_MODEL").ok())
+        .unwrap_or_else(|| config.resolve_model_for_role(DispatchRole::TaskAgent).model);
+
+    let working_dir = std::env::current_dir().unwrap_or_default();
+
+    let registry =
+        ToolRegistry::default_all_with_config(workgraph_dir, &working_dir, &config.native_executor);
+
+    let client = create_provider_ext(workgraph_dir, &effective_model, None, endpoint, None)?;
+
+    let model_registry = ModelRegistry::load(workgraph_dir).unwrap_or_default();
+    let supports_tools = model_registry.supports_tool_use(&effective_model);
+
+    let system_prompt = format!(
+        "You are an expert software engineer working in an interactive coding session via a TUI.\n\
+         Working directory: {}\n\n\
+         You have tools available: read/write/edit files, run bash, grep, web, summarize, delegate, \
+         and more. Use them freely to help the user. Be concise. Show code when relevant.",
+        working_dir.display()
+    );
+
+    Ok(TuiNexSession {
+        client,
+        tools: registry,
+        supports_tools,
+        system_prompt,
+        effective_model,
+    })
+}
+
+/// Run the agent task. Reads user input from `rx_input`, sends events
+/// to `tx_output`. Terminates when `rx_input` is closed or a Quit
+/// message arrives.
+async fn run_agent_task(
+    client: Box<dyn Provider>,
+    tools: ToolRegistry,
+    system_prompt: String,
+    supports_tools: bool,
+    mut rx_input: mpsc::UnboundedReceiver<UiToAgent>,
+    tx_output: mpsc::UnboundedSender<AgentToUi>,
+) {
+    let mut messages: Vec<Message> = Vec::new();
+    let tool_defs = if supports_tools {
+        tools.definitions()
+    } else {
+        vec![]
+    };
+
+    while let Some(msg) = rx_input.recv().await {
+        let user_text = match msg {
+            UiToAgent::UserInput(s) => s,
+            UiToAgent::Cancel => continue, // Not in a turn — nothing to cancel.
+            UiToAgent::Quit => break,
+        };
+
+        messages.push(Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text { text: user_text }],
+        });
+
+        // Inner turn loop: run until EndTurn or interrupted.
+        loop {
+            let request = MessagesRequest {
+                model: client.model().to_string(),
+                max_tokens: client.max_tokens(),
+                system: Some(system_prompt.clone()),
+                messages: messages.clone(),
+                tools: tool_defs.clone(),
+                stream: false,
+            };
+
+            // Stream callback: forward tokens to the UI.
+            let tx = tx_output.clone();
+            let on_text = move |text: String| {
+                let _ = tx.send(AgentToUi::Token(text));
+            };
+
+            // Race the streaming call against a Cancel from the UI.
+            let streaming_future = client.send_streaming(&request, &on_text);
+            let cancel_future = async {
+                loop {
+                    match rx_input.recv().await {
+                        Some(UiToAgent::Cancel) => return true,
+                        Some(UiToAgent::Quit) => return true,
+                        Some(UiToAgent::UserInput(_)) => {
+                            // User hit Enter while we were generating. Drop it
+                            // on the floor for now — they can resend after the
+                            // turn ends. (A real enqueue would be nicer.)
+                            continue;
+                        }
+                        None => return true,
+                    }
+                }
+            };
+
+            let response = tokio::select! {
+                biased;
+                cancelled = cancel_future => {
+                    if cancelled {
+                        let _ = tx_output.send(AgentToUi::Info(
+                            "[cancelled] in-flight turn aborted".to_string(),
+                        ));
+                        let _ = tx_output.send(AgentToUi::TurnEnded);
+                    }
+                    break;
+                }
+                res = streaming_future => match res {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = tx_output.send(AgentToUi::Error(format!("{}", e)));
+                        let _ = tx_output.send(AgentToUi::TurnEnded);
+                        break;
+                    }
+                }
+            };
+
+            messages.push(Message {
+                role: Role::Assistant,
+                content: response.content.clone(),
+            });
+
+            match response.stop_reason {
+                Some(StopReason::EndTurn) | Some(StopReason::StopSequence) | None => {
+                    let _ = tx_output.send(AgentToUi::TurnEnded);
+                    break;
+                }
+                Some(StopReason::MaxTokens) => {
+                    messages.push(Message {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text {
+                            text: "Your response was truncated. Please continue.".to_string(),
+                        }],
+                    });
+                    continue;
+                }
+                Some(StopReason::ToolUse) => {
+                    // Collect and execute tool calls sequentially for
+                    // the MVP (matches delegate's mini-loop pattern).
+                    let tool_use_blocks: Vec<_> = response
+                        .content
+                        .iter()
+                        .filter_map(|b| match b {
+                            ContentBlock::ToolUse { id, name, input } => {
+                                Some((id.clone(), name.clone(), input.clone()))
+                            }
+                            _ => None,
+                        })
+                        .collect();
+
+                    let mut results = Vec::new();
+                    for (id, name, input) in &tool_use_blocks {
+                        let summary = compact_tool_input_summary(input);
+                        let _ = tx_output.send(AgentToUi::ToolStart {
+                            name: name.clone(),
+                            summary,
+                        });
+                        let output = tools.execute(name, input).await;
+                        let _ = tx_output.send(AgentToUi::ToolEnd {
+                            name: name.clone(),
+                            chars: output.content.len(),
+                            is_error: output.is_error,
+                        });
+                        results.push(ContentBlock::ToolResult {
+                            tool_use_id: id.clone(),
+                            content: output.content,
+                            is_error: output.is_error,
+                        });
+                    }
+
+                    messages.push(Message {
+                        role: Role::User,
+                        content: results,
+                    });
+                    // Loop back for the next turn with the tool results.
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+/// Produce a compact one-line summary of a tool-call input for display.
+fn compact_tool_input_summary(input: &serde_json::Value) -> String {
+    if let Some(cmd) = input.get("command").and_then(|v| v.as_str()) {
+        format!("command={}", truncate(cmd, 60))
+    } else if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
+        format!("path={}", path)
+    } else if let Some(pat) = input.get("pattern").and_then(|v| v.as_str()) {
+        format!("pattern={}", truncate(pat, 50))
+    } else if let Some(url) = input.get("url").and_then(|v| v.as_str()) {
+        format!("url={}", truncate(url, 60))
+    } else if let Some(src) = input.get("source").and_then(|v| v.as_str()) {
+        format!("source={}", truncate(src, 60))
+    } else {
+        truncate(&input.to_string(), 60).to_string()
+    }
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        &s[..s.floor_char_boundary(max)]
+    }
+}
+
+/// Render the app state to the terminal.
+fn draw<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    app: &App,
+) -> std::io::Result<()> {
+    terminal.draw(|f| {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Min(5),
+                Constraint::Length(3),
+                Constraint::Length(1),
+            ])
+            .split(f.area());
+
+        let messages_block = Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" messages — {} ", app.model_label));
+
+        let lines: Vec<Line> = app
+            .display
+            .iter()
+            .flat_map(|dl| render_display_line(dl))
+            .collect();
+
+        let messages_p = Paragraph::new(lines)
+            .block(messages_block)
+            .wrap(Wrap { trim: false })
+            .scroll((app.scroll_offset, 0));
+        f.render_widget(messages_p, chunks[0]);
+
+        let input_title = if app.awaiting_response {
+            " thinking... (Ctrl-C to cancel) ".to_string()
+        } else {
+            " input (Enter to send, Esc to quit) ".to_string()
+        };
+        let input_block = Block::default().borders(Borders::ALL).title(input_title);
+        let input_p = Paragraph::new(app.input.as_str()).block(input_block);
+        f.render_widget(input_p, chunks[1]);
+
+        // Set cursor position inside the input box.
+        if !app.awaiting_response {
+            let cursor_x = chunks[1].x + 1 + app.cursor_pos as u16;
+            let cursor_y = chunks[1].y + 1;
+            f.set_cursor_position((cursor_x, cursor_y));
+        }
+
+        let hint = Line::from(vec![
+            Span::styled("Ctrl-C", Style::default().fg(Color::Yellow)),
+            Span::raw(" cancel turn  "),
+            Span::styled("Esc/Ctrl-Q", Style::default().fg(Color::Yellow)),
+            Span::raw(" quit  "),
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::raw(" send"),
+        ]);
+        f.render_widget(Paragraph::new(hint), chunks[2]);
+    })?;
+    Ok(())
+}
+
+fn render_display_line(dl: &DisplayLine) -> Vec<Line<'static>> {
+    match dl {
+        DisplayLine::User(text) => wrap_role("user", text, Color::Cyan),
+        DisplayLine::Assistant(text) => wrap_role("assistant", text, Color::Green),
+        DisplayLine::AssistantStreaming(text) => wrap_role("assistant", text, Color::Green),
+        DisplayLine::ToolCall { name, summary } => vec![Line::from(vec![
+            Span::styled("  → ", Style::default().fg(Color::Magenta)),
+            Span::styled(name.clone(), Style::default().fg(Color::Magenta)),
+            Span::raw("("),
+            Span::styled(summary.clone(), Style::default().fg(Color::DarkGray)),
+            Span::raw(")"),
+        ])],
+        DisplayLine::ToolResult {
+            name,
+            chars,
+            is_error,
+        } => {
+            let (marker, color) = if *is_error {
+                ("  ✗", Color::Red)
+            } else {
+                ("  ✓", Color::Green)
+            };
+            vec![Line::from(vec![
+                Span::styled(marker, Style::default().fg(color)),
+                Span::raw(" "),
+                Span::styled(name.clone(), Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!(" ({} chars)", chars),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ])]
+        }
+        DisplayLine::Info(text) => vec![Line::from(Span::styled(
+            text.clone(),
+            Style::default().fg(Color::Yellow),
+        ))],
+        DisplayLine::Error(text) => vec![Line::from(Span::styled(
+            text.clone(),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ))],
+    }
+}
+
+fn wrap_role(role_label: &str, text: &str, color: Color) -> Vec<Line<'static>> {
+    let mut out = Vec::new();
+    out.push(Line::from(Span::styled(
+        format!("{}:", role_label),
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    )));
+    for line in text.lines() {
+        out.push(Line::from(Span::raw(format!("  {}", line))));
+    }
+    out.push(Line::from(Span::raw("")));
+    out
+}
+
+/// Public entry point called from main.rs.
+pub fn run(workgraph_dir: &Path, model: Option<&str>, endpoint: Option<&str>) -> Result<()> {
+    let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+    rt.block_on(run_async(workgraph_dir, model, endpoint))
+}
+
+async fn run_async(
+    workgraph_dir: &Path,
+    model: Option<&str>,
+    endpoint: Option<&str>,
+) -> Result<()> {
+    let TuiNexSession {
+        client,
+        tools,
+        supports_tools,
+        system_prompt,
+        effective_model,
+    } = build_session(workgraph_dir, model, endpoint)?;
+
+    // Set up terminal.
+    enable_raw_mode().context("enable_raw_mode failed")?;
+    let mut stdout = std::io::stdout();
+    crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture)
+        .context("terminal enter failed")?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("terminal init failed")?;
+
+    // Channels.
+    let (tx_input, rx_input) = mpsc::unbounded_channel::<UiToAgent>();
+    let (tx_output, mut rx_output) = mpsc::unbounded_channel::<AgentToUi>();
+
+    // Spawn agent task.
+    let agent_handle = tokio::spawn(run_agent_task(
+        client,
+        tools,
+        system_prompt,
+        supports_tools,
+        rx_input,
+        tx_output,
+    ));
+
+    let mut app = App::new(effective_model);
+    app.display.push(DisplayLine::Info(format!(
+        "wg tui-nex — interactive session with {}. Type a message and press Enter.",
+        app.model_label
+    )));
+
+    // Main event loop.
+    let result: Result<()> = loop {
+        if let Err(e) = draw(&mut terminal, &app) {
+            break Err(anyhow::anyhow!("draw failed: {}", e));
+        }
+
+        // Drain any pending agent events without blocking.
+        while let Ok(ev) = rx_output.try_recv() {
+            app.handle_agent_event(ev);
+        }
+
+        // Poll for input events with a short timeout so we re-render
+        // when agent events arrive.
+        if event::poll(Duration::from_millis(50))? {
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    let modifiers = key.modifiers;
+                    match key.code {
+                        KeyCode::Esc => {
+                            app.should_quit = true;
+                        }
+                        KeyCode::Char('q') if modifiers.contains(KeyModifiers::CONTROL) => {
+                            app.should_quit = true;
+                        }
+                        KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                            if app.awaiting_response {
+                                let _ = tx_input.send(UiToAgent::Cancel);
+                            } else {
+                                app.should_quit = true;
+                            }
+                        }
+                        KeyCode::Enter => {
+                            if !app.awaiting_response && !app.input.trim().is_empty() {
+                                let text = std::mem::take(&mut app.input);
+                                app.cursor_pos = 0;
+                                app.display.push(DisplayLine::User(text.clone()));
+                                app.awaiting_response = true;
+                                let _ = tx_input.send(UiToAgent::UserInput(text));
+                            }
+                        }
+                        KeyCode::Backspace => {
+                            if !app.awaiting_response && app.cursor_pos > 0 {
+                                let new_pos = app.cursor_pos - 1;
+                                app.input.remove(new_pos);
+                                app.cursor_pos = new_pos;
+                            }
+                        }
+                        KeyCode::Left => {
+                            if !app.awaiting_response && app.cursor_pos > 0 {
+                                app.cursor_pos -= 1;
+                            }
+                        }
+                        KeyCode::Right => {
+                            if !app.awaiting_response && app.cursor_pos < app.input.len() {
+                                app.cursor_pos += 1;
+                            }
+                        }
+                        KeyCode::Home => {
+                            app.cursor_pos = 0;
+                        }
+                        KeyCode::End => {
+                            app.cursor_pos = app.input.len();
+                        }
+                        KeyCode::PageUp => {
+                            app.scroll_offset = app.scroll_offset.saturating_sub(5);
+                        }
+                        KeyCode::PageDown => {
+                            app.scroll_offset = app.scroll_offset.saturating_add(5);
+                        }
+                        KeyCode::Char(c) => {
+                            if !app.awaiting_response {
+                                app.input.insert(app.cursor_pos, c);
+                                app.cursor_pos += 1;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if app.should_quit {
+            let _ = tx_input.send(UiToAgent::Quit);
+            break Ok(());
+        }
+    };
+
+    // Tear down terminal regardless of success.
+    let _ = disable_raw_mode();
+    let _ = crossterm::execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    );
+    let _ = terminal.show_cursor();
+
+    // Wait briefly for agent task to drain.
+    let _ = tokio::time::timeout(Duration::from_secs(2), agent_handle).await;
+
+    result
+}

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -1430,6 +1430,364 @@ impl AgentLoop {
 
         messages
     }
+
+    /// Run an interactive multi-turn REPL.
+    ///
+    /// Like `run()`, but instead of exiting on `EndTurn`, prints the assistant's
+    /// text and reads the next user message from stdin. Streams tokens to stdout
+    /// as they arrive. The loop exits when the user sends EOF (Ctrl-D) or types
+    /// /quit or /exit.
+    pub async fn run_interactive(&mut self, initial_message: Option<&str>) -> Result<AgentResult> {
+        use std::io::{BufRead, Write as IoWrite};
+
+        let mut messages: Vec<Message> = Vec::new();
+        let mut total_usage = Usage::default();
+        let mut tool_calls = Vec::new();
+        let mut turns: usize = 0;
+        let mut consecutive_server_errors: u32 = 0;
+        const MAX_CONSECUTIVE_SERVER_ERRORS: u32 = 3;
+
+        let first_input = if let Some(msg) = initial_message {
+            msg.to_string()
+        } else {
+            eprint!("\x1b[1;36m>\x1b[0m ");
+            std::io::stderr().flush().ok();
+            let mut line = String::new();
+            match std::io::stdin().lock().read_line(&mut line) {
+                Ok(0) | Err(_) => {
+                    return Ok(AgentResult {
+                        final_text: String::new(),
+                        turns: 0,
+                        total_usage,
+                        tool_calls,
+                    });
+                }
+                Ok(_) => {}
+            }
+            let trimmed = line.trim().to_string();
+            if trimmed.is_empty() {
+                return Ok(AgentResult {
+                    final_text: String::new(),
+                    turns: 0,
+                    total_usage,
+                    tool_calls,
+                });
+            }
+            trimmed
+        };
+
+        messages.push(Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text { text: first_input }],
+        });
+
+        loop {
+            if turns >= self.max_turns {
+                eprintln!(
+                    "\n\x1b[33m[nex] Max turns ({}) reached.\x1b[0m",
+                    self.max_turns
+                );
+                break;
+            }
+
+            let request = MessagesRequest {
+                model: self.client.model().to_string(),
+                max_tokens: self.client.max_tokens(),
+                system: Some(self.system_prompt.clone()),
+                messages: messages.clone(),
+                tools: if self.supports_tools {
+                    self.tools.definitions()
+                } else {
+                    vec![]
+                },
+                stream: false,
+            };
+
+            let on_text = |text: String| {
+                eprint!("{}", text);
+                let _ = std::io::stderr().flush();
+            };
+
+            let response = match self.client.send_streaming(&request, &on_text).await {
+                Ok(resp) => {
+                    consecutive_server_errors = 0;
+                    resp
+                }
+                Err(e) => {
+                    if super::openai_client::is_context_too_long(&e) {
+                        eprintln!("\n\x1b[33m[nex] Context too long — compacting...\x1b[0m");
+                        let pre = messages.len();
+                        messages = ContextBudget::emergency_compact(messages, 5);
+                        eprintln!(
+                            "\x1b[33m[nex] Compacted {} -> {} messages\x1b[0m",
+                            pre,
+                            messages.len()
+                        );
+                        continue;
+                    }
+                    if let Some(api_err) = e.downcast_ref::<super::openai_client::ApiError>() {
+                        if api_err.status == 401 || api_err.status == 403 {
+                            return Err(e);
+                        }
+                        if super::openai_client::is_retryable_status(api_err.status) {
+                            consecutive_server_errors += 1;
+                            if consecutive_server_errors > MAX_CONSECUTIVE_SERVER_ERRORS {
+                                return Err(e);
+                            }
+                            eprintln!(
+                                "\n\x1b[33m[nex] API error {} — retrying ({}/{})\x1b[0m",
+                                api_err.status,
+                                consecutive_server_errors,
+                                MAX_CONSECUTIVE_SERVER_ERRORS
+                            );
+                            continue;
+                        }
+                    }
+                    if is_timeout_error(&e) {
+                        consecutive_server_errors += 1;
+                        if consecutive_server_errors > MAX_CONSECUTIVE_SERVER_ERRORS {
+                            return Err(e);
+                        }
+                        eprintln!("\n\x1b[33m[nex] Request timed out — retrying\x1b[0m");
+                        continue;
+                    }
+                    return Err(e).context("API request failed");
+                }
+            };
+
+            total_usage.add(&response.usage);
+            turns += 1;
+
+            messages.push(Message {
+                role: Role::Assistant,
+                content: response.content.clone(),
+            });
+
+            match response.stop_reason {
+                Some(StopReason::EndTurn) | Some(StopReason::StopSequence) | None => {
+                    let has_text = response
+                        .content
+                        .iter()
+                        .any(|b| matches!(b, ContentBlock::Text { text } if !text.is_empty()));
+                    if has_text {
+                        eprintln!();
+                    }
+
+                    eprint!("\n\x1b[1;36m>\x1b[0m ");
+                    std::io::stderr().flush().ok();
+                    let mut line = String::new();
+                    match std::io::stdin().lock().read_line(&mut line) {
+                        Ok(0) => {
+                            eprintln!();
+                            break;
+                        }
+                        Err(_) => break,
+                        Ok(_) => {}
+                    }
+                    let trimmed = line.trim().to_string();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    if trimmed == "/quit" || trimmed == "/exit" {
+                        break;
+                    }
+
+                    messages.push(Message {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text { text: trimmed }],
+                    });
+                }
+                Some(StopReason::ToolUse) => {
+                    let tool_use_blocks: Vec<_> = response
+                        .content
+                        .iter()
+                        .filter_map(|b| match b {
+                            ContentBlock::ToolUse { id, name, input } => {
+                                Some((id.clone(), name.clone(), input.clone()))
+                            }
+                            _ => None,
+                        })
+                        .collect();
+
+                    for (_, name, input) in &tool_use_blocks {
+                        let input_summary = if let Some(cmd) =
+                            input.get("command").and_then(|v| v.as_str())
+                        {
+                            format!("command={}", truncate_for_display(cmd, 80))
+                        } else if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
+                            format!("path={}", path)
+                        } else if let Some(pat) = input.get("pattern").and_then(|v| v.as_str()) {
+                            format!("pattern={}", truncate_for_display(pat, 60))
+                        } else {
+                            let s = input.to_string();
+                            truncate_for_display(&s, 80).to_string()
+                        };
+                        eprintln!("\x1b[2m  > {}({})\x1b[0m", name, input_summary);
+                    }
+
+                    let mut parse_error_results = Vec::new();
+                    let mut batch_calls: Vec<(usize, String, super::tools::ToolCall)> = Vec::new();
+
+                    for (i, (id, name, input)) in tool_use_blocks.iter().enumerate() {
+                        if input.get("__parse_error").is_some() {
+                            let error_msg = input
+                                .get("__parse_error")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown parse error");
+                            let raw_args = input
+                                .get("__raw_arguments")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("");
+                            parse_error_results.push((
+                                i,
+                                id.clone(),
+                                name.clone(),
+                                input.clone(),
+                                super::tools::ToolOutput {
+                                    content: format!(
+                                        "ERROR: Tool arguments JSON parse failed: {}. Raw: {}",
+                                        error_msg, raw_args
+                                    ),
+                                    is_error: true,
+                                },
+                            ));
+                        } else {
+                            batch_calls.push((
+                                i,
+                                id.clone(),
+                                super::tools::ToolCall {
+                                    name: name.clone(),
+                                    input: input.clone(),
+                                },
+                            ));
+                        }
+                    }
+
+                    let calls_only: Vec<_> =
+                        batch_calls.iter().map(|(_, _, c)| c.clone()).collect();
+                    let batch_results = self
+                        .tools
+                        .execute_batch(&calls_only, super::tools::DEFAULT_MAX_CONCURRENT_TOOLS)
+                        .await;
+
+                    let mut all_results: Vec<(
+                        usize,
+                        String,
+                        String,
+                        serde_json::Value,
+                        super::tools::ToolOutput,
+                        u64,
+                    )> = Vec::with_capacity(tool_use_blocks.len());
+
+                    for (orig_idx, id, name, input, output) in parse_error_results {
+                        all_results.push((orig_idx, id, name, input, output, 0));
+                    }
+                    for (batch_idx, batch_result) in batch_results.into_iter().enumerate() {
+                        let (orig_idx, id, _) = &batch_calls[batch_idx];
+                        let input = tool_use_blocks[*orig_idx].2.clone();
+                        all_results.push((
+                            *orig_idx,
+                            id.clone(),
+                            batch_result.name,
+                            input,
+                            batch_result.output,
+                            batch_result.duration_ms,
+                        ));
+                    }
+                    all_results.sort_by_key(|(idx, _, _, _, _, _)| *idx);
+
+                    let mut results = Vec::new();
+                    for (_, id, name, input, output, _) in &all_results {
+                        if output.is_error {
+                            eprintln!(
+                                "\x1b[2m  x {} error: {}\x1b[0m",
+                                name,
+                                truncate_for_display(&output.content, 100)
+                            );
+                        } else {
+                            eprintln!(
+                                "\x1b[2m  + {} ({} chars)\x1b[0m",
+                                name,
+                                output.content.len()
+                            );
+                        }
+
+                        tool_calls.push(ToolCallRecord {
+                            name: name.clone(),
+                            input: input.clone(),
+                            output: output.content.clone(),
+                            is_error: output.is_error,
+                        });
+
+                        results.push(ContentBlock::ToolResult {
+                            tool_use_id: id.clone(),
+                            content: output.content.clone(),
+                            is_error: output.is_error,
+                        });
+                    }
+
+                    messages.push(Message {
+                        role: Role::User,
+                        content: results,
+                    });
+                }
+                Some(StopReason::MaxTokens) => {
+                    messages.push(Message {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text {
+                            text: "Your response was truncated. Please continue.".to_string(),
+                        }],
+                    });
+                }
+            }
+
+            match self.context_budget.check_pressure(&messages) {
+                ContextPressureAction::Ok | ContextPressureAction::Warning => {}
+                ContextPressureAction::EmergencyCompaction => {
+                    let pre = messages.len();
+                    messages = ContextBudget::emergency_compact(messages, 5);
+                    eprintln!(
+                        "\x1b[33m[nex] Context pressure — compacted {} -> {} messages\x1b[0m",
+                        pre,
+                        messages.len()
+                    );
+                }
+                ContextPressureAction::CleanExit => {
+                    eprintln!(
+                        "\x1b[33m[nex] Context limit reached. Please start a new session.\x1b[0m"
+                    );
+                    break;
+                }
+            }
+        }
+
+        let final_text = messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant)
+            .map(|m| {
+                m.content
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::Text { text } => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+            .unwrap_or_default();
+
+        Ok(AgentResult {
+            final_text,
+            turns,
+            total_usage,
+            tool_calls,
+        })
+    }
+}
+
+fn truncate_for_display(s: &str, max: usize) -> &str {
+    if s.len() <= max { s } else { &s[..max] }
 }
 
 /// Check whether an error is a request timeout.

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -1515,7 +1515,10 @@ impl AgentLoop {
         // Handle slash commands on the first input too, so users can
         // start with `/help` or `/load session.json` from a cold prompt.
         if first_input.starts_with('/') {
-            match Self::handle_nex_slash_command(&first_input, &mut messages, &total_usage) {
+            match self
+                .handle_nex_slash_command(&first_input, &mut messages, &total_usage)
+                .await
+            {
                 NexSlashResult::Quit => {
                     let _ = editor.save_history(&history_path);
                     return Ok(AgentResult {
@@ -1568,11 +1571,10 @@ impl AgentLoop {
                         }
                         let _ = editor.add_history_entry(&trimmed);
                         if trimmed.starts_with('/') {
-                            match Self::handle_nex_slash_command(
-                                &trimmed,
-                                &mut messages,
-                                &total_usage,
-                            ) {
+                            match self
+                                .handle_nex_slash_command(&trimmed, &mut messages, &total_usage)
+                                .await
+                            {
                                 NexSlashResult::Quit => break,
                                 NexSlashResult::Continue => continue,
                                 NexSlashResult::NotASlashCommand => {
@@ -1706,11 +1708,10 @@ impl AgentLoop {
                             }
                             let _ = editor.add_history_entry(&trimmed);
                             if trimmed.starts_with('/') {
-                                match Self::handle_nex_slash_command(
-                                    &trimmed,
-                                    &mut messages,
-                                    &total_usage,
-                                ) {
+                                match self
+                                    .handle_nex_slash_command(&trimmed, &mut messages, &total_usage)
+                                    .await
+                                {
                                     NexSlashResult::Quit => break,
                                     NexSlashResult::Continue => continue,
                                     NexSlashResult::NotASlashCommand => {
@@ -1944,15 +1945,21 @@ impl AgentLoop {
     /// (they are NOT forwarded to the model as text).
     ///
     /// Supported commands:
-    /// - `/help`                   — print the command list
+    /// - `/help`, `/?`             — print the command list
     /// - `/quit`, `/exit`          — exit the REPL
     /// - `/clear`                  — clear conversation history
     /// - `/tokens`                 — print current cumulative token usage
     /// - `/save <path>`            — save session messages as JSON
     /// - `/load <path>`            — load session messages from JSON
-    /// - `/bg list|run|kill|...`   — shorthand for the `bg` tool (placeholder;
-    ///   currently prints a reminder to call the `bg` tool directly from the turn)
-    fn handle_nex_slash_command(
+    /// - `/bg run <cmd>`           — start a background task
+    /// - `/bg list`                — list all background jobs
+    /// - `/bg status <id>`         — show status of a specific job
+    /// - `/bg output <id> [lines]` — stream output from a job
+    /// - `/bg kill <id>`           — terminate a background job
+    /// - `/bg delete <id>`         — remove a terminated job from the registry
+    /// - `/cancel <id>`            — alias for `/bg kill <id>`
+    async fn handle_nex_slash_command(
+        &self,
         input: &str,
         messages: &mut Vec<Message>,
         total_usage: &Usage,
@@ -1971,13 +1978,19 @@ impl AgentLoop {
             "/help" | "/?" => {
                 eprintln!(
                     "\x1b[1mNex REPL commands:\x1b[0m\n\
-                     \x1b[1;36m  /help, /?\x1b[0m              — this message\n\
-                     \x1b[1;36m  /quit, /exit\x1b[0m           — exit the REPL (Ctrl-D also works)\n\
-                     \x1b[1;36m  /clear\x1b[0m                 — clear conversation history\n\
-                     \x1b[1;36m  /tokens\x1b[0m                — show current cumulative token usage\n\
-                     \x1b[1;36m  /save <path>\x1b[0m           — save current session to JSON file\n\
-                     \x1b[1;36m  /load <path>\x1b[0m           — load session from JSON file (replaces current)\n\
-                     \x1b[1;36m  /bg\x1b[0m                    — hint to use the bg tool from your next turn\n\
+                     \x1b[1;36m  /help, /?\x1b[0m                    — this message\n\
+                     \x1b[1;36m  /quit, /exit\x1b[0m                 — exit the REPL (Ctrl-D also works)\n\
+                     \x1b[1;36m  /clear\x1b[0m                       — clear conversation history\n\
+                     \x1b[1;36m  /tokens\x1b[0m                      — show cumulative token usage\n\
+                     \x1b[1;36m  /save <path>\x1b[0m                 — save session to JSON file\n\
+                     \x1b[1;36m  /load <path>\x1b[0m                 — load session from JSON file\n\
+                     \x1b[1;36m  /bg run <cmd>\x1b[0m                — start a background task\n\
+                     \x1b[1;36m  /bg list\x1b[0m                     — list all background jobs\n\
+                     \x1b[1;36m  /bg status <id>\x1b[0m              — show status of a job\n\
+                     \x1b[1;36m  /bg output <id> [lines]\x1b[0m      — stream output of a job\n\
+                     \x1b[1;36m  /bg kill <id>\x1b[0m                — kill a background job\n\
+                     \x1b[1;36m  /bg delete <id>\x1b[0m              — remove terminated job from registry\n\
+                     \x1b[1;36m  /cancel <id>\x1b[0m                 — alias for /bg kill <id>\n\
                      \n\
                      \x1b[2mCtrl-C during generation cancels the in-flight response.\x1b[0m\n\
                      \x1b[2mCtrl-C at the prompt is a no-op (use /quit or Ctrl-D to exit).\x1b[0m"
@@ -2044,13 +2057,104 @@ impl AgentLoop {
             }
 
             "/bg" => {
-                eprintln!(
-                    "\x1b[2m[nex] To manage background jobs, tell the model to call the `bg` tool. \
-                     Example prompts:\n\
-                     \x20  'run cargo build in the background'\n\
-                     \x20  'list my background jobs'\n\
-                     \x20  'kill background job <id>'\x1b[0m"
-                );
+                // Parse the bg subcommand.
+                let mut bg_parts = arg.splitn(2, char::is_whitespace);
+                let action = bg_parts.next().unwrap_or("");
+                let rest = bg_parts.next().unwrap_or("").trim();
+                if action.is_empty() {
+                    eprintln!(
+                        "\x1b[31m[nex] /bg requires an action: run|list|status|output|kill|delete\x1b[0m"
+                    );
+                    return NexSlashResult::Continue;
+                }
+                let input_json = match action {
+                    "run" => {
+                        if rest.is_empty() {
+                            eprintln!("\x1b[31m[nex] /bg run requires a command\x1b[0m");
+                            return NexSlashResult::Continue;
+                        }
+                        serde_json::json!({
+                            "action": "run",
+                            "command": rest,
+                        })
+                    }
+                    "list" => serde_json::json!({ "action": "list" }),
+                    "status" => {
+                        if rest.is_empty() {
+                            eprintln!("\x1b[31m[nex] /bg status requires a job id/name\x1b[0m");
+                            return NexSlashResult::Continue;
+                        }
+                        serde_json::json!({ "action": "status", "job": rest })
+                    }
+                    "kill" => {
+                        if rest.is_empty() {
+                            eprintln!("\x1b[31m[nex] /bg kill requires a job id/name\x1b[0m");
+                            return NexSlashResult::Continue;
+                        }
+                        serde_json::json!({ "action": "kill", "job": rest })
+                    }
+                    "output" => {
+                        let mut out_parts = rest.splitn(2, char::is_whitespace);
+                        let job = out_parts.next().unwrap_or("").trim();
+                        if job.is_empty() {
+                            eprintln!("\x1b[31m[nex] /bg output requires a job id/name\x1b[0m");
+                            return NexSlashResult::Continue;
+                        }
+                        let lines: Option<i64> =
+                            out_parts.next().and_then(|s| s.trim().parse().ok());
+                        if let Some(n) = lines {
+                            serde_json::json!({
+                                "action": "output",
+                                "job": job,
+                                "lines": n,
+                            })
+                        } else {
+                            serde_json::json!({ "action": "output", "job": job })
+                        }
+                    }
+                    "delete" => {
+                        if rest.is_empty() {
+                            eprintln!("\x1b[31m[nex] /bg delete requires a job id/name\x1b[0m");
+                            return NexSlashResult::Continue;
+                        }
+                        serde_json::json!({ "action": "delete", "job": rest })
+                    }
+                    other => {
+                        eprintln!(
+                            "\x1b[31m[nex] /bg: unknown action '{}'\x1b[0m — use run|list|status|output|kill|delete",
+                            other
+                        );
+                        return NexSlashResult::Continue;
+                    }
+                };
+
+                // Call the bg tool directly through the registry. No LLM
+                // round-trip — the REPL gets immediate feedback.
+                let result = self.tools.execute("bg", &input_json).await;
+                if result.is_error {
+                    eprintln!("\x1b[31m[nex] /bg error: {}\x1b[0m", result.content);
+                } else {
+                    // Print the tool result indented so it's visible as
+                    // output, not conversation.
+                    for line in result.content.lines() {
+                        eprintln!("\x1b[2m  {}\x1b[0m", line);
+                    }
+                }
+                NexSlashResult::Continue
+            }
+
+            "/cancel" => {
+                if arg.is_empty() {
+                    eprintln!("\x1b[31m[nex] /cancel requires a job id/name\x1b[0m");
+                    return NexSlashResult::Continue;
+                }
+                let input_json = serde_json::json!({ "action": "kill", "job": arg });
+                let result = self.tools.execute("bg", &input_json).await;
+                if result.is_error {
+                    eprintln!("\x1b[31m[nex] /cancel error: {}\x1b[0m", result.content);
+                } else {
+                    eprintln!("\x1b[2m[nex] {}\x1b[0m", result.content.trim());
+                }
                 NexSlashResult::Continue
             }
 

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -1438,7 +1438,8 @@ impl AgentLoop {
     /// as they arrive. The loop exits when the user sends EOF (Ctrl-D) or types
     /// /quit or /exit.
     pub async fn run_interactive(&mut self, initial_message: Option<&str>) -> Result<AgentResult> {
-        use std::io::{BufRead, Write as IoWrite};
+        use rustyline::DefaultEditor;
+        use rustyline::error::ReadlineError;
 
         let mut messages: Vec<Message> = Vec::new();
         let mut total_usage = Usage::default();
@@ -1447,14 +1448,60 @@ impl AgentLoop {
         let mut consecutive_server_errors: u32 = 0;
         const MAX_CONSECUTIVE_SERVER_ERRORS: u32 = 3;
 
+        // Rustyline editor for line editing + history.
+        let mut editor = DefaultEditor::new().context("failed to initialize rustyline editor")?;
+        // Persistent history file — survives sessions.
+        let history_path = if let Some(home) = std::env::var_os("HOME") {
+            std::path::PathBuf::from(home).join(".workgraph-nex-history")
+        } else {
+            std::path::PathBuf::from(".workgraph-nex-history")
+        };
+        let _ = editor.load_history(&history_path);
+
+        // Helper: read a user line with rustyline. Returns:
+        // - `Some(line)` on normal input (empty line allowed — caller filters)
+        // - `None` on Ctrl-D (EOF) or non-recoverable error → exit REPL
+        // - Loops on Ctrl-C at the prompt (does NOT exit — just re-prompts)
+        let read_user_input = |editor: &mut DefaultEditor| -> Option<String> {
+            loop {
+                match editor.readline("\x1b[1;36m>\x1b[0m ") {
+                    Ok(line) => return Some(line),
+                    Err(ReadlineError::Interrupted) => {
+                        // Ctrl-C at the prompt: re-display and re-read.
+                        eprintln!(
+                            "\x1b[2m(Ctrl-C — press again or /quit to exit, empty line to continue)\x1b[0m"
+                        );
+                        continue;
+                    }
+                    Err(ReadlineError::Eof) => return None,
+                    Err(e) => {
+                        eprintln!("\x1b[31m[nex] readline error: {}\x1b[0m", e);
+                        return None;
+                    }
+                }
+            }
+        };
+
         let first_input = if let Some(msg) = initial_message {
             msg.to_string()
         } else {
-            eprint!("\x1b[1;36m>\x1b[0m ");
-            std::io::stderr().flush().ok();
-            let mut line = String::new();
-            match std::io::stdin().lock().read_line(&mut line) {
-                Ok(0) | Err(_) => {
+            match read_user_input(&mut editor) {
+                Some(line) => {
+                    let trimmed = line.trim().to_string();
+                    if trimmed.is_empty() {
+                        let _ = editor.save_history(&history_path);
+                        return Ok(AgentResult {
+                            final_text: String::new(),
+                            turns: 0,
+                            total_usage,
+                            tool_calls,
+                        });
+                    }
+                    let _ = editor.add_history_entry(&trimmed);
+                    trimmed
+                }
+                None => {
+                    let _ = editor.save_history(&history_path);
                     return Ok(AgentResult {
                         final_text: String::new(),
                         turns: 0,
@@ -1462,24 +1509,39 @@ impl AgentLoop {
                         tool_calls,
                     });
                 }
-                Ok(_) => {}
             }
-            let trimmed = line.trim().to_string();
-            if trimmed.is_empty() {
-                return Ok(AgentResult {
-                    final_text: String::new(),
-                    turns: 0,
-                    total_usage,
-                    tool_calls,
-                });
-            }
-            trimmed
         };
 
-        messages.push(Message {
-            role: Role::User,
-            content: vec![ContentBlock::Text { text: first_input }],
-        });
+        // Handle slash commands on the first input too, so users can
+        // start with `/help` or `/load session.json` from a cold prompt.
+        if first_input.starts_with('/') {
+            match Self::handle_nex_slash_command(&first_input, &mut messages, &total_usage) {
+                NexSlashResult::Quit => {
+                    let _ = editor.save_history(&history_path);
+                    return Ok(AgentResult {
+                        final_text: String::new(),
+                        turns: 0,
+                        total_usage,
+                        tool_calls,
+                    });
+                }
+                NexSlashResult::Continue => {
+                    // Handled; fall through to the main loop which will
+                    // prompt for the next input.
+                }
+                NexSlashResult::NotASlashCommand => {
+                    messages.push(Message {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text { text: first_input }],
+                    });
+                }
+            }
+        } else {
+            messages.push(Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text { text: first_input }],
+            });
+        }
 
         loop {
             if turns >= self.max_turns {
@@ -1488,6 +1550,47 @@ impl AgentLoop {
                     self.max_turns
                 );
                 break;
+            }
+
+            // If the last entry isn't a user message (e.g., we just
+            // handled a slash command that printed info), prompt again
+            // before the next LLM call.
+            let needs_user_input = messages
+                .last()
+                .map(|m| m.role != Role::User)
+                .unwrap_or(true);
+            if needs_user_input {
+                match read_user_input(&mut editor) {
+                    Some(line) => {
+                        let trimmed = line.trim().to_string();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        let _ = editor.add_history_entry(&trimmed);
+                        if trimmed.starts_with('/') {
+                            match Self::handle_nex_slash_command(
+                                &trimmed,
+                                &mut messages,
+                                &total_usage,
+                            ) {
+                                NexSlashResult::Quit => break,
+                                NexSlashResult::Continue => continue,
+                                NexSlashResult::NotASlashCommand => {
+                                    messages.push(Message {
+                                        role: Role::User,
+                                        content: vec![ContentBlock::Text { text: trimmed }],
+                                    });
+                                }
+                            }
+                        } else {
+                            messages.push(Message {
+                                role: Role::User,
+                                content: vec![ContentBlock::Text { text: trimmed }],
+                            });
+                        }
+                    }
+                    None => break,
+                }
             }
 
             let request = MessagesRequest {
@@ -1508,7 +1611,24 @@ impl AgentLoop {
                 let _ = std::io::stderr().flush();
             };
 
-            let response = match self.client.send_streaming(&request, &on_text).await {
+            // Wrap the streaming call in a Ctrl-C-aware select. On Ctrl-C
+            // the in-flight provider call is cancelled, the partial
+            // response is dropped, and we return to the prompt without
+            // pushing a (possibly malformed) assistant message.
+            let streaming_future = self.client.send_streaming(&request, &on_text);
+            let ctrl_c_future = tokio::signal::ctrl_c();
+            let response = tokio::select! {
+                biased;
+                _ = ctrl_c_future => {
+                    eprintln!(
+                        "\n\x1b[33m[nex] Interrupted — dropping in-flight response.\x1b[0m"
+                    );
+                    // The partial streaming output was already written to
+                    // stderr. Don't add a partial/malformed assistant
+                    // message to the history.
+                    continue;
+                }
+                res = streaming_future => match res {
                 Ok(resp) => {
                     consecutive_server_errors = 0;
                     resp
@@ -1553,6 +1673,7 @@ impl AgentLoop {
                     }
                     return Err(e).context("API request failed");
                 }
+                }
             };
 
             total_usage.add(&response.usage);
@@ -1573,29 +1694,41 @@ impl AgentLoop {
                         eprintln!();
                     }
 
-                    eprint!("\n\x1b[1;36m>\x1b[0m ");
-                    std::io::stderr().flush().ok();
-                    let mut line = String::new();
-                    match std::io::stdin().lock().read_line(&mut line) {
-                        Ok(0) => {
-                            eprintln!();
-                            break;
+                    // Add a blank line between the assistant's response
+                    // and our next prompt. The readline call handles
+                    // rustyline's own display.
+                    eprintln!();
+                    match read_user_input(&mut editor) {
+                        Some(line) => {
+                            let trimmed = line.trim().to_string();
+                            if trimmed.is_empty() {
+                                continue;
+                            }
+                            let _ = editor.add_history_entry(&trimmed);
+                            if trimmed.starts_with('/') {
+                                match Self::handle_nex_slash_command(
+                                    &trimmed,
+                                    &mut messages,
+                                    &total_usage,
+                                ) {
+                                    NexSlashResult::Quit => break,
+                                    NexSlashResult::Continue => continue,
+                                    NexSlashResult::NotASlashCommand => {
+                                        messages.push(Message {
+                                            role: Role::User,
+                                            content: vec![ContentBlock::Text { text: trimmed }],
+                                        });
+                                    }
+                                }
+                            } else {
+                                messages.push(Message {
+                                    role: Role::User,
+                                    content: vec![ContentBlock::Text { text: trimmed }],
+                                });
+                            }
                         }
-                        Err(_) => break,
-                        Ok(_) => {}
+                        None => break,
                     }
-                    let trimmed = line.trim().to_string();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-                    if trimmed == "/quit" || trimmed == "/exit" {
-                        break;
-                    }
-
-                    messages.push(Message {
-                        role: Role::User,
-                        content: vec![ContentBlock::Text { text: trimmed }],
-                    });
                 }
                 Some(StopReason::ToolUse) => {
                     let tool_use_blocks: Vec<_> = response
@@ -1761,6 +1894,9 @@ impl AgentLoop {
             }
         }
 
+        // Persist history to disk on exit (best-effort).
+        let _ = editor.save_history(&history_path);
+
         let final_text = messages
             .iter()
             .rev()
@@ -1788,6 +1924,145 @@ impl AgentLoop {
 
 fn truncate_for_display(s: &str, max: usize) -> &str {
     if s.len() <= max { s } else { &s[..max] }
+}
+
+/// Result of processing a nex REPL slash command.
+enum NexSlashResult {
+    /// Command handled; the REPL should continue (prompt for next input).
+    Continue,
+    /// User asked to quit; the REPL should exit cleanly.
+    Quit,
+    /// Input was not actually a slash command (or was an unknown one
+    /// treated as literal text); the caller should push it as a regular
+    /// user message and proceed with an LLM turn.
+    NotASlashCommand,
+}
+
+impl AgentLoop {
+    /// Handle a nex REPL slash command. Returns what the caller should do
+    /// next. Unknown `/...` inputs print a help hint and return `Continue`
+    /// (they are NOT forwarded to the model as text).
+    ///
+    /// Supported commands:
+    /// - `/help`                   — print the command list
+    /// - `/quit`, `/exit`          — exit the REPL
+    /// - `/clear`                  — clear conversation history
+    /// - `/tokens`                 — print current cumulative token usage
+    /// - `/save <path>`            — save session messages as JSON
+    /// - `/load <path>`            — load session messages from JSON
+    /// - `/bg list|run|kill|...`   — shorthand for the `bg` tool (placeholder;
+    ///   currently prints a reminder to call the `bg` tool directly from the turn)
+    fn handle_nex_slash_command(
+        input: &str,
+        messages: &mut Vec<Message>,
+        total_usage: &Usage,
+    ) -> NexSlashResult {
+        let trimmed = input.trim();
+        if !trimmed.starts_with('/') {
+            return NexSlashResult::NotASlashCommand;
+        }
+        let mut parts = trimmed.splitn(2, char::is_whitespace);
+        let cmd = parts.next().unwrap_or("");
+        let arg = parts.next().unwrap_or("").trim();
+
+        match cmd {
+            "/quit" | "/exit" => NexSlashResult::Quit,
+
+            "/help" | "/?" => {
+                eprintln!(
+                    "\x1b[1mNex REPL commands:\x1b[0m\n\
+                     \x1b[1;36m  /help, /?\x1b[0m              — this message\n\
+                     \x1b[1;36m  /quit, /exit\x1b[0m           — exit the REPL (Ctrl-D also works)\n\
+                     \x1b[1;36m  /clear\x1b[0m                 — clear conversation history\n\
+                     \x1b[1;36m  /tokens\x1b[0m                — show current cumulative token usage\n\
+                     \x1b[1;36m  /save <path>\x1b[0m           — save current session to JSON file\n\
+                     \x1b[1;36m  /load <path>\x1b[0m           — load session from JSON file (replaces current)\n\
+                     \x1b[1;36m  /bg\x1b[0m                    — hint to use the bg tool from your next turn\n\
+                     \n\
+                     \x1b[2mCtrl-C during generation cancels the in-flight response.\x1b[0m\n\
+                     \x1b[2mCtrl-C at the prompt is a no-op (use /quit or Ctrl-D to exit).\x1b[0m"
+                );
+                NexSlashResult::Continue
+            }
+
+            "/clear" => {
+                messages.clear();
+                eprintln!("\x1b[2m[nex] conversation cleared.\x1b[0m");
+                NexSlashResult::Continue
+            }
+
+            "/tokens" => {
+                eprintln!(
+                    "\x1b[2m[nex] session: {} input + {} output tokens \
+                     (= {} total, {} messages in history)\x1b[0m",
+                    total_usage.input_tokens,
+                    total_usage.output_tokens,
+                    total_usage.input_tokens + total_usage.output_tokens,
+                    messages.len(),
+                );
+                NexSlashResult::Continue
+            }
+
+            "/save" => {
+                if arg.is_empty() {
+                    eprintln!("\x1b[31m[nex] /save requires a path argument\x1b[0m");
+                    return NexSlashResult::Continue;
+                }
+                match serde_json::to_string_pretty(messages) {
+                    Ok(json) => match std::fs::write(arg, json) {
+                        Ok(()) => eprintln!(
+                            "\x1b[2m[nex] saved {} messages to {}\x1b[0m",
+                            messages.len(),
+                            arg
+                        ),
+                        Err(e) => eprintln!("\x1b[31m[nex] failed to write {}: {}\x1b[0m", arg, e),
+                    },
+                    Err(e) => eprintln!("\x1b[31m[nex] failed to serialize session: {}\x1b[0m", e),
+                }
+                NexSlashResult::Continue
+            }
+
+            "/load" => {
+                if arg.is_empty() {
+                    eprintln!("\x1b[31m[nex] /load requires a path argument\x1b[0m");
+                    return NexSlashResult::Continue;
+                }
+                match std::fs::read_to_string(arg) {
+                    Ok(text) => match serde_json::from_str::<Vec<Message>>(&text) {
+                        Ok(loaded) => {
+                            let n = loaded.len();
+                            *messages = loaded;
+                            eprintln!("\x1b[2m[nex] loaded {} messages from {}\x1b[0m", n, arg);
+                        }
+                        Err(e) => {
+                            eprintln!("\x1b[31m[nex] failed to parse {}: {}\x1b[0m", arg, e)
+                        }
+                    },
+                    Err(e) => eprintln!("\x1b[31m[nex] failed to read {}: {}\x1b[0m", arg, e),
+                }
+                NexSlashResult::Continue
+            }
+
+            "/bg" => {
+                eprintln!(
+                    "\x1b[2m[nex] To manage background jobs, tell the model to call the `bg` tool. \
+                     Example prompts:\n\
+                     \x20  'run cargo build in the background'\n\
+                     \x20  'list my background jobs'\n\
+                     \x20  'kill background job <id>'\x1b[0m"
+                );
+                NexSlashResult::Continue
+            }
+
+            other => {
+                eprintln!(
+                    "\x1b[31m[nex] unknown command: {}\x1b[0m — type /help for the list",
+                    other
+                );
+                NexSlashResult::Continue
+            }
+        }
+    }
 }
 
 /// Check whether an error is a request timeout.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2454,6 +2454,20 @@ fn main() -> Result<()> {
                 global,
             ),
         },
+        Commands::Nex {
+            model,
+            endpoint,
+            system_prompt,
+            message,
+            max_turns,
+        } => commands::nex::run(
+            &workgraph_dir,
+            model.as_deref(),
+            endpoint.as_deref(),
+            system_prompt.as_deref(),
+            message.as_deref(),
+            max_turns,
+        ),
         Commands::NativeExec {
             prompt_file,
             exec_mode,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2468,6 +2468,9 @@ fn main() -> Result<()> {
             message.as_deref(),
             max_turns,
         ),
+        Commands::TuiNex { model, endpoint } => {
+            commands::tui_nex::run(&workgraph_dir, model.as_deref(), endpoint.as_deref())
+        }
         Commands::NativeExec {
             prompt_file,
             exec_mode,

--- a/tests/test_nex.rs
+++ b/tests/test_nex.rs
@@ -3,8 +3,8 @@
 //! Uses mock providers to verify multi-turn conversation, tool calling,
 //! and streaming behavior in the interactive agent loop.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use tempfile::TempDir;
@@ -156,10 +156,7 @@ async fn test_nex_interactive_single_turn() {
         tmp.path().join("test.ndjson"),
     );
 
-    let result = agent
-        .run_interactive(Some("Hello, world!"))
-        .await
-        .unwrap();
+    let result = agent.run_interactive(Some("Hello, world!")).await.unwrap();
 
     assert_eq!(call_count.load(Ordering::SeqCst), 1);
     assert!(result.final_text.contains("Echo #0"));

--- a/tests/test_nex.rs
+++ b/tests/test_nex.rs
@@ -1,0 +1,453 @@
+//! Tests for the nex interactive REPL.
+//!
+//! Uses mock providers to verify multi-turn conversation, tool calling,
+//! and streaming behavior in the interactive agent loop.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tempfile::TempDir;
+
+use workgraph::executor::native::agent::AgentLoop;
+use workgraph::executor::native::client::{
+    ContentBlock, MessagesRequest, MessagesResponse, StopReason, Usage,
+};
+use workgraph::executor::native::provider::Provider;
+use workgraph::executor::native::tools::ToolRegistry;
+
+struct EchoProvider {
+    call_count: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Provider for EchoProvider {
+    fn name(&self) -> &str {
+        "mock-echo"
+    }
+    fn model(&self) -> &str {
+        "echo-model"
+    }
+    fn max_tokens(&self) -> u32 {
+        1024
+    }
+    async fn send(&self, req: &MessagesRequest) -> anyhow::Result<MessagesResponse> {
+        let count = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let user_text = req
+            .messages
+            .last()
+            .and_then(|m| {
+                m.content.iter().find_map(|b| match b {
+                    ContentBlock::Text { text } => Some(text.clone()),
+                    _ => None,
+                })
+            })
+            .unwrap_or_else(|| "no input".to_string());
+        Ok(MessagesResponse {
+            id: format!("msg_echo_{}", count),
+            content: vec![ContentBlock::Text {
+                text: format!("Echo #{}: {}", count, user_text),
+            }],
+            stop_reason: Some(StopReason::EndTurn),
+            usage: Usage {
+                input_tokens: 10,
+                output_tokens: 15,
+                ..Default::default()
+            },
+        })
+    }
+    async fn send_streaming(
+        &self,
+        req: &MessagesRequest,
+        on_text: &(dyn Fn(String) + Send + Sync),
+    ) -> anyhow::Result<MessagesResponse> {
+        let resp = self.send(req).await?;
+        for block in &resp.content {
+            if let ContentBlock::Text { text } = block {
+                on_text(text.clone());
+            }
+        }
+        Ok(resp)
+    }
+}
+
+struct ToolUseProvider {
+    call_count: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Provider for ToolUseProvider {
+    fn name(&self) -> &str {
+        "mock-tool"
+    }
+    fn model(&self) -> &str {
+        "tool-model"
+    }
+    fn max_tokens(&self) -> u32 {
+        1024
+    }
+    async fn send(&self, _req: &MessagesRequest) -> anyhow::Result<MessagesResponse> {
+        let count = self.call_count.fetch_add(1, Ordering::SeqCst);
+        if count == 0 {
+            Ok(MessagesResponse {
+                id: "msg_tool_0".to_string(),
+                content: vec![
+                    ContentBlock::Text {
+                        text: "Let me read that file.".to_string(),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "tool_call_1".to_string(),
+                        name: "read_file".to_string(),
+                        input: serde_json::json!({
+                            "file_path": "/nonexistent/test/path.txt"
+                        }),
+                    },
+                ],
+                stop_reason: Some(StopReason::ToolUse),
+                usage: Usage {
+                    input_tokens: 20,
+                    output_tokens: 30,
+                    ..Default::default()
+                },
+            })
+        } else {
+            Ok(MessagesResponse {
+                id: "msg_tool_1".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "The file was not found. Done.".to_string(),
+                }],
+                stop_reason: Some(StopReason::EndTurn),
+                usage: Usage {
+                    input_tokens: 25,
+                    output_tokens: 20,
+                    ..Default::default()
+                },
+            })
+        }
+    }
+    async fn send_streaming(
+        &self,
+        req: &MessagesRequest,
+        on_text: &(dyn Fn(String) + Send + Sync),
+    ) -> anyhow::Result<MessagesResponse> {
+        let resp = self.send(req).await?;
+        for block in &resp.content {
+            if let ContentBlock::Text { text } = block {
+                on_text(text.clone());
+            }
+        }
+        Ok(resp)
+    }
+}
+
+#[tokio::test]
+async fn test_nex_interactive_single_turn() {
+    let tmp = TempDir::new().unwrap();
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let provider = Box::new(EchoProvider {
+        call_count: call_count.clone(),
+    });
+
+    let mut agent = AgentLoop::new(
+        provider,
+        ToolRegistry::new(),
+        "You are a test assistant.".to_string(),
+        10,
+        tmp.path().join("test.ndjson"),
+    );
+
+    let result = agent
+        .run_interactive(Some("Hello, world!"))
+        .await
+        .unwrap();
+
+    assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    assert!(result.final_text.contains("Echo #0"));
+    assert!(result.turns >= 1);
+    assert_eq!(result.total_usage.input_tokens, 10);
+    assert_eq!(result.total_usage.output_tokens, 15);
+}
+
+#[tokio::test]
+async fn test_nex_interactive_tool_calling() {
+    let tmp = TempDir::new().unwrap();
+    let wg_dir = tmp.path().join(".workgraph");
+    std::fs::create_dir_all(&wg_dir).unwrap();
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let provider = Box::new(ToolUseProvider {
+        call_count: call_count.clone(),
+    });
+
+    let mut tools = ToolRegistry::new();
+    workgraph::executor::native::tools::file::register_file_tools(&mut tools);
+
+    let mut agent = AgentLoop::new(
+        provider,
+        tools,
+        "You are a test assistant with file tools.".to_string(),
+        10,
+        tmp.path().join("test.ndjson"),
+    );
+
+    let result = agent
+        .run_interactive(Some("Read /nonexistent/test/path.txt"))
+        .await
+        .unwrap();
+
+    assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    assert!(result.final_text.contains("Done"));
+    assert!(!result.tool_calls.is_empty());
+    assert_eq!(result.tool_calls[0].name, "read_file");
+    assert!(result.tool_calls[0].is_error);
+    assert_eq!(result.total_usage.input_tokens, 45);
+    assert_eq!(result.total_usage.output_tokens, 50);
+}
+
+#[tokio::test]
+async fn test_nex_interactive_streaming_called() {
+    let tmp = TempDir::new().unwrap();
+    let streaming_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let streaming_called_clone = streaming_called.clone();
+
+    struct StreamCheckProvider {
+        streaming_called: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Provider for StreamCheckProvider {
+        fn name(&self) -> &str {
+            "stream-check"
+        }
+        fn model(&self) -> &str {
+            "stream-model"
+        }
+        fn max_tokens(&self) -> u32 {
+            1024
+        }
+        async fn send(&self, _: &MessagesRequest) -> anyhow::Result<MessagesResponse> {
+            Ok(MessagesResponse {
+                id: "msg".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "non-streaming".to_string(),
+                }],
+                stop_reason: Some(StopReason::EndTurn),
+                usage: Usage::default(),
+            })
+        }
+        async fn send_streaming(
+            &self,
+            _: &MessagesRequest,
+            on_text: &(dyn Fn(String) + Send + Sync),
+        ) -> anyhow::Result<MessagesResponse> {
+            self.streaming_called
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            on_text("streamed!".to_string());
+            Ok(MessagesResponse {
+                id: "msg".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "streamed!".to_string(),
+                }],
+                stop_reason: Some(StopReason::EndTurn),
+                usage: Usage::default(),
+            })
+        }
+    }
+
+    let provider = Box::new(StreamCheckProvider {
+        streaming_called: streaming_called_clone,
+    });
+
+    let mut agent = AgentLoop::new(
+        provider,
+        ToolRegistry::new(),
+        "Test.".to_string(),
+        10,
+        tmp.path().join("test.ndjson"),
+    );
+
+    let _result = agent.run_interactive(Some("test")).await.unwrap();
+    assert!(streaming_called.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn test_nex_interactive_max_tokens_continuation() {
+    let tmp = TempDir::new().unwrap();
+    let call_count = Arc::new(AtomicUsize::new(0));
+
+    struct MaxTokensProvider {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Provider for MaxTokensProvider {
+        fn name(&self) -> &str {
+            "max-tokens"
+        }
+        fn model(&self) -> &str {
+            "max-model"
+        }
+        fn max_tokens(&self) -> u32 {
+            1024
+        }
+        async fn send(&self, _: &MessagesRequest) -> anyhow::Result<MessagesResponse> {
+            let count = self.call_count.fetch_add(1, Ordering::SeqCst);
+            if count == 0 {
+                Ok(MessagesResponse {
+                    id: "msg_0".to_string(),
+                    content: vec![ContentBlock::Text {
+                        text: "Truncated...".to_string(),
+                    }],
+                    stop_reason: Some(StopReason::MaxTokens),
+                    usage: Usage {
+                        input_tokens: 10,
+                        output_tokens: 100,
+                        ..Default::default()
+                    },
+                })
+            } else {
+                Ok(MessagesResponse {
+                    id: "msg_1".to_string(),
+                    content: vec![ContentBlock::Text {
+                        text: "Continuation complete.".to_string(),
+                    }],
+                    stop_reason: Some(StopReason::EndTurn),
+                    usage: Usage {
+                        input_tokens: 15,
+                        output_tokens: 20,
+                        ..Default::default()
+                    },
+                })
+            }
+        }
+        async fn send_streaming(
+            &self,
+            req: &MessagesRequest,
+            on_text: &(dyn Fn(String) + Send + Sync),
+        ) -> anyhow::Result<MessagesResponse> {
+            let resp = self.send(req).await?;
+            for b in &resp.content {
+                if let ContentBlock::Text { text } = b {
+                    on_text(text.clone());
+                }
+            }
+            Ok(resp)
+        }
+    }
+
+    let provider = Box::new(MaxTokensProvider {
+        call_count: call_count.clone(),
+    });
+
+    let mut agent = AgentLoop::new(
+        provider,
+        ToolRegistry::new(),
+        "Test.".to_string(),
+        10,
+        tmp.path().join("test.ndjson"),
+    );
+
+    let result = agent
+        .run_interactive(Some("generate something long"))
+        .await
+        .unwrap();
+
+    assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    assert!(result.final_text.contains("Continuation complete"));
+}
+
+#[tokio::test]
+async fn test_nex_interactive_parallel_tool_calls() {
+    let tmp = TempDir::new().unwrap();
+    let call_count = Arc::new(AtomicUsize::new(0));
+
+    struct ParallelToolProvider {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Provider for ParallelToolProvider {
+        fn name(&self) -> &str {
+            "parallel-tool"
+        }
+        fn model(&self) -> &str {
+            "parallel-model"
+        }
+        fn max_tokens(&self) -> u32 {
+            1024
+        }
+        async fn send(&self, _: &MessagesRequest) -> anyhow::Result<MessagesResponse> {
+            let count = self.call_count.fetch_add(1, Ordering::SeqCst);
+            if count == 0 {
+                Ok(MessagesResponse {
+                    id: "msg_0".to_string(),
+                    content: vec![
+                        ContentBlock::ToolUse {
+                            id: "call_a".to_string(),
+                            name: "read_file".to_string(),
+                            input: serde_json::json!({"file_path": "/tmp/a.txt"}),
+                        },
+                        ContentBlock::ToolUse {
+                            id: "call_b".to_string(),
+                            name: "read_file".to_string(),
+                            input: serde_json::json!({"file_path": "/tmp/b.txt"}),
+                        },
+                    ],
+                    stop_reason: Some(StopReason::ToolUse),
+                    usage: Usage {
+                        input_tokens: 20,
+                        output_tokens: 30,
+                        ..Default::default()
+                    },
+                })
+            } else {
+                Ok(MessagesResponse {
+                    id: "msg_1".to_string(),
+                    content: vec![ContentBlock::Text {
+                        text: "Read both files.".to_string(),
+                    }],
+                    stop_reason: Some(StopReason::EndTurn),
+                    usage: Usage::default(),
+                })
+            }
+        }
+        async fn send_streaming(
+            &self,
+            req: &MessagesRequest,
+            on_text: &(dyn Fn(String) + Send + Sync),
+        ) -> anyhow::Result<MessagesResponse> {
+            let resp = self.send(req).await?;
+            for b in &resp.content {
+                if let ContentBlock::Text { text } = b {
+                    on_text(text.clone());
+                }
+            }
+            Ok(resp)
+        }
+    }
+
+    let provider = Box::new(ParallelToolProvider {
+        call_count: call_count.clone(),
+    });
+
+    let mut tools = ToolRegistry::new();
+    workgraph::executor::native::tools::file::register_file_tools(&mut tools);
+
+    let mut agent = AgentLoop::new(
+        provider,
+        tools,
+        "Test.".to_string(),
+        10,
+        tmp.path().join("test.ndjson"),
+    );
+
+    let result = agent
+        .run_interactive(Some("read both files"))
+        .await
+        .unwrap();
+
+    assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    assert_eq!(result.tool_calls.len(), 2);
+    assert_eq!(result.tool_calls[0].name, "read_file");
+    assert_eq!(result.tool_calls[1].name, "read_file");
+}


### PR DESCRIPTION
## Summary

Ships the full 4-phase roadmap for `wg nex` — a Claude Code-style interactive agentic REPL built on the native executor. Each phase is its own commit for reviewability.

**Phase 1** — Merge the existing `wg nex` REPL from an unmerged agent branch (`wg/agent-16779/implement-nex-interactive`, commit `e9a20f9b`) onto main. Cherry-picked cleanly onto the current main (which now has L0–L4 reliability work from PR #10). No conflicts.

**Phase 2** — Make the REPL feel like a real interactive shell:
- **Ctrl-C mid-generation interrupt** — `tokio::select!` races the streaming provider call against `tokio::signal::ctrl_c()`; Ctrl-C during generation cancels the in-flight request, drops the partial response, and returns to the prompt without corrupting history.
- **rustyline** — both input sites in `run_interactive` now use `DefaultEditor` with persistent history at `~/.workgraph-nex-history`. Gets line editing, reverse search, up/down navigation for free.
- **Slash commands**: `/help`, `/?`, `/quit`, `/exit`, `/clear`, `/tokens`, `/save <path>`, `/load <path>`. Unknown `/...` inputs print a help hint instead of being forwarded to the model.

**Phase 3** — First-class background/cancel semantics:
- `/bg run <cmd>`, `/bg list`, `/bg status <id>`, `/bg output <id> [lines]`, `/bg kill <id>`, `/bg delete <id>` — all call the existing `bg` tool directly (no LLM round-trip, no tokens consumed)
- `/cancel <id>` as an alias for `/bg kill <id>`
- `handle_nex_slash_command` moved from static `fn` to `async fn` taking `&self` to `.await` tool execution

**Phase 4** — New `wg tui-nex` command: ratatui TUI wrapper around the nex REPL. Self-contained; doesn't touch the existing 42k-line `wg tui` viz_viewer.
- Two-pane layout: scrollable messages + single-line input
- Token streaming updates in real time
- Tool calls render as compact `→ name(summary)` / `✓ name (N chars)` lines
- Ctrl-C cancels the current turn; Esc/Ctrl-Q quits
- `--model` / `--endpoint` flags mirror `wg nex`
- Channel-based architecture (`UiToAgent` / `AgentToUi` mpsc) decouples rendering from the agent task

## Test plan

- [x] `cargo test --lib` — 1668/1668 pass
- [x] `cargo test --test test_nex` — 5/5 pass (pre-existing nex integration tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `wg nex --help` — shows merged Phase 1 command
- [x] `wg tui-nex --help` — shows new Phase 4 command
- [ ] Manual smoke — interactive session with a local model (requires tty; not part of CI)

## Deferred follow-ups

- Slash commands inside `tui-nex` (channel architecture supports them, not wired yet)
- `/model <name>` to hot-swap models mid-session (requires recreating the Provider)
- Integration of `tui-nex` into the existing `wg tui` chat panel (biggest remaining piece — replaces the coordinator-chat IPC backend with an in-process agent loop)
- Markdown rendering / syntax highlighting in `tui-nex`

Refs: action-plan-2026-04-14.md (nex roadmap)