### PR TITLE
feat(nex): web search, Chrome emulation, UX, journal, read-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5359381fd414fbdb272c48f2111c16cb0bb3447bfacd59311ff3736da9f6664"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +537,72 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chromiumoxide"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8380ce7721cc895fe8a184c49d615fe755b0c9a3d7986355cee847439fff907f"
+dependencies = [
+ "async-tungstenite",
+ "base64 0.22.1",
+ "cfg-if",
+ "chromiumoxide_cdp",
+ "chromiumoxide_types",
+ "dunce",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+ "which",
+ "winreg 0.52.0",
+]
+
+[[package]]
+name = "chromiumoxide_cdp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadbfb52fa0aeca43626f6c42ca04184b108b786f8e45198dc41a42aedcf2e50"
+dependencies = [
+ "chromiumoxide_pdl",
+ "chromiumoxide_types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_pdl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c197aeb42872c5d4c923e7d8ad46d99a58fd0fec37f6491554ff677a6791d3c9"
+dependencies = [
+ "chromiumoxide_types",
+ "either",
+ "heck 0.4.1",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923486888790528d55ac37ec2f7483ed19eb8ccbb44701878e5856d1ceadf5d8"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -952,6 +1032,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "date_header"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1256,12 @@ checksum = "d81175dab5ec79c30e0576df2ed2c244e1721720c302000bb321b107e82e265c"
 dependencies = [
  "futures",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ed25519"
@@ -1620,6 +1712,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -4262,7 +4360,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -5779,6 +5877,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6202,6 +6318,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "wildmatch"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6568,6 +6696,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6663,6 +6807,7 @@ dependencies = [
  "anyhow",
  "ascii-dag",
  "async-trait",
+ "chromiumoxide",
  "chrono",
  "clap",
  "cron",
@@ -6683,6 +6828,7 @@ dependencies = [
  "lettre",
  "libc",
  "log",
+ "lru",
  "matrix-sdk",
  "notify",
  "notify-debouncer-mini",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +207,15 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -349,6 +379,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +462,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "boring-sys2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6c876a958d17057d9d3a31075bb9609237413a1fe665432782c31ef596eb6b"
+dependencies = [
+ "autocfg",
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
+]
+
+[[package]]
+name = "boring2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4470e96bd94533c2f88c08be95a8e6d2d37a3b497a773b0a46273a376978f00"
+dependencies = [
+ "bitflags 2.11.0",
+ "boring-sys2",
+ "brotli",
+ "flate2",
+ "foreign-types 0.5.0",
+ "libc",
+ "openssl-macros",
+ "zstd",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -504,6 +602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +621,12 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -616,7 +729,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -628,6 +741,17 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -680,6 +804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,9 +848,12 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
+ "brotli",
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -1605,7 +1741,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1613,6 +1770,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1624,12 +1787,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1762,7 +1941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1794,9 +1973,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2013,7 +2194,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2143,6 +2324,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http2"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e23815f8ec982e1452e1d0fda921ec20a9187fb610ad003c90cc5abd65b2c4"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,6 +2412,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2262,11 +2462,29 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+]
+
+[[package]]
+name = "hyper2"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a1bb25e0cbdbe7b21f8ef6c3c4785f147d79e7ded438b5ee2b70e380183294"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http2",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
 ]
 
 [[package]]
@@ -2815,6 +3033,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2841,6 +3069,15 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2883,6 +3120,18 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3416,7 +3665,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "libc",
 ]
 
@@ -3654,7 +3903,7 @@ checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -3722,7 +3971,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4100,6 +4349,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4217,7 +4521,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -4371,7 +4675,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -4385,10 +4688,11 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4396,6 +4700,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4405,6 +4710,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4438,6 +4744,58 @@ checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rquest"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821ab2b3866cc43b553364566edf7387aea98b28b87213d8a889fc2504b3b8b0"
+dependencies = [
+ "antidote",
+ "arc-swap",
+ "async-compression",
+ "base64 0.22.1",
+ "boring2",
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper2",
+ "ipnet",
+ "linked_hash_set",
+ "log",
+ "lru 0.13.0",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "socket2 0.5.10",
+ "sync_wrapper 1.0.2",
+ "system-configuration 0.6.1",
+ "tokio",
+ "tokio-boring2",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "typed-builder",
+ "url",
+ "webpki-root-certs 0.26.11",
+ "windows-registry",
+]
+
+[[package]]
+name = "rquest-util"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e3762f6e3e0d1674a6e74ebcbcb3b8d56c895757fc2cc2aa0d5e62ccfcb21e"
+dependencies = [
+ "rquest",
+ "typed-builder",
 ]
 
 [[package]]
@@ -4630,6 +4988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4671,6 +5035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4692,6 +5057,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5336,9 +5702,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
@@ -5602,6 +5968,17 @@ dependencies = [
  "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-boring2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3866209c48e3d69e709a9d6105d7e2aa34e4374bc5dcaec32e0f8e53a28db14a"
+dependencies = [
+ "boring-sys2",
+ "boring2",
+ "tokio",
 ]
 
 [[package]]
@@ -5892,6 +6269,26 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6312,6 +6709,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.6",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6374,9 +6798,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6403,19 +6827,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.6.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6424,7 +6863,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6433,7 +6881,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6478,7 +6926,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6518,7 +6966,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -6828,7 +7276,7 @@ dependencies = [
  "lettre",
  "libc",
  "log",
- "lru",
+ "lru 0.12.5",
  "matrix-sdk",
  "notify",
  "notify-debouncer-mini",
@@ -6838,6 +7286,8 @@ dependencies = [
  "readability",
  "regex",
  "reqwest 0.12.28",
+ "rquest",
+ "rquest-util",
  "rustyline",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ csv = "1.3"
 cron = "0.12"
 log = "0.4"
 env_logger = "0.11"
+lru = "0.12"
+chromiumoxide = { version = "0.7", features = ["tokio-runtime"], default-features = false }
 
 # Optional Matrix integration (requires sqlite3)
 matrix-sdk = { version = "0.16", features = ["e2e-encryption", "sqlite"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ regex = "1"
 async-trait = "0.1"
 html-escape = "0.2"
 futures-util = "0.3"
-reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }
+reqwest = { version = "0.12", features = ["json", "blocking", "stream", "rustls-tls"], default-features = false }
 glob = "0.3"
 unicode-width = "0.2"
 edtui = "0.9"
@@ -61,6 +61,8 @@ log = "0.4"
 env_logger = "0.11"
 lru = "0.12"
 chromiumoxide = { version = "0.7", features = ["tokio-runtime"], default-features = false }
+rquest = { version = "5", features = ["json", "gzip", "brotli"] }
+rquest-util = "2"
 
 # Optional Matrix integration (requires sqlite3)
 matrix-sdk = { version = "0.16", features = ["e2e-encryption", "sqlite"], optional = true }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1797,10 +1797,19 @@ pub enum Commands {
         #[arg(long, default_value = "200")]
         max_turns: usize,
 
-        /// Verbose console output: show tool-call previews, result sizes,
-        /// compaction diagnostics, and the exit summary. Default is quiet
-        /// (only the prompt, assistant text, and errors). The on-disk
-        /// NDJSON session log is always complete regardless of this flag.
+        /// Chatty mode: echo the full tool output content under each
+        /// tool-call line, exactly as the model sees it (capped at
+        /// 20 lines / 1600 bytes per call). Default shows only a
+        /// one-line summary per call. Useful when actively following
+        /// an agent's actions.
+        #[arg(long, short = 'c')]
+        chatty: bool,
+
+        /// Verbose console output: implies `--chatty` and also emits
+        /// compaction diagnostics, token accounting, and the
+        /// session-log path banner. Useful for debugging the REPL
+        /// itself. The on-disk NDJSON session log is always complete
+        /// regardless of this flag.
         #[arg(long, short = 'v')]
         verbose: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1812,6 +1812,15 @@ pub enum Commands {
         /// regardless of this flag.
         #[arg(long, short = 'v')]
         verbose: bool,
+
+        /// Read-only safety mode: only expose tools that cannot modify
+        /// state (read_file, grep, web_search, web_fetch, etc.). Tools
+        /// like write_file, edit_file, and bash (which can run arbitrary
+        /// commands) are removed from the registry. Use this when you
+        /// want to browse, research, or explore without risk of the
+        /// agent modifying any files.
+        #[arg(long, short = 'r')]
+        read_only: bool,
     },
 
     /// Interactive agentic TUI — ratatui-based nex (two-pane with streaming + Ctrl-C cancel)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1796,6 +1796,13 @@ pub enum Commands {
         /// Maximum conversation turns
         #[arg(long, default_value = "200")]
         max_turns: usize,
+
+        /// Verbose console output: show tool-call previews, result sizes,
+        /// compaction diagnostics, and the exit summary. Default is quiet
+        /// (only the prompt, assistant text, and errors). The on-disk
+        /// NDJSON session log is always complete regardless of this flag.
+        #[arg(long, short = 'v')]
+        verbose: bool,
     },
 
     /// Interactive agentic TUI — ratatui-based nex (two-pane with streaming + Ctrl-C cancel)

--- a/src/commands/nex.rs
+++ b/src/commands/nex.rs
@@ -78,7 +78,8 @@ pub fn run(
         output_log,
         supports_tools,
     )
-    .with_nex_verbose(verbose);
+    .with_nex_verbose(verbose)
+    .with_nex_repl_mode(true);
 
     if let Some(entry) = config.registry_lookup(&effective_model) {
         agent = agent.with_registry_entry(entry);

--- a/src/commands/nex.rs
+++ b/src/commands/nex.rs
@@ -21,6 +21,7 @@ pub fn run(
     system_prompt: Option<&str>,
     message: Option<&str>,
     max_turns: usize,
+    verbose: bool,
 ) -> Result<()> {
     let config = Config::load_or_default(workgraph_dir);
 
@@ -57,10 +58,12 @@ pub fn run(
         let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
         sessions_dir.join(format!("{}.ndjson", stamp))
     };
-    eprintln!(
-        "\x1b[2m[wg nex] session log → {}\x1b[0m",
-        output_log.display()
-    );
+    if verbose {
+        eprintln!(
+            "\x1b[2m[wg nex] session log → {}\x1b[0m",
+            output_log.display()
+        );
+    }
 
     let client = create_provider_ext(workgraph_dir, &effective_model, None, endpoint, None)?;
 
@@ -74,12 +77,16 @@ pub fn run(
         max_turns,
         output_log,
         supports_tools,
-    );
+    )
+    .with_nex_verbose(verbose);
 
     if let Some(entry) = config.registry_lookup(&effective_model) {
         agent = agent.with_registry_entry(entry);
     }
 
+    // Always show the minimal banner — it names the model so the user
+    // knows what they're talking to. Verbose-only details (warning
+    // text, exit hint) are gated.
     eprintln!(
         "\x1b[1;32mwg nex\x1b[0m — interactive session with \x1b[1m{}\x1b[0m",
         effective_model
@@ -90,16 +97,22 @@ pub fn run(
             effective_model
         );
     }
-    eprintln!("Type /quit or Ctrl-D to exit.\n");
+    if verbose {
+        eprintln!("Type /quit or Ctrl-D to exit.\n");
+    } else {
+        eprintln!();
+    }
 
     let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
 
     let result = rt.block_on(agent.run_interactive(message))?;
 
-    eprintln!(
-        "\n\x1b[2mSession: {} turns, {} input + {} output tokens\x1b[0m",
-        result.turns, result.total_usage.input_tokens, result.total_usage.output_tokens,
-    );
+    if verbose {
+        eprintln!(
+            "\n\x1b[2mSession: {} turns, {} input + {} output tokens\x1b[0m",
+            result.turns, result.total_usage.input_tokens, result.total_usage.output_tokens,
+        );
+    }
 
     Ok(())
 }

--- a/src/commands/nex.rs
+++ b/src/commands/nex.rs
@@ -21,6 +21,7 @@ pub fn run(
     system_prompt: Option<&str>,
     message: Option<&str>,
     max_turns: usize,
+    chatty: bool,
     verbose: bool,
 ) -> Result<()> {
     let config = Config::load_or_default(workgraph_dir);
@@ -79,6 +80,7 @@ pub fn run(
         supports_tools,
     )
     .with_nex_verbose(verbose)
+    .with_nex_chatty(chatty || verbose)
     .with_nex_repl_mode(true);
 
     if let Some(entry) = config.registry_lookup(&effective_model) {

--- a/src/commands/nex.rs
+++ b/src/commands/nex.rs
@@ -23,6 +23,7 @@ pub fn run(
     max_turns: usize,
     chatty: bool,
     verbose: bool,
+    read_only: bool,
 ) -> Result<()> {
     let config = Config::load_or_default(workgraph_dir);
 
@@ -33,8 +34,18 @@ pub fn run(
 
     let working_dir = std::env::current_dir().unwrap_or_default();
 
-    let registry =
-        ToolRegistry::default_all_with_config(workgraph_dir, &working_dir, &config.native_executor);
+    let registry = {
+        let full = ToolRegistry::default_all_with_config(
+            workgraph_dir,
+            &working_dir,
+            &config.native_executor,
+        );
+        if read_only {
+            full.filter_read_only()
+        } else {
+            full
+        }
+    };
 
     let default_system = format!(
         "You are an expert software engineer working in an interactive coding session.\n\
@@ -102,10 +113,17 @@ pub fn run(
     // Always show the minimal banner — it names the model so the user
     // knows what they're talking to. Verbose-only details (warning
     // text, exit hint) are gated.
-    eprintln!(
-        "\x1b[1;32mwg nex\x1b[0m — interactive session with \x1b[1m{}\x1b[0m",
-        effective_model
-    );
+    if read_only {
+        eprintln!(
+            "\x1b[1;32mwg nex\x1b[0m \x1b[33m[read-only]\x1b[0m — interactive session with \x1b[1m{}\x1b[0m",
+            effective_model
+        );
+    } else {
+        eprintln!(
+            "\x1b[1;32mwg nex\x1b[0m — interactive session with \x1b[1m{}\x1b[0m",
+            effective_model
+        );
+    }
     if !supports_tools {
         eprintln!(
             "\x1b[33mWarning: model '{}' may not support tool use\x1b[0m",

--- a/src/commands/nex.rs
+++ b/src/commands/nex.rs
@@ -49,20 +49,30 @@ pub fn run(
     );
     let system = system_prompt.unwrap_or(&default_system);
 
-    // Per-session timestamped log path — every invocation of `wg nex`
-    // leaves its own file under `.workgraph/nex-sessions/` so history
-    // is preserved and sessions don't clobber each other. Path format:
-    // `.workgraph/nex-sessions/<rfc3339-utc>.ndjson`
-    let output_log = {
-        let sessions_dir = workgraph_dir.join("nex-sessions");
-        let _ = std::fs::create_dir_all(&sessions_dir);
-        let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
-        sessions_dir.join(format!("{}.ndjson", stamp))
-    };
+    // Per-session timestamped paths. Every `wg nex` invocation gets:
+    //
+    // - `.ndjson` — compact event log (tool calls, user inputs) for
+    //   the session-trace display and post-hoc analysis.
+    //
+    // - `.journal.jsonl` — full replayable conversation journal
+    //   (Init, every Message with role/content, ToolExecution,
+    //   Compaction, End). This is what enables resume, fork, replay,
+    //   and forensic analysis. Same format the background task agents
+    //   use, so tools that work on agent journals work on nex
+    //   journals too.
+    let sessions_dir = workgraph_dir.join("nex-sessions");
+    let _ = std::fs::create_dir_all(&sessions_dir);
+    let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let output_log = sessions_dir.join(format!("{}.ndjson", &stamp));
+    let journal_path = sessions_dir.join(format!("{}.journal.jsonl", &stamp));
     if verbose {
         eprintln!(
             "\x1b[2m[wg nex] session log → {}\x1b[0m",
             output_log.display()
+        );
+        eprintln!(
+            "\x1b[2m[wg nex] journal    → {}\x1b[0m",
+            journal_path.display()
         );
     }
 
@@ -81,7 +91,9 @@ pub fn run(
     )
     .with_nex_verbose(verbose)
     .with_nex_chatty(chatty || verbose)
-    .with_nex_repl_mode(true);
+    .with_nex_repl_mode(true)
+    .with_journal(journal_path, format!("nex-{}", stamp))
+    .with_working_dir(working_dir.clone());
 
     if let Some(entry) = config.registry_lookup(&effective_model) {
         agent = agent.with_registry_entry(entry);

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -107,6 +107,13 @@ pub struct AgentLoop {
     /// be exploded by a single large tool call. The agent retrieves full
     /// content via `bash` (cat/head/tail/sed/grep) on the handle path.
     tool_output_channeler: Option<super::channel::ToolOutputChanneler>,
+    /// REPL verbose mode. When false (default), `run_interactive` suppresses
+    /// tool-call previews, tool-result size lines, compaction chatter, and
+    /// other infrastructure telemetry — leaving only assistant text, the
+    /// prompt, errors, and the exit summary. Machine-testing flows set this
+    /// to true via the `--verbose` CLI flag to recover full console output.
+    /// The on-disk NDJSON session log is unaffected and always complete.
+    nex_verbose: bool,
 }
 
 /// NDJSON log entry types for the output file.
@@ -266,7 +273,15 @@ impl AgentLoop {
             state_injector: None,
             registry_entry: None,
             tool_output_channeler,
+            nex_verbose: false,
         }
+    }
+
+    /// Enable verbose REPL output in `run_interactive`.
+    /// Defaults to quiet. Use `--verbose` / `-v` on `wg nex` to turn on.
+    pub fn with_nex_verbose(mut self, verbose: bool) -> Self {
+        self.nex_verbose = verbose;
+        self
     }
 
     /// Set the registry entry for cost estimation.
@@ -1739,18 +1754,17 @@ impl AgentLoop {
                         // real reduction, and let the next turn use the
                         // reduced messages. Same pattern as the
                         // `AgentLoop::run` streaming-400 path.
-                        eprintln!(
-                            "\n\x1b[33m[nex] Context too long — hard compaction...\x1b[0m"
-                        );
                         let pre_tokens = self.context_budget.effective_tokens(&messages);
                         messages = ContextBudget::hard_emergency_compact(messages, 1);
                         let post_tokens = self.context_budget.effective_tokens(&messages);
-                        eprintln!(
-                            "\x1b[33m[nex] Hard emergency: ~{} → ~{} tokens (Δ -{})\x1b[0m",
-                            pre_tokens,
-                            post_tokens,
-                            pre_tokens.saturating_sub(post_tokens),
-                        );
+                        if self.nex_verbose {
+                            eprintln!(
+                                "\n\x1b[33m[nex] Context too long — hard compaction: ~{} → ~{} tokens (Δ -{})\x1b[0m",
+                                pre_tokens,
+                                post_tokens,
+                                pre_tokens.saturating_sub(post_tokens),
+                            );
+                        }
                         // Reset the streak — we just did the most
                         // aggressive compaction available.
                         nex_noop_streak = 0;
@@ -1859,20 +1873,25 @@ impl AgentLoop {
                         })
                         .collect();
 
-                    for (_, name, input) in &tool_use_blocks {
-                        let input_summary = if let Some(cmd) =
-                            input.get("command").and_then(|v| v.as_str())
-                        {
-                            format!("command={}", truncate_for_display(cmd, 80))
-                        } else if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
-                            format!("path={}", path)
-                        } else if let Some(pat) = input.get("pattern").and_then(|v| v.as_str()) {
-                            format!("pattern={}", truncate_for_display(pat, 60))
-                        } else {
-                            let s = input.to_string();
-                            truncate_for_display(&s, 80).to_string()
-                        };
-                        eprintln!("\x1b[2m  > {}({})\x1b[0m", name, input_summary);
+                    if self.nex_verbose {
+                        for (_, name, input) in &tool_use_blocks {
+                            let input_summary = if let Some(cmd) =
+                                input.get("command").and_then(|v| v.as_str())
+                            {
+                                format!("command={}", truncate_for_display(cmd, 80))
+                            } else if let Some(path) =
+                                input.get("file_path").and_then(|v| v.as_str())
+                            {
+                                format!("path={}", path)
+                            } else if let Some(pat) = input.get("pattern").and_then(|v| v.as_str())
+                            {
+                                format!("pattern={}", truncate_for_display(pat, 60))
+                            } else {
+                                let s = input.to_string();
+                                truncate_for_display(&s, 80).to_string()
+                            };
+                            eprintln!("\x1b[2m  > {}({})\x1b[0m", name, input_summary);
+                        }
                     }
 
                     let mut parse_error_results = Vec::new();
@@ -1915,10 +1934,49 @@ impl AgentLoop {
 
                     let calls_only: Vec<_> =
                         batch_calls.iter().map(|(_, _, c)| c.clone()).collect();
-                    let batch_results = self
-                        .tools
-                        .execute_batch(&calls_only, super::tools::DEFAULT_MAX_CONCURRENT_TOOLS)
-                        .await;
+
+                    // Wrap tool execution in a Ctrl-C-aware select so the
+                    // human can regain the prompt even if a tool is
+                    // running a long subprocess. On interrupt we produce
+                    // synthetic "[interrupted by user]" tool results for
+                    // every pending tool_use in the assistant message
+                    // (the OpenAI wire format requires a tool_result for
+                    // every tool_use), push them, and `continue` back to
+                    // the prompt. Note: this does NOT kill the child
+                    // process launched by `bash` — that needs proper
+                    // cancellation plumbing through ToolRegistry. But it
+                    // does return control to the human immediately.
+                    let batch_results = {
+                        let batch_future = self
+                            .tools
+                            .execute_batch(&calls_only, super::tools::DEFAULT_MAX_CONCURRENT_TOOLS);
+                        let ctrl_c_future = tokio::signal::ctrl_c();
+                        tokio::select! {
+                            biased;
+                            _ = ctrl_c_future => {
+                                eprintln!(
+                                    "\n\x1b[33m[nex] Interrupted during tool execution — returning to prompt.\x1b[0m"
+                                );
+                                // Synthesize interrupted results for every
+                                // tool_use in the assistant message so the
+                                // message history stays well-formed.
+                                let mut interrupted_results = Vec::new();
+                                for (id, _name, _input) in &tool_use_blocks {
+                                    interrupted_results.push(ContentBlock::ToolResult {
+                                        tool_use_id: id.clone(),
+                                        content: "[interrupted by user]".to_string(),
+                                        is_error: true,
+                                    });
+                                }
+                                messages.push(Message {
+                                    role: Role::User,
+                                    content: interrupted_results,
+                                });
+                                continue;
+                            }
+                            res = batch_future => res,
+                        }
+                    };
 
                     let mut all_results: Vec<(
                         usize,
@@ -1948,13 +2006,16 @@ impl AgentLoop {
 
                     let mut results = Vec::new();
                     for (_, id, name, input, output, _) in &all_results {
+                        // Always surface tool errors — they are
+                        // actionable signal even in quiet mode. Success
+                        // lines are verbose-only.
                         if output.is_error {
                             eprintln!(
                                 "\x1b[2m  x {} error: {}\x1b[0m",
                                 name,
                                 truncate_for_display(&output.content, 100)
                             );
-                        } else {
+                        } else if self.nex_verbose {
                             eprintln!(
                                 "\x1b[2m  + {} ({} chars)\x1b[0m",
                                 name,
@@ -2056,16 +2117,18 @@ impl AgentLoop {
                         nex_noop_streak = nex_noop_streak.saturating_add(1);
                     }
 
-                    eprintln!(
-                        "\x1b[33m[nex] {} compaction: ~{} → ~{} tokens (Δ -{}, {} → {} msgs, noop_streak={})\x1b[0m",
-                        tier_name,
-                        pre_tokens,
-                        post_tokens,
-                        delta,
-                        pre_count,
-                        post_count,
-                        nex_noop_streak,
-                    );
+                    if self.nex_verbose {
+                        eprintln!(
+                            "\x1b[33m[nex] {} compaction: ~{} → ~{} tokens (Δ -{}, {} → {} msgs, noop_streak={})\x1b[0m",
+                            tier_name,
+                            pre_tokens,
+                            post_tokens,
+                            delta,
+                            pre_count,
+                            post_count,
+                            nex_noop_streak,
+                        );
+                    }
                 }
                 ContextPressureAction::CleanExit => {
                     eprintln!(

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -1586,6 +1586,40 @@ impl AgentLoop {
         // file so the trace has a clear beginning marker.
         self.log_session_start(None);
 
+        // Open the journal for this session (if configured via
+        // `with_journal`). The journal records the FULL replayable
+        // message history — Init, every Message (user/assistant/
+        // tool-result), ToolExecution, Compaction, End — in the same
+        // format background task agents use. This enables resume,
+        // fork, replay, and forensic analysis of nex sessions.
+        let mut journal = if let Some(ref path) = self.journal_path {
+            match Journal::open(path) {
+                Ok(j) => Some(j),
+                Err(e) => {
+                    eprintln!("[nex] Warning: failed to open journal: {}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        // Write Init journal entry with session metadata.
+        if let Some(ref mut j) = journal {
+            let tool_defs = if self.supports_tools {
+                self.tools.definitions()
+            } else {
+                vec![]
+            };
+            let _ = j.append(JournalEntryKind::Init {
+                model: self.client.model().to_string(),
+                provider: self.client.name().to_string(),
+                system_prompt: self.system_prompt.clone(),
+                tools: tool_defs,
+                task_id: self.task_id.clone(),
+            });
+        }
+
         // Rustyline editor for line editing + history.
         let mut editor = DefaultEditor::new().context("failed to initialize rustyline editor")?;
         // Persistent history file — survives sessions.
@@ -1744,6 +1778,21 @@ impl AgentLoop {
                 }
             }
 
+            // Journal the last message (user input or tool results)
+            // before the API call so the journal captures the full
+            // input that drove each model turn.
+            if let Some(ref mut j) = journal
+                && let Some(last) = messages.last()
+            {
+                let _ = j.append(JournalEntryKind::Message {
+                    role: last.role,
+                    content: last.content.clone(),
+                    usage: None,
+                    response_id: None,
+                    stop_reason: None,
+                });
+            }
+
             let request = MessagesRequest {
                 model: self.client.model().to_string(),
                 max_tokens: self.client.max_tokens(),
@@ -1846,6 +1895,18 @@ impl AgentLoop {
                 role: Role::Assistant,
                 content: response.content.clone(),
             });
+
+            // Journal the assistant message so the full conversation
+            // is replayable from the journal file.
+            if let Some(ref mut j) = journal {
+                let _ = j.append(JournalEntryKind::Message {
+                    role: Role::Assistant,
+                    content: response.content.clone(),
+                    usage: Some(response.usage.clone()),
+                    response_id: None,
+                    stop_reason: response.stop_reason,
+                });
+            }
 
             match response.stop_reason {
                 Some(StopReason::EndTurn) | Some(StopReason::StopSequence) | None => {
@@ -2221,6 +2282,26 @@ impl AgentLoop {
         // Emit the session-end marker and the final result into the
         // session log so the on-disk trace has a clear terminator.
         self.log_session_end(turns, session_exit_reason, &total_usage);
+
+        // Close the journal with an End entry.
+        if let Some(ref mut j) = journal {
+            use crate::executor::native::journal::EndReason;
+            let reason = match session_exit_reason {
+                "user_quit" | "eof" => EndReason::Complete,
+                "max_turns" => EndReason::MaxTurns,
+                "context_limit" => EndReason::Error {
+                    message: "context limit".to_string(),
+                },
+                other => EndReason::Error {
+                    message: other.to_string(),
+                },
+            };
+            let _ = j.append(JournalEntryKind::End {
+                reason,
+                total_usage: total_usage.clone(),
+                turns: turns as u32,
+            });
+        }
         let result_preview = AgentResult {
             final_text: final_text.clone(),
             turns,

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -107,13 +107,17 @@ pub struct AgentLoop {
     /// be exploded by a single large tool call. The agent retrieves full
     /// content via `bash` (cat/head/tail/sed/grep) on the handle path.
     tool_output_channeler: Option<super::channel::ToolOutputChanneler>,
-    /// REPL verbose mode. When false (default), `run_interactive` suppresses
-    /// tool-call previews, tool-result size lines, compaction chatter, and
-    /// other infrastructure telemetry — leaving only assistant text, the
-    /// prompt, errors, and the exit summary. Machine-testing flows set this
-    /// to true via the `--verbose` CLI flag to recover full console output.
-    /// The on-disk NDJSON session log is unaffected and always complete.
+    /// REPL verbose mode. When true, emits compaction diagnostics, token
+    /// accounting, session-log-path banner, and other infrastructure
+    /// telemetry on top of the tool-call action trace. Implies chatty
+    /// mode. Defaults to false. Toggled by `-v` / `--verbose` on `wg nex`.
     nex_verbose: bool,
+    /// REPL chatty mode. When true, the full tool output content is
+    /// echoed under each tool-call line (as the model sees it, capped
+    /// at 20 lines / 1600 bytes). When false (default), only a one-line
+    /// summary per call is shown. Implied by `nex_verbose`. Toggled by
+    /// `-c` / `--chatty` on `wg nex`.
+    nex_chatty: bool,
     /// REPL mode marker. When true, the agent is running inside an
     /// interactive nex REPL where stdout is the human's terminal and
     /// must stay sacred for assistant text. When false (the default,
@@ -281,14 +285,27 @@ impl AgentLoop {
             registry_entry: None,
             tool_output_channeler,
             nex_verbose: false,
+            nex_chatty: false,
             nex_repl_mode: false,
         }
     }
 
     /// Enable verbose REPL output in `run_interactive`.
     /// Defaults to quiet. Use `--verbose` / `-v` on `wg nex` to turn on.
+    /// Implies chatty mode.
     pub fn with_nex_verbose(mut self, verbose: bool) -> Self {
         self.nex_verbose = verbose;
+        if verbose {
+            self.nex_chatty = true;
+        }
+        self
+    }
+
+    /// Enable chatty REPL output — echo the full tool output content
+    /// under each tool-call line, as the model sees it. Defaults to
+    /// false. Use `--chatty` / `-c` on `wg nex` to turn on.
+    pub fn with_nex_chatty(mut self, chatty: bool) -> Self {
+        self.nex_chatty = chatty;
         self
     }
 
@@ -2033,17 +2050,36 @@ impl AgentLoop {
 
                     let mut results = Vec::new();
                     for (_, id, name, input, output, _) in &all_results {
-                        // Always surface actual tool output content so
-                        // the human can follow what the agent received
-                        // and verify artifacts line up with
-                        // expectations. Errors use a distinct marker;
-                        // successes are rendered as indented output
-                        // with a sensible line/char cap.
+                        // Default (non-chatty) mode shows a one-line
+                        // summary per tool call — enough to follow what
+                        // happened, not enough to flood the terminal.
+                        // Chatty mode (and verbose, which implies
+                        // chatty) dumps the full tool output exactly as
+                        // it enters the model's context, capped at
+                        // MAX_LINES / MAX_BYTES in print_indented_output.
+                        // Errors always get a visible distinguishing
+                        // marker and a compact excerpt even in default
+                        // mode — they're actionable signal.
                         if output.is_error {
-                            eprintln!("\x1b[31m× {} error\x1b[0m", name);
-                            print_indented_output(&output.content, "\x1b[31m  ", "\x1b[0m");
-                        } else {
+                            eprintln!(
+                                "\x1b[31m× {} error: {}\x1b[0m",
+                                name,
+                                summarize_tool_output(&output.content)
+                            );
+                            if self.nex_chatty {
+                                print_indented_output(&output.content, "\x1b[31m  ", "\x1b[0m");
+                            }
+                        } else if self.nex_chatty {
+                            eprintln!(
+                                "\x1b[2m  → {}\x1b[0m",
+                                summarize_tool_output(&output.content)
+                            );
                             print_indented_output(&output.content, "\x1b[2m  ", "\x1b[0m");
+                        } else {
+                            eprintln!(
+                                "\x1b[2m  → {}\x1b[0m",
+                                summarize_tool_output(&output.content)
+                            );
                         }
 
                         tool_calls.push(ToolCallRecord {
@@ -2214,6 +2250,56 @@ fn truncate_for_display(s: &str, max: usize) -> &str {
             end -= 1;
         }
         &s[..end]
+    }
+}
+
+/// Build a one-line summary of a tool output for the default
+/// (non-chatty) display mode. Goals:
+/// - short enough to fit on one terminal line
+/// - informative enough that the human doesn't need to go look at the
+///   session log for most routine calls
+/// - degrades gracefully for empty / single-line / multi-line outputs
+///
+/// For single-line outputs ≤ 120 bytes, echoes the whole thing. For
+/// multi-line or longer outputs, shows the first non-empty line
+/// (truncated) plus a `(N lines, M bytes)` suffix.
+fn summarize_tool_output(content: &str) -> String {
+    let total_bytes = content.len();
+    if total_bytes == 0 {
+        return "ok (empty)".to_string();
+    }
+    let first_line = content
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or("")
+        .trim();
+    let total_lines = content.lines().count();
+
+    const LINE_CAP: usize = 120;
+    let truncated_first = if first_line.len() > LINE_CAP {
+        let end = {
+            let mut e = LINE_CAP;
+            while e > 0 && !first_line.is_char_boundary(e) {
+                e -= 1;
+            }
+            e
+        };
+        format!("{}…", &first_line[..end])
+    } else {
+        first_line.to_string()
+    };
+
+    if total_lines <= 1 && total_bytes <= LINE_CAP {
+        if truncated_first.is_empty() {
+            format!("ok ({} bytes)", total_bytes)
+        } else {
+            truncated_first
+        }
+    } else {
+        format!(
+            "{} ({} lines, {} bytes)",
+            truncated_first, total_lines, total_bytes
+        )
     }
 }
 

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -114,6 +114,13 @@ pub struct AgentLoop {
     /// to true via the `--verbose` CLI flag to recover full console output.
     /// The on-disk NDJSON session log is unaffected and always complete.
     nex_verbose: bool,
+    /// REPL mode marker. When true, the agent is running inside an
+    /// interactive nex REPL where stdout is the human's terminal and
+    /// must stay sacred for assistant text. When false (the default,
+    /// used by background native-exec agents), the log events are
+    /// *also* mirrored to stdout so the wrapper script can capture
+    /// them into `output.log` for TUI display.
+    nex_repl_mode: bool,
 }
 
 /// NDJSON log entry types for the output file.
@@ -274,6 +281,7 @@ impl AgentLoop {
             registry_entry: None,
             tool_output_channeler,
             nex_verbose: false,
+            nex_repl_mode: false,
         }
     }
 
@@ -281,6 +289,15 @@ impl AgentLoop {
     /// Defaults to quiet. Use `--verbose` / `-v` on `wg nex` to turn on.
     pub fn with_nex_verbose(mut self, verbose: bool) -> Self {
         self.nex_verbose = verbose;
+        self
+    }
+
+    /// Mark this agent as running inside a nex REPL. Suppresses the
+    /// stdout mirror of NDJSON log events so the human's terminal
+    /// stays clean (assistant text only). The disk-side session log
+    /// is unaffected.
+    pub fn with_nex_repl_mode(mut self, repl: bool) -> Self {
+        self.nex_repl_mode = repl;
         self
     }
 
@@ -1480,9 +1497,13 @@ impl AgentLoop {
             {
                 let _ = writeln!(file, "{}", json);
             }
-            // Also write to stdout so the wrapper script captures it to output.log,
-            // making events visible to the TUI.
-            println!("{}", json);
+            // Also mirror to stdout so the background-agent wrapper
+            // script captures it into output.log for TUI display.
+            // Skip this in nex REPL mode — stdout is the human's
+            // terminal, the file is the only sink they care about.
+            if !self.nex_repl_mode {
+                println!("{}", json);
+            }
         }
     }
 

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -1894,25 +1894,31 @@ impl AgentLoop {
                         })
                         .collect();
 
-                    if self.nex_verbose {
-                        for (_, name, input) in &tool_use_blocks {
-                            let input_summary = if let Some(cmd) =
-                                input.get("command").and_then(|v| v.as_str())
-                            {
-                                format!("command={}", truncate_for_display(cmd, 80))
-                            } else if let Some(path) =
-                                input.get("file_path").and_then(|v| v.as_str())
-                            {
-                                format!("path={}", path)
-                            } else if let Some(pat) = input.get("pattern").and_then(|v| v.as_str())
-                            {
-                                format!("pattern={}", truncate_for_display(pat, 60))
-                            } else {
-                                let s = input.to_string();
-                                truncate_for_display(&s, 80).to_string()
-                            };
-                            eprintln!("\x1b[2m  > {}({})\x1b[0m", name, input_summary);
-                        }
+                    // Tool-call previews are always shown (even in the
+                    // default non-verbose mode) so the human can follow
+                    // what the agent is doing — which command was run,
+                    // which file was read, etc. Verbose mode adds
+                    // compaction/token diagnostics on top of this, but
+                    // the per-call action trace is the minimum "I can
+                    // see what's happening" UX.
+                    for (_, name, input) in &tool_use_blocks {
+                        let input_summary = if let Some(cmd) =
+                            input.get("command").and_then(|v| v.as_str())
+                        {
+                            format!("command={}", truncate_for_display(cmd, 120))
+                        } else if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
+                            format!("path={}", path)
+                        } else if let Some(pat) = input.get("pattern").and_then(|v| v.as_str()) {
+                            format!("pattern={}", truncate_for_display(pat, 80))
+                        } else if let Some(q) = input.get("query").and_then(|v| v.as_str()) {
+                            format!("query={}", truncate_for_display(q, 80))
+                        } else if let Some(url) = input.get("url").and_then(|v| v.as_str()) {
+                            format!("url={}", url)
+                        } else {
+                            let s = input.to_string();
+                            truncate_for_display(&s, 120).to_string()
+                        };
+                        eprintln!("\x1b[2;36m> {}({})\x1b[0m", name, input_summary);
                     }
 
                     let mut parse_error_results = Vec::new();
@@ -2027,21 +2033,17 @@ impl AgentLoop {
 
                     let mut results = Vec::new();
                     for (_, id, name, input, output, _) in &all_results {
-                        // Always surface tool errors — they are
-                        // actionable signal even in quiet mode. Success
-                        // lines are verbose-only.
+                        // Always surface actual tool output content so
+                        // the human can follow what the agent received
+                        // and verify artifacts line up with
+                        // expectations. Errors use a distinct marker;
+                        // successes are rendered as indented output
+                        // with a sensible line/char cap.
                         if output.is_error {
-                            eprintln!(
-                                "\x1b[2m  x {} error: {}\x1b[0m",
-                                name,
-                                truncate_for_display(&output.content, 100)
-                            );
-                        } else if self.nex_verbose {
-                            eprintln!(
-                                "\x1b[2m  + {} ({} chars)\x1b[0m",
-                                name,
-                                output.content.len()
-                            );
+                            eprintln!("\x1b[31m× {} error\x1b[0m", name);
+                            print_indented_output(&output.content, "\x1b[31m  ", "\x1b[0m");
+                        } else {
+                            print_indented_output(&output.content, "\x1b[2m  ", "\x1b[0m");
                         }
 
                         tool_calls.push(ToolCallRecord {
@@ -2201,7 +2203,53 @@ impl AgentLoop {
 }
 
 fn truncate_for_display(s: &str, max: usize) -> &str {
-    if s.len() <= max { s } else { &s[..max] }
+    if s.len() <= max {
+        s
+    } else {
+        // Walk back to the nearest char boundary so we don't slice a
+        // multi-byte UTF-8 sequence. `floor_char_boundary` is nightly,
+        // so do it by hand.
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
+    }
+}
+
+/// Render a tool output to stderr under the per-call trace line with
+/// uniform indent and sensible bounds — caps at both a byte limit and
+/// a line-count limit so a multi-megabyte file read doesn't saturate
+/// the terminal. `prefix` is printed before every output line (use for
+/// indent + ANSI color), `suffix` after (use to close the color span).
+fn print_indented_output(content: &str, prefix: &str, suffix: &str) {
+    const MAX_LINES: usize = 20;
+    const MAX_BYTES: usize = 1600;
+
+    let truncated = truncate_for_display(content, MAX_BYTES);
+    let mut line_count = 0usize;
+    for line in truncated.lines() {
+        if line_count >= MAX_LINES {
+            break;
+        }
+        eprintln!("{}{}{}", prefix, line, suffix);
+        line_count += 1;
+    }
+
+    let total_lines = content.lines().count();
+    let total_bytes = content.len();
+    let shown_lines = line_count;
+    let shown_bytes = truncated.len();
+    let line_overflow = total_lines > shown_lines;
+    let byte_overflow = total_bytes > shown_bytes;
+    if line_overflow || byte_overflow {
+        let extra_lines = total_lines.saturating_sub(shown_lines);
+        let extra_bytes = total_bytes.saturating_sub(shown_bytes);
+        eprintln!(
+            "{}… (+{} lines, +{} bytes truncated){}",
+            prefix, extra_lines, extra_bytes, suffix
+        );
+    }
 }
 
 /// Result of processing a nex REPL slash command.

--- a/src/executor/native/channel.rs
+++ b/src/executor/native/channel.rs
@@ -20,6 +20,23 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// Anything larger gets channeled.
 pub const DEFAULT_CHANNEL_THRESHOLD_BYTES: usize = 2048;
 
+/// Tools whose output should NEVER be channeled — their whole job is
+/// to bring structured data INTO the model's context, so replacing
+/// that data with a handle defeats the point. `web_search` enforces
+/// its own size cap (MAX_RESULTS results) so it fits comfortably in
+/// a turn and channeling is redundant. `web_fetch` self-manages its
+/// output differently — it writes fetched pages to a file artifact
+/// and returns metadata + preview, so it never passes a huge body
+/// to the channeler in the first place.
+///
+/// We learned this the hard way: qwen3-coder-30b was hallucinating
+/// restaurant names from real-looking URLs because it had never
+/// actually seen the web_search output — the 8 KB of results had
+/// been channeled to disk and the model only had a 400-char preview
+/// to work with. The model grounded on what it could see (restaurant
+/// name fragments) and confabulated plausible variants for the rest.
+const NEVER_CHANNEL_TOOLS: &[&str] = &["web_search"];
+
 /// Number of chars of preview included in the handle string.
 pub const DEFAULT_PREVIEW_CHARS: usize = 400;
 
@@ -54,9 +71,16 @@ impl ToolOutputChanneler {
     /// handle string pointing to the file. Otherwise return `content`
     /// unchanged.
     ///
+    /// Tools in `NEVER_CHANNEL_TOOLS` always pass through regardless
+    /// of size — their outputs are the whole point of the call and
+    /// truncating them to a 400-char preview destroys the value.
+    ///
     /// On any I/O failure, returns the original content rather than
     /// silently losing it — channeling is best-effort, never a blocker.
     pub fn maybe_channel(&self, tool_name: &str, content: &str) -> String {
+        if NEVER_CHANNEL_TOOLS.contains(&tool_name) {
+            return content.to_string();
+        }
         if content.len() <= self.threshold_bytes {
             return content.to_string();
         }

--- a/src/executor/native/openai_client.rs
+++ b/src/executor/native/openai_client.rs
@@ -368,9 +368,11 @@ impl OpenAiClient {
         // output (8 192 tokens for a 32 k window, 32 768 for 128 k).
         let cap = (tokens / 4) as u32;
         if cap > 0 && self.max_tokens > cap {
-            eprintln!(
+            log::debug!(
                 "[openai-client] Capping max_tokens from {} to {} (context_window={})",
-                self.max_tokens, cap, tokens
+                self.max_tokens,
+                cap,
+                tokens
             );
             self.max_tokens = cap;
         }

--- a/src/executor/native/provider.rs
+++ b/src/executor/native/provider.rs
@@ -337,7 +337,7 @@ pub fn create_provider_ext(
                     );
                 }
             }
-            eprintln!(
+            log::debug!(
                 "[native-exec] Using OpenAI-compatible provider ({})",
                 client.model
             );
@@ -365,7 +365,7 @@ pub fn create_provider_ext(
             if let Some(mt) = max_tokens {
                 client = client.with_max_tokens(mt);
             }
-            eprintln!("[native-exec] Using Anthropic provider ({})", client.model);
+            log::debug!("[native-exec] Using Anthropic provider ({})", client.model);
             Ok(Box::new(client))
         }
     }

--- a/src/executor/native/tools/delegate.rs
+++ b/src/executor/native/tools/delegate.rs
@@ -198,7 +198,7 @@ pub fn build_child_registry(
     bash::register_bash_tool(&mut registry, working_dir.to_path_buf());
     wg::register_wg_tools(&mut registry, workgraph_dir.to_path_buf());
     web_search::register_web_search_tool(&mut registry);
-    web_fetch::register_web_fetch_tool(&mut registry);
+    web_fetch::register_web_fetch_tool(&mut registry, workgraph_dir.to_path_buf());
     bg::register_bg_tool(&mut registry, workgraph_dir.to_path_buf());
 
     // Apply bundle filtering for the exec_mode

--- a/src/executor/native/tools/mod.rs
+++ b/src/executor/native/tools/mod.rs
@@ -364,6 +364,7 @@ impl ToolRegistry {
         // Web fetch tool
         web_fetch::register_web_fetch_tool_with_config(
             &mut registry,
+            workgraph_dir.to_path_buf(),
             config.web.fetch_max_chars,
             config.web.fetch_timeout_secs,
         );

--- a/src/executor/native/tools/mod.rs
+++ b/src/executor/native/tools/mod.rs
@@ -174,6 +174,21 @@ impl ToolRegistry {
         self.tools.get(name).is_some_and(|t| t.is_read_only())
     }
 
+    /// Return a new registry containing only read-only tools. Used by
+    /// `wg nex --read-only` to provide a safe browsing mode where the
+    /// agent can read files, search the web, and run non-destructive
+    /// commands but cannot write files, edit code, or run arbitrary
+    /// bash that modifies state.
+    pub fn filter_read_only(self) -> Self {
+        let mut filtered = ToolRegistry::new();
+        for (name, tool) in self.tools {
+            if tool.is_read_only() {
+                filtered.tools.insert(name, tool);
+            }
+        }
+        filtered
+    }
+
     /// Execute a batch of tool calls with parallelism for read-only tools.
     ///
     /// Partitions calls into read-only and mutating. Read-only calls execute

--- a/src/executor/native/tools/web_fetch.rs
+++ b/src/executor/native/tools/web_fetch.rs
@@ -220,12 +220,49 @@ impl Tool for WebFetchTool {
             preview.push_str(&format!("{:>4}: {}\n", i + 1, line));
         }
 
+        // Large-page guidance: if the page is bigger than a threshold,
+        // surface the `summarize` tool as the preferred path for
+        // extracting specific info without reading the whole thing.
+        // The agent can still `cat`/`grep` the file for small slices,
+        // but summarize is the right primitive for "give me X from
+        // this long article" queries.
+        const SUMMARIZE_SUGGEST_LINES: usize = 80;
+        const SUMMARIZE_SUGGEST_BYTES: usize = 6_000;
+        let suggest_summarize =
+            total_lines > SUMMARIZE_SUGGEST_LINES || total_bytes > SUMMARIZE_SUGGEST_BYTES;
+        let summarize_hint = if suggest_summarize {
+            format!(
+                "\nThis page is large ({lines} lines, {bytes} bytes). For focused \
+                 extraction of specific info, prefer the `summarize` tool over reading \
+                 the whole file:\n\
+                 \n\
+                 summarize(source='{path}', instruction='<what you want to extract>')\n\
+                 \n\
+                 Examples:\n\
+                 • instruction='list the three best pizzerias mentioned with their addresses'\n\
+                 • instruction='extract all dates and what happened on each'\n\
+                 • instruction='summarize the author's main argument in 3 bullet points'\n\
+                 \n\
+                 The summarize tool recursively map-reduces the text so you never have \
+                 to load more than one chunk at a time — use it whenever you only need \
+                 a subset of what's on the page.\n",
+                lines = total_lines,
+                bytes = total_bytes,
+                path = artifact_path.display(),
+            )
+        } else {
+            String::new()
+        };
+
+        // Compact one-line header FIRST so the nex default display
+        // mode picks a useful summary line, same treatment as
+        // web_search. The grounding details + full preview follow
+        // below and are visible in chatty mode.
         let response = format!(
-            "Fetched: {url}\n\
+            "web_fetch: {url} → {lines} lines, {bytes} bytes via {path_used} ({ms} ms) \
+             → {path}\n\
+             \n\
              Title:   {title}\n\
-             Path:    {path}\n\
-             Size:    {bytes} bytes, {lines} lines\n\
-             Via:     {path_used} ({ms} ms)\n\
              \n\
              Preview (first {preview_lines} lines):\n\
              ────────────────────────────────────────────────────\n\
@@ -237,7 +274,8 @@ impl Tool for WebFetchTool {
              • First N lines: head -n 100 '{path}'\n\
              • Last N lines:  tail -n 100 '{path}'\n\
              • Search:        grep -in 'pattern' '{path}'\n\
-             • Line range:    sed -n '50,120p' '{path}'\n",
+             • Line range:    sed -n '50,120p' '{path}'\n\
+             {summarize_hint}",
             url = url_str,
             title = if title.is_empty() {
                 "(untitled)"
@@ -251,6 +289,7 @@ impl Tool for WebFetchTool {
             ms = duration_ms,
             preview_lines = PREVIEW_LINES,
             preview = preview,
+            summarize_hint = summarize_hint,
         );
 
         ToolOutput::success(response)

--- a/src/executor/native/tools/web_fetch.rs
+++ b/src/executor/native/tools/web_fetch.rs
@@ -1,6 +1,8 @@
-//! Web fetch tool: fetch a URL, extract main content, convert to markdown.
+//! Web fetch tool: fetch a URL, extract main content, **write to a
+//! file artifact**, and return a compact metadata+preview entry that
+//! the agent can then explore with `bash cat/head/grep`.
 //!
-//! Two-tier architecture:
+//! Two-tier fetch architecture:
 //!
 //! 1. **`rquest` with Chrome-136 emulation (primary path)**. Presents
 //!    as a real Chrome browser at the TLS (JA3/JA4), HTTP/2, and header
@@ -12,37 +14,62 @@
 //!    where even TLS-level emulation isn't enough (some Cloudflare
 //!    Turnstile configurations, JS-rendered content, cookie walls),
 //!    drop into the shared chromiumoxide `BrowserHandle` and navigate
-//!    to the URL for real. This is the same `BrowserHandle` the
-//!    `web_search` Browser backend uses, so cost is amortized across
-//!    both tools.
+//!    to the URL for real. Same `BrowserHandle` the `web_search`
+//!    Browser backend uses, so cost is amortized across both tools.
 //!
-//! The response JSON records `path_used` (`rquest_chrome136` |
-//! `headless_chrome`) and `duration_ms` per fetch so sessions can be
-//! analyzed later to measure how often the fallback is actually
-//! needed. The intent: if headless Chrome fallback fires on <5% of
-//! queries, rquest is load-bearing and headless Chrome is the tail;
-//! if >20%, rquest isn't cutting it and we need more aggressive
-//! emulation or different backends.
+//! File artifact architecture:
+//!
+//! Every successful fetch writes the extracted markdown to
+//! `<workgraph_dir>/nex-sessions/fetched-pages/NNNNN-<slug>.md`. The
+//! tool then returns ~1 KB of metadata (path, size, line count, first
+//! 20 lines preview) plus explicit bash hints for how to read the
+//! file. This keeps the full page OUT of the model's context on every
+//! turn — the agent reads what it needs via bash, exactly like it
+//! already does for large file_read outputs. The artifact survives
+//! the session for user inspection.
+//!
+//! Measurement: the metadata response includes `path_used`
+//! (`rquest_chrome136` | `headless_chrome`) and `duration_ms` per
+//! fetch so sessions can be analyzed later to measure how often the
+//! browser fallback is actually needed.
 
 use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use serde_json::json;
 use url::Url;
 
-use super::{Tool, ToolOutput, truncate_tool_output};
+use super::{Tool, ToolOutput};
 use crate::executor::native::client::ToolDefinition;
 
-/// Default maximum content length before truncation (chars).
+/// Cap on the size of any single fetched page written to disk. Real
+/// pages beyond this cap are truncated and the tool response says so.
+/// Prevents pathological fetches (100 MB HTML bombs) from filling the
+/// session dir.
 const DEFAULT_MAX_CONTENT_CHARS: usize = 16_000;
 
 /// Default HTTP request timeout.
 const DEFAULT_FETCH_TIMEOUT_SECS: u64 = 30;
 
-/// Register the web_fetch tool with default config.
-pub fn register_web_fetch_tool(registry: &mut super::ToolRegistry) {
+/// How many lines of the fetched page to inline into the tool
+/// response as a preview. The agent gets a taste of the content
+/// without loading the whole page into context.
+const PREVIEW_LINES: usize = 20;
+
+/// Monotonic counter for fetched-page filenames within a single
+/// process. Each fetch gets a unique number regardless of URL, so
+/// two fetches of the same URL produce two distinct artifacts.
+static FETCH_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+/// Register the web_fetch tool. `workgraph_dir` is the root of the
+/// `.workgraph/` directory — fetched pages go under
+/// `<workgraph_dir>/nex-sessions/fetched-pages/`.
+pub fn register_web_fetch_tool(registry: &mut super::ToolRegistry, workgraph_dir: PathBuf) {
     registry.register(Box::new(WebFetchTool {
+        workgraph_dir,
         max_content_chars: DEFAULT_MAX_CONTENT_CHARS,
         fetch_timeout_secs: DEFAULT_FETCH_TIMEOUT_SECS,
     }));
@@ -51,16 +78,19 @@ pub fn register_web_fetch_tool(registry: &mut super::ToolRegistry) {
 /// Register the web_fetch tool with custom config values.
 pub fn register_web_fetch_tool_with_config(
     registry: &mut super::ToolRegistry,
+    workgraph_dir: PathBuf,
     max_content_chars: usize,
     fetch_timeout_secs: u64,
 ) {
     registry.register(Box::new(WebFetchTool {
+        workgraph_dir,
         max_content_chars,
         fetch_timeout_secs,
     }));
 }
 
 struct WebFetchTool {
+    workgraph_dir: PathBuf,
     max_content_chars: usize,
     fetch_timeout_secs: u64,
 }
@@ -78,16 +108,21 @@ impl Tool for WebFetchTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "web_fetch".to_string(),
-            description: "Fetch a web page and return its main content as clean markdown. \
-                          Presents as a real Chrome browser (full TLS + HTTP/2 + client-hints \
-                          fingerprint) so anti-bot systems see a human, not a script. Falls \
-                          back to a headless Chrome process if TLS emulation isn't enough. \
+            description: "Fetch a web page and save it as a local markdown file artifact. \
+                          Returns metadata (path, size, title) and the first 20 lines as a \
+                          preview. To read the full page, use `bash` with `cat`, `head`, \
+                          `tail`, `sed`, or `grep` on the returned path. \
                           \n\n\
-                          IMPORTANT: Prefer URLs returned by `web_search` over guessing URLs. \
-                          Hallucinated URLs (like 'en.wikipedia.org/wiki/Naples_pizza' when \
-                          the real page is 'Neapolitan_pizza') will return 404 — `web_fetch` \
-                          cannot conjure pages that don't exist. Use `web_search` first, then \
-                          fetch a URL from its results."
+                          Presents as a real Chrome browser (TLS + HTTP/2 + client-hints \
+                          fingerprint via rquest) so anti-bot systems see a human, not a \
+                          script. Falls back to a headless Chrome process if TLS emulation \
+                          isn't enough. \
+                          \n\n\
+                          IMPORTANT: Prefer URLs returned by `web_search` over guessing \
+                          URLs. Hallucinated URLs (like 'en.wikipedia.org/wiki/Naples_pizza' \
+                          when the real page is 'Neapolitan_pizza') will return 404 — \
+                          `web_fetch` cannot conjure pages that don't exist. Use `web_search` \
+                          first, then fetch a URL from its results."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -115,65 +150,197 @@ impl Tool for WebFetchTool {
             Err(e) => return ToolOutput::error(format!("Invalid URL: {}", e)),
         };
 
+        let overall_started = Instant::now();
+
         // Primary path: rquest with Chrome-136 emulation.
-        let primary_started = Instant::now();
         let primary_result = fetch_via_rquest(&url_str, self.fetch_timeout_secs).await;
-        let primary_duration_ms = primary_started.elapsed().as_millis() as u64;
 
-        let (html, path_used, fallback_error): (String, &str, Option<String>) = match primary_result
-        {
-            Ok(body) => (body, "rquest_chrome136", None),
+        let (html, path_used): (String, &str) = match primary_result {
+            Ok(body) => (body, "rquest_chrome136"),
             Err(primary_err) => {
-                // rquest-with-Chrome-emulation failed. Before
-                // giving up, try the real headless Chrome process
-                // as a last resort. This is the 5% tail of sites
-                // that Cloudflare Turnstile or similar catch even
-                // with TLS-level emulation.
-                let fallback_started = Instant::now();
-                let fallback_result = fetch_via_browser(&url_str).await;
-                let fallback_duration_ms = fallback_started.elapsed().as_millis() as u64;
-
-                match fallback_result {
-                    Ok(body) => {
-                        // We use the fallback duration for the
-                        // reported duration_ms since that's what
-                        // actually produced the content.
-                        let _ = fallback_duration_ms; // silence unused
-                        (body, "headless_chrome", None)
-                    }
+                // rquest-with-Chrome-emulation failed. Before giving
+                // up, try the real headless Chrome process — the
+                // residual 5% of sites that Cloudflare Turnstile or
+                // similar catch even with TLS-level emulation.
+                match fetch_via_browser(&url_str).await {
+                    Ok(body) => (body, "headless_chrome"),
                     Err(browser_err) => {
-                        // Both paths failed. Report both errors so
-                        // the human and the model can see what
-                        // went wrong.
-                        let combined = format!(
+                        return ToolOutput::error(format!(
                             "Failed to fetch URL (both paths):\n\
-                                 - rquest_chrome136 ({}ms): {}\n\
-                                 - headless_chrome ({}ms): {}\n\n\
-                                 If the URL came from a web_search result, this is a transient \
-                                 failure — retry or use `bash curl` as a last resort. If you \
-                                 guessed the URL, it likely doesn't exist — use `web_search` \
-                                 to find real URLs first.",
-                            primary_duration_ms, primary_err, fallback_duration_ms, browser_err
-                        );
-                        return ToolOutput::error(combined);
+                             - rquest_chrome136: {}\n\
+                             - headless_chrome: {}\n\n\
+                             If the URL came from a web_search result, this is a transient \
+                             failure — retry or use `bash` with `curl` as a last resort. If \
+                             you guessed the URL, it likely doesn't exist — use `web_search` \
+                             to find real URLs first.",
+                            primary_err, browser_err
+                        ));
                     }
                 }
             }
         };
-        let _ = fallback_error; // destructure placeholder
 
         // Extract main content using readability + html2md.
-        let markdown = extract_to_markdown(&html, &parsed_url);
+        let (title, markdown) = extract_to_markdown(&html, &parsed_url);
 
-        // Stamp measurement header at the top of the output. Tiny
-        // overhead, visible in chatty mode, and downstream log
-        // analyzers can parse it to aggregate path-usage statistics
-        // across a session.
-        let header = format!("<!-- web_fetch path={} url={} -->\n", path_used, url_str);
-        let with_header = format!("{}{}", header, markdown);
+        // Write to a file artifact under <workgraph>/nex-sessions/fetched-pages/.
+        // The agent can then `cat`/`head`/`grep` it without loading the
+        // whole page into context on every turn.
+        let capped_markdown = if markdown.len() > self.max_content_chars {
+            let end = markdown
+                .char_indices()
+                .nth(self.max_content_chars)
+                .map(|(i, _)| i)
+                .unwrap_or(markdown.len());
+            format!(
+                "{}\n\n[... content truncated at {} chars; upstream page was larger ...]\n",
+                &markdown[..end],
+                self.max_content_chars
+            )
+        } else {
+            markdown
+        };
 
-        let truncated = truncate_tool_output(&with_header, self.max_content_chars);
-        ToolOutput::success(truncated)
+        let artifact_path = match self.write_artifact(&url_str, &title, &capped_markdown) {
+            Ok(p) => p,
+            Err(e) => {
+                return ToolOutput::error(format!(
+                    "Fetched {} successfully via {} but failed to write artifact file: {}",
+                    url_str, path_used, e
+                ));
+            }
+        };
+
+        let total_bytes = capped_markdown.len();
+        let total_lines = capped_markdown.lines().count();
+        let duration_ms = overall_started.elapsed().as_millis() as u64;
+
+        let mut preview = String::new();
+        for (i, line) in capped_markdown.lines().take(PREVIEW_LINES).enumerate() {
+            preview.push_str(&format!("{:>4}: {}\n", i + 1, line));
+        }
+
+        let response = format!(
+            "Fetched: {url}\n\
+             Title:   {title}\n\
+             Path:    {path}\n\
+             Size:    {bytes} bytes, {lines} lines\n\
+             Via:     {path_used} ({ms} ms)\n\
+             \n\
+             Preview (first {preview_lines} lines):\n\
+             ────────────────────────────────────────────────────\n\
+             {preview}\
+             ────────────────────────────────────────────────────\n\
+             \n\
+             To read the full page, use `bash` on the path above:\n\
+             • Whole file:    cat '{path}'\n\
+             • First N lines: head -n 100 '{path}'\n\
+             • Last N lines:  tail -n 100 '{path}'\n\
+             • Search:        grep -in 'pattern' '{path}'\n\
+             • Line range:    sed -n '50,120p' '{path}'\n",
+            url = url_str,
+            title = if title.is_empty() {
+                "(untitled)"
+            } else {
+                title.as_str()
+            },
+            path = artifact_path.display(),
+            bytes = total_bytes,
+            lines = total_lines,
+            path_used = path_used,
+            ms = duration_ms,
+            preview_lines = PREVIEW_LINES,
+            preview = preview,
+        );
+
+        ToolOutput::success(response)
+    }
+}
+
+impl WebFetchTool {
+    /// Write the fetched page to `<workgraph>/nex-sessions/fetched-pages/`
+    /// under a counter-prefixed, URL-slug-based filename. Returns the
+    /// canonical absolute path for the agent to reference.
+    fn write_artifact(&self, url: &str, title: &str, markdown: &str) -> Result<PathBuf, String> {
+        let dir = self
+            .workgraph_dir
+            .join("nex-sessions")
+            .join("fetched-pages");
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("create_dir_all {}: {}", dir.display(), e))?;
+
+        let n = FETCH_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let slug = slug_from_url(url);
+        let filename = format!("{:05}-{}.md", n, slug);
+        let path = dir.join(filename);
+
+        // Prepend a small provenance header so the artifact is self-
+        // documenting when the user opens it later.
+        let header = format!(
+            "<!-- web_fetch artifact -->\n\
+             <!-- url: {} -->\n\
+             <!-- title: {} -->\n\
+             <!-- fetched: {} -->\n\n",
+            url,
+            title,
+            chrono::Utc::now().to_rfc3339()
+        );
+        let body = format!("{}{}", header, markdown);
+
+        std::fs::write(&path, body).map_err(|e| format!("write {}: {}", path.display(), e))?;
+
+        Ok(std::fs::canonicalize(&path).unwrap_or(path))
+    }
+}
+
+/// Short filesystem-safe slug from a URL's host + path, capped at 40
+/// chars, with non-alphanumeric collapsed to `-`. Used in the
+/// artifact filename so users opening the fetched-pages directory
+/// can eyeball which file corresponds to which URL.
+fn slug_from_url(url: &str) -> String {
+    let parsed = Url::parse(url).ok();
+    let host = parsed
+        .as_ref()
+        .and_then(|u| u.host_str())
+        .unwrap_or("unknown");
+    let path = parsed
+        .as_ref()
+        .map(|u| u.path().trim_matches('/').to_string())
+        .unwrap_or_default();
+    let combined = if path.is_empty() {
+        host.to_string()
+    } else {
+        format!("{}-{}", host, path)
+    };
+    let cleaned: String = combined
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    // Collapse runs of dashes
+    let mut out = String::with_capacity(cleaned.len());
+    let mut prev_dash = false;
+    for c in cleaned.chars() {
+        if c == '-' {
+            if !prev_dash {
+                out.push(c);
+            }
+            prev_dash = true;
+        } else {
+            out.push(c);
+            prev_dash = false;
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    if trimmed.len() > 40 {
+        trimmed[..40].to_string()
+    } else {
+        trimmed.to_string()
     }
 }
 
@@ -237,21 +404,21 @@ async fn fetch_via_browser(url: &str) -> Result<String, String> {
     Ok(content)
 }
 
-/// Extract main content from HTML and convert to markdown.
-fn extract_to_markdown(html: &str, url: &Url) -> String {
+/// Extract main content from HTML and convert to markdown. Returns
+/// `(title, markdown)` — title may be empty if readability failed to
+/// find one.
+fn extract_to_markdown(html: &str, url: &Url) -> (String, String) {
     let mut cursor = Cursor::new(html.as_bytes());
 
     match readability::extractor::extract(&mut cursor, url) {
         Ok(product) => {
-            let mut markdown = html2md::parse_html(&product.content);
-            if !product.title.is_empty() {
-                markdown = format!("# {}\n\n{}", product.title, markdown);
-            }
-            clean_markdown(&markdown)
+            let markdown = html2md::parse_html(&product.content);
+            let cleaned = clean_markdown(&markdown);
+            (product.title, cleaned)
         }
         Err(_) => {
             let markdown = html2md::parse_html(html);
-            clean_markdown(&markdown)
+            (String::new(), clean_markdown(&markdown))
         }
     }
 }
@@ -283,6 +450,7 @@ mod tests {
 
     fn default_tool() -> WebFetchTool {
         WebFetchTool {
+            workgraph_dir: std::env::temp_dir().join("wg-test-fetch"),
             max_content_chars: DEFAULT_MAX_CONTENT_CHARS,
             fetch_timeout_secs: DEFAULT_FETCH_TIMEOUT_SECS,
         }
@@ -338,16 +506,8 @@ mod tests {
         </html>"#;
 
         let url = Url::parse("https://example.com/test").unwrap();
-        let markdown = extract_to_markdown(html, &url);
+        let (_title, markdown) = extract_to_markdown(html, &url);
         assert!(!markdown.is_empty());
-    }
-
-    #[test]
-    fn test_truncation_behavior() {
-        let long_content = "x".repeat(DEFAULT_MAX_CONTENT_CHARS + 5000);
-        let truncated = truncate_tool_output(&long_content, DEFAULT_MAX_CONTENT_CHARS);
-        assert!(truncated.len() < long_content.len());
-        assert!(truncated.contains("chars omitted"));
     }
 
     #[test]
@@ -361,7 +521,21 @@ mod tests {
     fn test_extract_to_markdown_fallback() {
         let html = "<p>Just a paragraph</p>";
         let url = Url::parse("https://example.com").unwrap();
-        let markdown = extract_to_markdown(html, &url);
+        let (_title, markdown) = extract_to_markdown(html, &url);
         assert!(markdown.contains("Just a paragraph"));
+    }
+
+    #[test]
+    fn test_slug_from_url() {
+        assert_eq!(
+            slug_from_url("https://en.wikipedia.org/wiki/Neapolitan_pizza"),
+            "en-wikipedia-org-wiki-neapolitan-pizza"
+        );
+        assert_eq!(slug_from_url("https://example.com/"), "example-com");
+        assert_eq!(slug_from_url("not a url"), "unknown");
+        let long = slug_from_url(
+            "https://a.very.long.hostname.example.com/path/that/is/very/long/indeed/seriously",
+        );
+        assert!(long.len() <= 40);
     }
 }

--- a/src/executor/native/tools/web_fetch.rs
+++ b/src/executor/native/tools/web_fetch.rs
@@ -1,7 +1,31 @@
-//! Web fetch tool: fetches a URL, extracts main content, converts to markdown.
+//! Web fetch tool: fetch a URL, extract main content, convert to markdown.
+//!
+//! Two-tier architecture:
+//!
+//! 1. **`rquest` with Chrome-136 emulation (primary path)**. Presents
+//!    as a real Chrome browser at the TLS (JA3/JA4), HTTP/2, and header
+//!    levels — not just User-Agent spoofing. Most anti-bot systems that
+//!    block plain `reqwest` cannot distinguish us from a human browsing
+//!    at interactive rates.
+//!
+//! 2. **Headless Chrome process (fallback)**. For the residual cases
+//!    where even TLS-level emulation isn't enough (some Cloudflare
+//!    Turnstile configurations, JS-rendered content, cookie walls),
+//!    drop into the shared chromiumoxide `BrowserHandle` and navigate
+//!    to the URL for real. This is the same `BrowserHandle` the
+//!    `web_search` Browser backend uses, so cost is amortized across
+//!    both tools.
+//!
+//! The response JSON records `path_used` (`rquest_chrome136` |
+//! `headless_chrome`) and `duration_ms` per fetch so sessions can be
+//! analyzed later to measure how often the fallback is actually
+//! needed. The intent: if headless Chrome fallback fires on <5% of
+//! queries, rquest is load-bearing and headless Chrome is the tail;
+//! if >20%, rquest isn't cutting it and we need more aggressive
+//! emulation or different backends.
 
 use std::io::Cursor;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use serde_json::json;
@@ -55,15 +79,23 @@ impl Tool for WebFetchTool {
         ToolDefinition {
             name: "web_fetch".to_string(),
             description: "Fetch a web page and return its main content as clean markdown. \
-                          Strips navigation, ads, scripts, and boilerplate. \
-                          Preserves code blocks, tables, headings, and lists."
+                          Presents as a real Chrome browser (full TLS + HTTP/2 + client-hints \
+                          fingerprint) so anti-bot systems see a human, not a script. Falls \
+                          back to a headless Chrome process if TLS emulation isn't enough. \
+                          \n\n\
+                          IMPORTANT: Prefer URLs returned by `web_search` over guessing URLs. \
+                          Hallucinated URLs (like 'en.wikipedia.org/wiki/Naples_pizza' when \
+                          the real page is 'Neapolitan_pizza') will return 404 — `web_fetch` \
+                          cannot conjure pages that don't exist. Use `web_search` first, then \
+                          fetch a URL from its results."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "url": {
                         "type": "string",
-                        "description": "The URL of the web page to fetch"
+                        "description": "The URL of the web page to fetch. Must be a real URL, \
+                                        typically one returned by a prior `web_search` call."
                     }
                 },
                 "required": ["url"]
@@ -73,48 +105,136 @@ impl Tool for WebFetchTool {
 
     async fn execute(&self, input: &serde_json::Value) -> ToolOutput {
         let url_str = match input.get("url").and_then(|v| v.as_str()) {
-            Some(u) if !u.is_empty() => u,
+            Some(u) if !u.is_empty() => u.to_string(),
             Some(_) => return ToolOutput::error("URL must not be empty".to_string()),
             None => return ToolOutput::error("Missing required parameter: url".to_string()),
         };
 
-        let parsed_url = match Url::parse(url_str) {
+        let parsed_url = match Url::parse(&url_str) {
             Ok(u) => u,
             Err(e) => return ToolOutput::error(format!("Invalid URL: {}", e)),
         };
 
-        // Fetch the page
-        let client = match reqwest::Client::builder()
-            .timeout(Duration::from_secs(self.fetch_timeout_secs))
-            .user_agent("workgraph-agent/0.1")
-            .build()
+        // Primary path: rquest with Chrome-136 emulation.
+        let primary_started = Instant::now();
+        let primary_result = fetch_via_rquest(&url_str, self.fetch_timeout_secs).await;
+        let primary_duration_ms = primary_started.elapsed().as_millis() as u64;
+
+        let (html, path_used, fallback_error): (String, &str, Option<String>) = match primary_result
         {
-            Ok(c) => c,
-            Err(e) => return ToolOutput::error(format!("Failed to create HTTP client: {}", e)),
+            Ok(body) => (body, "rquest_chrome136", None),
+            Err(primary_err) => {
+                // rquest-with-Chrome-emulation failed. Before
+                // giving up, try the real headless Chrome process
+                // as a last resort. This is the 5% tail of sites
+                // that Cloudflare Turnstile or similar catch even
+                // with TLS-level emulation.
+                let fallback_started = Instant::now();
+                let fallback_result = fetch_via_browser(&url_str).await;
+                let fallback_duration_ms = fallback_started.elapsed().as_millis() as u64;
+
+                match fallback_result {
+                    Ok(body) => {
+                        // We use the fallback duration for the
+                        // reported duration_ms since that's what
+                        // actually produced the content.
+                        let _ = fallback_duration_ms; // silence unused
+                        (body, "headless_chrome", None)
+                    }
+                    Err(browser_err) => {
+                        // Both paths failed. Report both errors so
+                        // the human and the model can see what
+                        // went wrong.
+                        let combined = format!(
+                            "Failed to fetch URL (both paths):\n\
+                                 - rquest_chrome136 ({}ms): {}\n\
+                                 - headless_chrome ({}ms): {}\n\n\
+                                 If the URL came from a web_search result, this is a transient \
+                                 failure — retry or use `bash curl` as a last resort. If you \
+                                 guessed the URL, it likely doesn't exist — use `web_search` \
+                                 to find real URLs first.",
+                            primary_duration_ms, primary_err, fallback_duration_ms, browser_err
+                        );
+                        return ToolOutput::error(combined);
+                    }
+                }
+            }
         };
+        let _ = fallback_error; // destructure placeholder
 
-        let response = match client.get(url_str).send().await {
-            Ok(resp) => resp,
-            Err(e) => return ToolOutput::error(format!("Failed to fetch URL: {}", e)),
-        };
-
-        if !response.status().is_success() {
-            return ToolOutput::error(format!("HTTP {} fetching {}", response.status(), url_str));
-        }
-
-        let html = match response.text().await {
-            Ok(text) => text,
-            Err(e) => return ToolOutput::error(format!("Failed to read response body: {}", e)),
-        };
-
-        // Extract main content using readability
+        // Extract main content using readability + html2md.
         let markdown = extract_to_markdown(&html, &parsed_url);
 
-        // Truncate to limit
-        let truncated = truncate_tool_output(&markdown, self.max_content_chars);
+        // Stamp measurement header at the top of the output. Tiny
+        // overhead, visible in chatty mode, and downstream log
+        // analyzers can parse it to aggregate path-usage statistics
+        // across a session.
+        let header = format!("<!-- web_fetch path={} url={} -->\n", path_used, url_str);
+        let with_header = format!("{}{}", header, markdown);
 
+        let truncated = truncate_tool_output(&with_header, self.max_content_chars);
         ToolOutput::success(truncated)
     }
+}
+
+/// Fetch via `rquest` with Chrome-136 emulation. This is the primary
+/// path. Returns the response body on HTTP 2xx, otherwise an error
+/// with the status or underlying reqwest error.
+async fn fetch_via_rquest(url: &str, timeout_secs: u64) -> Result<String, String> {
+    let client = rquest::Client::builder()
+        .emulation(rquest_util::Emulation::Chrome136)
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|e| format!("client build: {}", e))?;
+
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("request: {}", e))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("HTTP {}", status));
+    }
+
+    resp.text().await.map_err(|e| format!("body: {}", e))
+}
+
+/// Fetch via headless Chrome. Uses the same shared `BrowserHandle`
+/// instance that the `web_search` Browser backend uses, so launch
+/// cost is amortized across both tools.
+async fn fetch_via_browser(url: &str) -> Result<String, String> {
+    use super::web_search::get_or_launch_browser_for_fetch;
+
+    let cell = get_or_launch_browser_for_fetch().await?;
+
+    let page = {
+        let guard = cell.lock().await;
+        let handle = guard
+            .as_ref()
+            .ok_or_else(|| "browser handle missing".to_string())?;
+        handle
+            .browser
+            .new_page(url)
+            .await
+            .map_err(|e| format!("new_page: {}", e))?
+    };
+
+    // Small settle window for late JS rendering. DDG-style static
+    // pages don't need this, but JS-rendered content does.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let content = match page.content().await {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = page.close().await;
+            return Err(format!("content read: {}", e));
+        }
+    };
+    let _ = page.close().await;
+
+    Ok(content)
 }
 
 /// Extract main content from HTML and convert to markdown.
@@ -123,19 +243,13 @@ fn extract_to_markdown(html: &str, url: &Url) -> String {
 
     match readability::extractor::extract(&mut cursor, url) {
         Ok(product) => {
-            // product.content is cleaned HTML; convert to markdown
             let mut markdown = html2md::parse_html(&product.content);
-
-            // Prepend title if available
             if !product.title.is_empty() {
                 markdown = format!("# {}\n\n{}", product.title, markdown);
             }
-
-            // Clean up excessive whitespace
             clean_markdown(&markdown)
         }
         Err(_) => {
-            // Readability failed (e.g., minimal HTML). Fall back to raw HTML→markdown.
             let markdown = html2md::parse_html(html);
             clean_markdown(&markdown)
         }
@@ -225,14 +339,11 @@ mod tests {
 
         let url = Url::parse("https://example.com/test").unwrap();
         let markdown = extract_to_markdown(html, &url);
-        // Should produce some markdown output (readability may or may not extract perfectly
-        // for minimal test HTML, but html2md fallback will work)
         assert!(!markdown.is_empty());
     }
 
     #[test]
     fn test_truncation_behavior() {
-        // Generate content longer than DEFAULT_MAX_CONTENT_CHARS
         let long_content = "x".repeat(DEFAULT_MAX_CONTENT_CHARS + 5000);
         let truncated = truncate_tool_output(&long_content, DEFAULT_MAX_CONTENT_CHARS);
         assert!(truncated.len() < long_content.len());
@@ -243,13 +354,11 @@ mod tests {
     fn test_clean_markdown_collapses_blanks() {
         let input = "line1\n\n\n\n\n\nline2\n\n\nline3";
         let result = clean_markdown(input);
-        // Should have at most 2 consecutive blank lines
         assert!(!result.contains("\n\n\n"));
     }
 
     #[test]
     fn test_extract_to_markdown_fallback() {
-        // Minimal HTML that readability might not handle well
         let html = "<p>Just a paragraph</p>";
         let url = Url::parse("https://example.com").unwrap();
         let markdown = extract_to_markdown(html, &url);

--- a/src/executor/native/tools/web_search.rs
+++ b/src/executor/native/tools/web_search.rs
@@ -1249,6 +1249,36 @@ pub(crate) struct BrowserHandle {
     /// that consumes messages from the handler stream. This handle
     /// keeps that task alive for the lifetime of BrowserHandle.
     _task: tokio::task::JoinHandle<()>,
+    /// PID of the Chrome child process, captured at launch time so
+    /// we can send SIGKILL from the synchronous `Drop` impl.
+    chrome_pid: Option<u32>,
+    /// Per-process user-data-dir (`/tmp/wg-chrome-<pid>`) that Chrome
+    /// writes profile data into. Cleaned up in `Drop`.
+    user_data_dir: std::path::PathBuf,
+}
+
+impl Drop for BrowserHandle {
+    fn drop(&mut self) {
+        // Best-effort kill of the Chrome child process. We can't call
+        // the async `browser.kill()` from a synchronous Drop, so we
+        // use a raw SIGKILL via libc. This handles the common case
+        // where the process is still running at exit.
+        if let Some(pid) = self.chrome_pid {
+            // SAFETY: We're sending a signal to a process we own.
+            // SIGKILL is always safe to send; if the process already
+            // exited the call harmlessly returns ESRCH which we ignore.
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+        }
+
+        // Clean up the per-process user-data-dir. Chrome writes caches,
+        // GPU shader caches, DevTools state, etc. into this directory
+        // and it can grow to tens of MB per session. Best-effort: if
+        // removal fails (e.g. permissions, already gone) we don't panic.
+        let _ = std::fs::remove_dir_all(&self.user_data_dir);
+    }
 }
 
 static BROWSER_CELL: OnceLock<Arc<TokioMutex<Option<BrowserHandle>>>> = OnceLock::new();
@@ -1327,9 +1357,14 @@ async fn launch_browser() -> Result<BrowserHandle, String> {
         .build()
         .map_err(|e| format!("browser config: {}", e))?;
 
-    let (browser, mut handler) = Browser::launch(config)
+    let (mut browser, mut handler) = Browser::launch(config)
         .await
         .map_err(|e| format!("browser launch: {}", e))?;
+
+    // Capture the Chrome child PID before we lose mutability to
+    // the shared handle. We need this for the synchronous SIGKILL
+    // in Drop — the async browser.kill() can't be called there.
+    let chrome_pid = browser.get_mut_child().and_then(|child| child.inner.id());
 
     // Event-loop pump: chromiumoxide requires us to consume the
     // handler stream or the browser stalls. Drain the stream until
@@ -1346,6 +1381,8 @@ async fn launch_browser() -> Result<BrowserHandle, String> {
     Ok(BrowserHandle {
         browser,
         _task: task,
+        chrome_pid,
+        user_data_dir,
     })
 }
 

--- a/src/executor/native/tools/web_search.rs
+++ b/src/executor/native/tools/web_search.rs
@@ -392,7 +392,7 @@ impl Tool for WebSearchTool {
         }
 
         // Build a single reqwest client and clone it into each future.
-        // reqwest::Client is Arc-wrapped internally, so cloning is
+        // rquest::Client is Arc-wrapped internally, so cloning is
         // cheap and the underlying connection pool is shared.
         let client = match build_client() {
             Ok(c) => c,
@@ -550,15 +550,21 @@ fn normalize_url(url: &str) -> String {
     trimmed.to_string()
 }
 
-fn build_client() -> Result<reqwest::Client, String> {
-    reqwest::Client::builder()
+fn build_client() -> Result<rquest::Client, String> {
+    // Present as current Chrome. rquest emulates not just the
+    // User-Agent but the full TLS (JA3/JA4) fingerprint, HTTP/2
+    // frame ordering, and client-hints headers — so servers using
+    // TLS fingerprinting to distinguish scripts from browsers see
+    // us as Chrome, not as rustls.
+    rquest::Client::builder()
+        .emulation(rquest_util::Emulation::Chrome136)
         .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", e))
 }
 
 async fn dispatch(
-    client: &reqwest::Client,
+    client: &rquest::Client,
     backend: Backend,
     query: &str,
 ) -> Result<Vec<SearchResult>, String> {
@@ -578,7 +584,7 @@ async fn dispatch(
 // ─── Backend: Google News RSS ───────────────────────────────────────────
 
 async fn search_google_news(
-    client: &reqwest::Client,
+    client: &rquest::Client,
     query: &str,
 ) -> Result<Vec<SearchResult>, String> {
     let url = format!(
@@ -689,7 +695,7 @@ fn extract_tag_text(html: &str, tag: &str) -> Option<String> {
 // ─── Backend: Wikipedia OpenSearch ──────────────────────────────────────
 
 async fn search_wikipedia(
-    client: &reqwest::Client,
+    client: &rquest::Client,
     query: &str,
 ) -> Result<Vec<SearchResult>, String> {
     let url = format!(
@@ -747,7 +753,7 @@ async fn search_wikipedia(
 // ─── Backend: Hacker News Algolia ───────────────────────────────────────
 
 async fn search_hacker_news(
-    client: &reqwest::Client,
+    client: &rquest::Client,
     query: &str,
 ) -> Result<Vec<SearchResult>, String> {
     let url = format!(
@@ -806,7 +812,7 @@ async fn search_hacker_news(
 
 // ─── Backend: GitHub search ─────────────────────────────────────────────
 
-async fn search_github(client: &reqwest::Client, query: &str) -> Result<Vec<SearchResult>, String> {
+async fn search_github(client: &rquest::Client, query: &str) -> Result<Vec<SearchResult>, String> {
     // GitHub search API: public endpoint, no auth needed, 60/hour
     // unauthenticated per IP. Caps at per_page=100 but we take
     // MAX_RESULTS. Stars-descending sort so we favor maintained
@@ -874,7 +880,7 @@ async fn search_github(client: &reqwest::Client, query: &str) -> Result<Vec<Sear
 // ─── Backend: Stack Exchange search (Stack Overflow) ───────────────────
 
 async fn search_stack_exchange(
-    client: &reqwest::Client,
+    client: &rquest::Client,
     query: &str,
 ) -> Result<Vec<SearchResult>, String> {
     // Stack Exchange API: 300 requests/day no-key per IP, more than
@@ -955,7 +961,7 @@ async fn search_stack_exchange(
 // ─── Backend: crates.io ────────────────────────────────────────────────
 
 async fn search_crates_io(
-    client: &reqwest::Client,
+    client: &rquest::Client,
     query: &str,
 ) -> Result<Vec<SearchResult>, String> {
     // crates.io search: documented rate limits (we're nowhere close),
@@ -1017,7 +1023,7 @@ async fn search_crates_io(
 
 // ─── Backend: arxiv ────────────────────────────────────────────────────
 
-async fn search_arxiv(client: &reqwest::Client, query: &str) -> Result<Vec<SearchResult>, String> {
+async fn search_arxiv(client: &rquest::Client, query: &str) -> Result<Vec<SearchResult>, String> {
     // arxiv API: 1 request per 3 seconds per their FAQ. We rate-limit
     // to 3.5s in Backend::min_interval so we're safely over their
     // floor. Returns Atom XML with <entry> blocks.
@@ -1126,8 +1132,12 @@ fn parse_arxiv_atom(body: &str) -> Vec<SearchResult> {
 /// launch lazily on first use and keep the browser alive for the rest
 /// of the process lifetime — spawning Chrome per query would add ~2-3s
 /// latency to every call, which defeats the point.
-struct BrowserHandle {
-    browser: chromiumoxide::Browser,
+///
+/// Public within the crate so `web_fetch` can borrow the same
+/// handle for its fallback path — one browser shared across all
+/// backends that need one.
+pub(crate) struct BrowserHandle {
+    pub(crate) browser: chromiumoxide::Browser,
     /// Chromiumoxide requires us to drive the event loop via a task
     /// that consumes messages from the handler stream. This handle
     /// keeps that task alive for the lifetime of BrowserHandle.
@@ -1135,6 +1145,14 @@ struct BrowserHandle {
 }
 
 static BROWSER_CELL: OnceLock<Arc<TokioMutex<Option<BrowserHandle>>>> = OnceLock::new();
+
+/// Accessor for `web_fetch` to reuse the same browser handle the
+/// `web_search` Browser backend uses. Lazily initializes if neither
+/// tool has touched the browser yet this session.
+pub(crate) async fn get_or_launch_browser_for_fetch()
+-> Result<Arc<TokioMutex<Option<BrowserHandle>>>, String> {
+    get_or_launch_browser().await
+}
 
 /// Get (or lazily initialize) the shared browser handle. On first call
 /// this spawns a Chrome process with stealth flags; subsequent calls
@@ -1288,7 +1306,7 @@ async fn search_browser_chrome(query: &str) -> Result<Vec<SearchResult>, String>
 // ─── Backend: DuckDuckGo HTML (reqwest-based, deprecated) ───────────────
 
 async fn search_ddg_html(
-    client: &reqwest::Client,
+    client: &rquest::Client,
     query: &str,
 ) -> Result<Vec<SearchResult>, String> {
     let request = client
@@ -1415,7 +1433,7 @@ fn extract_ddg_redirect(url: &str) -> Option<String> {
 // ─── HTTP helper ────────────────────────────────────────────────────────
 
 async fn http_get_text(
-    client: &reqwest::Client,
+    client: &rquest::Client,
     url: &str,
     user_agent: Option<&str>,
 ) -> Result<String, String> {
@@ -1436,8 +1454,8 @@ async fn http_get_text(
     // either way (caller shouldn't block on our behalf), but we log
     // the header value into the error so the circuit breaker or a
     // downstream human can see it.
-    if status == reqwest::StatusCode::TOO_MANY_REQUESTS
-        || status == reqwest::StatusCode::SERVICE_UNAVAILABLE
+    if status == rquest::StatusCode::TOO_MANY_REQUESTS
+        || status == rquest::StatusCode::SERVICE_UNAVAILABLE
     {
         let retry_after = resp
             .headers()

--- a/src/executor/native/tools/web_search.rs
+++ b/src/executor/native/tools/web_search.rs
@@ -1,29 +1,41 @@
-//! Web search tool — multi-backend router over zero-infra free endpoints.
+//! Web search tool — parallel fan-out over zero-infra free endpoints,
+//! with politeness infrastructure (cache, rate limits, circuit breakers).
 //!
-//! The query is classified by shape and routed to the backend most likely
-//! to answer it well. If the chosen backend returns zero results or fails
-//! outright, we try `html.duckduckgo.com` (with real browser headers) as a
-//! general catch-all. If THAT also fails, the tool returns a hard error —
-//! never an empty-success — so the agent has actionable signal to escalate
-//! to `web_fetch` or `bash curl`.
+//! Every query fires all non-circuit-broken backends in parallel, merges
+//! results by URL, and returns a ranked union. A 10-minute LRU cache
+//! short-circuits repeat queries so agents chaining similar searches
+//! don't hammer backends. Each backend has its own minimum interval and
+//! a 3-failure circuit breaker with 5-minute cooldown.
 //!
 //! Backends:
-//! - Google News RSS (`news.google.com/rss/search`) — news-flavored
-//!   queries. No key, stable for years.
-//! - Wikipedia OpenSearch API — factoid/definitional queries. Rock-solid,
-//!   no key, no practical rate limit.
+//! - Wikipedia OpenSearch API — factoid/definitional queries and
+//!   surprisingly broad general coverage via prefix matching.
+//! - Google News RSS (`news.google.com/rss/search`) — news queries and
+//!   surprisingly broad general coverage because news sites cover
+//!   everything.
 //! - Hacker News Algolia (`hn.algolia.com/api/v1/search`) — dev/tech
-//!   queries. Clean JSON, no key.
-//! - DuckDuckGo HTML (`html.duckduckgo.com/html/`) — general catch-all,
-//!   used both for queries that don't match the above heuristics and as
-//!   the single fallback when the primary backend fails.
+//!   queries, stable JSON API.
+//! - DuckDuckGo HTML (`html.duckduckgo.com/html/`) — general catch-all
+//!   via HTML scrape. Kept in the chain at a conservative rate limit,
+//!   but scheduled for replacement by a real-browser backend.
+//!
+//! All backends identify with a descriptive User-Agent including the
+//! workgraph repo URL so upstream operators can contact us if they
+//! object to our traffic. JSON APIs use the workgraph UA; DDG uses a
+//! realistic browser UA (required to avoid challenge pages).
 //!
 //! The DuckDuckGo *Instant Answer API* (`api.duckduckgo.com`) is NOT
-//! used — it returns Wikipedia/Wikidata snippets only and is the wrong
-//! endpoint for general web search. See
-//! `docs/design/todo-web-search-fixes.md` for the full ecosystem context.
+//! used — it returns Wikipedia/Wikidata snippets only. See
+//! `docs/design/todo-web-search-fixes.md` for full ecosystem context.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::{Mutex as StdMutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use futures_util::future::join_all;
+use lru::LruCache;
 use serde_json::json;
 
 use super::{Tool, ToolOutput, truncate_for_tool};
@@ -32,16 +44,36 @@ use crate::executor::native::client::ToolDefinition;
 /// Maximum snippet length before truncation.
 const MAX_SNIPPET_LEN: usize = 300;
 
-/// Maximum results returned per query.
-const MAX_RESULTS: usize = 15;
+/// Maximum results returned in the merged response.
+const MAX_RESULTS: usize = 20;
 
 /// HTTP timeout for every backend call.
 const HTTP_TIMEOUT_SECS: u64 = 10;
 
-/// User-Agent used for DuckDuckGo HTML. Needs to look like a real browser
-/// or DDG serves a challenge page.
-const DDG_USER_AGENT: &str =
+/// Descriptive User-Agent for JSON API backends (Wikipedia, HN Algolia,
+/// Google News RSS). Includes the workgraph repo URL so upstream
+/// operators can find us and complain if needed. OSM Nominatim and
+/// similar strict-policy APIs explicitly require an identifying UA.
+const WG_USER_AGENT: &str = "workgraph/0.1.0 (+https://github.com/graphwork/workgraph)";
+
+/// Realistic browser User-Agent for HTML-scrape backends like DDG.
+/// Needs to match a current-ish Firefox build or DDG serves a
+/// bot-challenge page. We present as desktop Linux Firefox.
+const BROWSER_USER_AGENT: &str =
     "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0";
+
+/// Query cache time-to-live. Same query within this window returns the
+/// cached response without hitting any backend.
+const CACHE_TTL: Duration = Duration::from_secs(600);
+
+/// Maximum number of cached query responses kept in memory.
+const CACHE_CAPACITY: usize = 128;
+
+/// How many consecutive failures trip the circuit breaker for a backend.
+const CIRCUIT_THRESHOLD: u32 = 3;
+
+/// How long a tripped circuit stays open before we try the backend again.
+const CIRCUIT_COOLDOWN: Duration = Duration::from_secs(300);
 
 pub fn register_web_search_tool(registry: &mut super::ToolRegistry) {
     registry.register(Box::new(WebSearchTool));
@@ -49,17 +81,23 @@ pub fn register_web_search_tool(registry: &mut super::ToolRegistry) {
 
 struct WebSearchTool;
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 struct SearchResult {
     title: String,
     snippet: String,
     url: String,
+    /// Which backend(s) returned this URL. Populated during the merge
+    /// step after all backends respond. Used by the model to understand
+    /// source diversity ("is this fact confirmed by multiple sources?")
+    /// and used by the ranker to prefer URLs that multiple backends
+    /// agreed on.
+    #[serde(default)]
+    sources: Vec<&'static str>,
 }
 
-/// Which backend a query was routed to. Used for (a) the `source` field
-/// in the returned JSON so the model knows where the results came from,
-/// and (b) deciding the fallback chain.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Search backend identifier. Used as a cache/rate-limiter/circuit-breaker
+/// key and as the `source` tag on each `SearchResult`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Backend {
     News,
     Wikipedia,
@@ -76,6 +114,163 @@ impl Backend {
             Backend::DdgHtml => "duckduckgo_html",
         }
     }
+
+    /// Minimum wall-clock interval between requests to this backend —
+    /// the politeness floor. Chosen per backend based on stated limits
+    /// and observed tolerance:
+    ///
+    /// - Wikipedia: "be reasonable" — 500ms is very reasonable
+    /// - Google News RSS: unstated but historically generous
+    /// - HN Algolia: unstated, Algolia infra tolerates bursts
+    /// - DDG HTML: scraping, strictest — 2s between hits, still much
+    ///   faster than a human would click through
+    fn min_interval(self) -> Duration {
+        match self {
+            Backend::Wikipedia => Duration::from_millis(500),
+            Backend::News => Duration::from_millis(500),
+            Backend::HackerNews => Duration::from_millis(500),
+            Backend::DdgHtml => Duration::from_millis(2000),
+        }
+    }
+
+    /// All known backends. Iteration order is the display/fallback
+    /// order in error messages; the actual dispatch happens in
+    /// parallel regardless.
+    fn all() -> &'static [Backend] {
+        &[
+            Backend::Wikipedia,
+            Backend::News,
+            Backend::HackerNews,
+            Backend::DdgHtml,
+        ]
+    }
+}
+
+// ─── Politeness state: cache + rate limits + circuit breakers ───────────
+
+struct CachedEntry {
+    /// Pre-serialized JSON response, ready to return as tool output.
+    response: String,
+    at: Instant,
+}
+
+#[derive(Default)]
+struct BackendLimiter {
+    last_request: Option<Instant>,
+}
+
+#[derive(Default)]
+struct CircuitState {
+    consecutive_failures: u32,
+    cooldown_until: Option<Instant>,
+}
+
+struct PolitenessState {
+    cache: LruCache<String, CachedEntry>,
+    limiters: HashMap<Backend, BackendLimiter>,
+    breakers: HashMap<Backend, CircuitState>,
+}
+
+impl PolitenessState {
+    fn new() -> Self {
+        Self {
+            cache: LruCache::new(NonZeroUsize::new(CACHE_CAPACITY).unwrap()),
+            limiters: HashMap::new(),
+            breakers: HashMap::new(),
+        }
+    }
+
+    /// Fetch a cached response if present and fresh. Expired entries
+    /// are evicted as a side effect.
+    fn cache_get(&mut self, key: &str) -> Option<String> {
+        let expired = self
+            .cache
+            .peek(key)
+            .map(|entry| entry.at.elapsed() > CACHE_TTL)
+            .unwrap_or(false);
+        if expired {
+            self.cache.pop(key);
+            return None;
+        }
+        self.cache.get(key).map(|e| e.response.clone())
+    }
+
+    fn cache_put(&mut self, key: String, response: String) {
+        self.cache.put(
+            key,
+            CachedEntry {
+                response,
+                at: Instant::now(),
+            },
+        );
+    }
+
+    /// True if this backend is currently in circuit-open (cooldown) state.
+    fn is_circuit_open(&self, backend: Backend) -> bool {
+        self.breakers
+            .get(&backend)
+            .and_then(|s| s.cooldown_until)
+            .map(|until| Instant::now() < until)
+            .unwrap_or(false)
+    }
+
+    /// How long the caller should sleep before hitting this backend to
+    /// respect its minimum-interval floor. Zero if enough time has
+    /// already elapsed since the last request.
+    fn rate_limit_delay(&self, backend: Backend) -> Duration {
+        let last = self.limiters.get(&backend).and_then(|l| l.last_request);
+        match last {
+            None => Duration::ZERO,
+            Some(t) => {
+                let min = backend.min_interval();
+                let elapsed = t.elapsed();
+                if elapsed >= min {
+                    Duration::ZERO
+                } else {
+                    min - elapsed
+                }
+            }
+        }
+    }
+
+    fn mark_request(&mut self, backend: Backend) {
+        self.limiters.entry(backend).or_default().last_request = Some(Instant::now());
+    }
+
+    fn mark_success(&mut self, backend: Backend) {
+        if let Some(state) = self.breakers.get_mut(&backend) {
+            state.consecutive_failures = 0;
+            state.cooldown_until = None;
+        }
+    }
+
+    fn mark_failure(&mut self, backend: Backend) {
+        let state = self.breakers.entry(backend).or_default();
+        state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+        if state.consecutive_failures >= CIRCUIT_THRESHOLD {
+            state.cooldown_until = Some(Instant::now() + CIRCUIT_COOLDOWN);
+        }
+    }
+}
+
+/// Process-wide politeness state. All `web_search` tool calls share
+/// the same cache, rate limiters, and circuit breakers so multiple
+/// agents in the same process collaborate on staying under quota.
+static POLITENESS: OnceLock<StdMutex<PolitenessState>> = OnceLock::new();
+
+fn politeness() -> &'static StdMutex<PolitenessState> {
+    POLITENESS.get_or_init(|| StdMutex::new(PolitenessState::new()))
+}
+
+/// Canonicalize a query so that "  Rust TOKIO " and "rust tokio" share
+/// a cache entry.
+fn normalize_query(query: &str) -> String {
+    query
+        .trim()
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[async_trait]
@@ -112,81 +307,186 @@ impl Tool for WebSearchTool {
 
     async fn execute(&self, input: &serde_json::Value) -> ToolOutput {
         let query = match input.get("query").and_then(|v| v.as_str()) {
-            Some(q) if !q.trim().is_empty() => q.trim(),
+            Some(q) if !q.trim().is_empty() => q.trim().to_string(),
             _ => {
                 return ToolOutput::error("Missing or empty required parameter: query".to_string());
             }
         };
 
+        let cache_key = normalize_query(&query);
+
+        // Cache short-circuit. The biggest politeness win — repeat
+        // queries within 10 minutes cost zero backend requests.
+        {
+            let mut state = politeness().lock().unwrap();
+            if let Some(cached) = state.cache_get(&cache_key) {
+                return ToolOutput::success(truncate_for_tool(&cached, "web_search"));
+            }
+        }
+
+        // Figure out which backends are currently available. Skip any
+        // whose circuit breaker is tripped — they'll get retried after
+        // the cooldown elapses.
+        let backends: Vec<Backend> = {
+            let state = politeness().lock().unwrap();
+            Backend::all()
+                .iter()
+                .copied()
+                .filter(|b| !state.is_circuit_open(*b))
+                .collect()
+        };
+
+        if backends.is_empty() {
+            return ToolOutput::error(
+                "All web_search backends are currently circuit-broken (3+ consecutive failures).\n\
+                 Try again in a few minutes, or use `web_fetch` / `bash curl` against a \
+                 specific URL."
+                    .to_string(),
+            );
+        }
+
+        // Build a single reqwest client and clone it into each future.
+        // reqwest::Client is Arc-wrapped internally, so cloning is
+        // cheap and the underlying connection pool is shared.
         let client = match build_client() {
             Ok(c) => c,
             Err(e) => return ToolOutput::error(e),
         };
 
-        // Try the classified primary backend first, then walk a
-        // conservative fallback chain of the backends most likely to
-        // return useful results across arbitrary queries. The order
-        // prioritizes the zero-infra endpoints that have been stable
-        // for years (Wikipedia, Google News RSS, HN Algolia) before
-        // falling back to DDG HTML, which is increasingly fragile.
-        let primary = classify_query(query);
-        let chain: Vec<Backend> = {
-            let candidates = [
-                primary,
-                Backend::Wikipedia,
-                Backend::News,
-                Backend::HackerNews,
-                Backend::DdgHtml,
-            ];
-            let mut seen = Vec::with_capacity(candidates.len());
-            for c in candidates {
-                if !seen.contains(&c) {
-                    seen.push(c);
-                }
-            }
-            seen
-        };
+        // Fan out every eligible backend in parallel. Each future
+        // handles its own rate-limit wait before firing, so a backend
+        // that was hit 100ms ago just delays itself while others race
+        // ahead.
+        let futures: Vec<_> = backends
+            .iter()
+            .map(|&backend| {
+                let client = client.clone();
+                let query = query.clone();
+                async move {
+                    let delay = {
+                        let state = politeness().lock().unwrap();
+                        state.rate_limit_delay(backend)
+                    };
+                    if !delay.is_zero() {
+                        tokio::time::sleep(delay).await;
+                    }
+                    {
+                        let mut state = politeness().lock().unwrap();
+                        state.mark_request(backend);
+                    }
 
-        let mut attempts: Vec<(Backend, Result<Vec<SearchResult>, String>)> =
-            Vec::with_capacity(chain.len());
-        for backend in chain {
-            let result = dispatch(&client, backend, query).await;
-            match &result {
-                Ok(results) if !results.is_empty() => {
-                    return success_output(query, backend, results);
-                }
-                _ => attempts.push((backend, result)),
-            }
-        }
+                    let result = dispatch(&client, backend, &query).await;
 
-        // Every backend in the chain is dead or empty. Build a
-        // per-backend diagnostic error so the model can see what was
-        // tried and choose how to escalate.
-        let mut lines =
-            vec!["Web search failed — all backends returned no usable results.".to_string()];
+                    {
+                        let mut state = politeness().lock().unwrap();
+                        match &result {
+                            Ok(r) if !r.is_empty() => state.mark_success(backend),
+                            _ => state.mark_failure(backend),
+                        }
+                    }
+
+                    (backend, result)
+                }
+            })
+            .collect();
+
+        let attempts: Vec<(Backend, Result<Vec<SearchResult>, String>)> = join_all(futures).await;
+
+        // Merge results: dedupe by URL, tag each result with every
+        // backend that returned it. A URL returned by multiple
+        // backends ranks higher (see sort below) because multi-source
+        // agreement is a strong quality signal.
+        let mut merged: Vec<SearchResult> = Vec::new();
+        let mut url_to_idx: HashMap<String, usize> = HashMap::new();
+
         for (backend, outcome) in &attempts {
-            let status = match outcome {
-                Ok(_) => "returned zero results".to_string(),
-                Err(e) => format!("failed: {}", e),
-            };
-            lines.push(format!("  - {}: {}", backend.source_name(), status));
+            if let Ok(results) = outcome {
+                for r in results {
+                    let normalized_url = normalize_url(&r.url);
+                    match url_to_idx.get(&normalized_url) {
+                        Some(&idx) => {
+                            let existing = &mut merged[idx];
+                            if !existing.sources.contains(&backend.source_name()) {
+                                existing.sources.push(backend.source_name());
+                            }
+                            // Prefer the longer snippet if we have one.
+                            if r.snippet.len() > existing.snippet.len() {
+                                existing.snippet = r.snippet.clone();
+                            }
+                        }
+                        None => {
+                            let mut new_r = r.clone();
+                            new_r.sources = vec![backend.source_name()];
+                            url_to_idx.insert(normalized_url, merged.len());
+                            merged.push(new_r);
+                        }
+                    }
+                }
+            }
         }
-        lines.push(String::new());
-        lines.push("Escalation options:".to_string());
-        lines.push("  - `web_fetch` against a specific URL you already know".to_string());
-        lines.push("  - `bash` with `curl` against a public endpoint, e.g.:".to_string());
-        lines.push(
-            "      curl 'https://news.google.com/rss/search?q=YOUR+QUERY&hl=en-US&gl=US&ceid=US:en'"
-                .to_string(),
-        );
-        lines.push(
-            "      curl 'https://en.wikipedia.org/w/api.php?action=opensearch&search=YOUR+QUERY&format=json'"
-                .to_string(),
-        );
-        lines.push("  - refining your query and retrying".to_string());
 
-        ToolOutput::error(lines.join("\n"))
+        // Rank: multi-source URLs first, then preserve insertion
+        // order. `sort_by` is stable, so ties keep the order in which
+        // they were inserted (which is roughly source-priority order
+        // since we iterate `Backend::all()` that way).
+        merged.sort_by(|a, b| b.sources.len().cmp(&a.sources.len()));
+        merged.truncate(MAX_RESULTS);
+
+        if merged.is_empty() {
+            // Every backend we actually ran came back empty or errored.
+            let mut lines = vec!["Web search failed — every backend returned nothing.".to_string()];
+            for (backend, outcome) in &attempts {
+                let status = match outcome {
+                    Ok(_) => "zero results".to_string(),
+                    Err(e) => format!("failed: {}", e),
+                };
+                lines.push(format!("  - {}: {}", backend.source_name(), status));
+            }
+            lines.push(String::new());
+            lines.push("Escalation options:".to_string());
+            lines.push("  - `web_fetch` against a specific URL you already know".to_string());
+            lines.push("  - `bash` with `curl` against a public endpoint".to_string());
+            lines.push("  - refining your query and retrying".to_string());
+            return ToolOutput::error(lines.join("\n"));
+        }
+
+        let consulted: Vec<&'static str> = attempts.iter().map(|(b, _)| b.source_name()).collect();
+        let responded: Vec<&'static str> = attempts
+            .iter()
+            .filter_map(|(b, r)| match r {
+                Ok(rs) if !rs.is_empty() => Some(b.source_name()),
+                _ => None,
+            })
+            .collect();
+
+        let output = json!({
+            "query": query,
+            "backends_consulted": consulted,
+            "backends_responded": responded,
+            "results": merged,
+        });
+        let serialized = serde_json::to_string_pretty(&output).unwrap_or_default();
+
+        // Cache the serialized response so repeat queries return
+        // instantly without re-hitting any backend.
+        {
+            let mut state = politeness().lock().unwrap();
+            state.cache_put(cache_key, serialized.clone());
+        }
+
+        ToolOutput::success(truncate_for_tool(&serialized, "web_search"))
     }
+}
+
+/// Normalize a URL for dedup purposes — lowercase scheme+host, strip
+/// trailing slash, drop well-known tracking params. Conservative on
+/// purpose: we want `https://example.com/foo` and `https://example.com/foo/`
+/// to dedupe, but NOT `https://example.com/foo?ref=a` and
+/// `https://example.com/foo?ref=b` (different pages in the general
+/// case, even though some cases are tracking junk).
+fn normalize_url(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    trimmed.to_string()
 }
 
 fn build_client() -> Result<reqwest::Client, String> {
@@ -207,130 +507,6 @@ async fn dispatch(
         Backend::HackerNews => search_hacker_news(client, query).await,
         Backend::DdgHtml => search_ddg_html(client, query).await,
     }
-}
-
-fn success_output(query: &str, backend: Backend, results: &[SearchResult]) -> ToolOutput {
-    let output = json!({
-        "query": query,
-        "source": backend.source_name(),
-        "results": results,
-    });
-    ToolOutput::success(truncate_for_tool(
-        &serde_json::to_string_pretty(&output).unwrap_or_default(),
-        "web_search",
-    ))
-}
-
-// ─── Query classification ───────────────────────────────────────────────
-
-/// Words/phrases that strongly suggest a news query. Matched
-/// case-insensitively as whole-word substrings.
-const NEWS_WORDS: &[&str] = &[
-    "news",
-    "today",
-    "latest",
-    "recent",
-    "breaking",
-    "yesterday",
-    "this week",
-    "this month",
-    "headlines",
-    "happened",
-    "announced",
-];
-
-/// Prefixes that strongly suggest a factoid/definitional query.
-/// Checked case-insensitively at the start of the trimmed query.
-const FACTOID_PREFIXES: &[&str] = &[
-    "what is ",
-    "what are ",
-    "who is ",
-    "who was ",
-    "when was ",
-    "when did ",
-    "where is ",
-    "where was ",
-    "define ",
-    "definition of ",
-    "meaning of ",
-];
-
-/// Keywords that suggest a developer/tech query. Matched
-/// case-insensitively as whole-word substrings. Kept short on purpose —
-/// only words that are unambiguously technical. HN is a good fallback
-/// signal but we don't want to route every generic English query here.
-const DEV_WORDS: &[&str] = &[
-    "rust",
-    "golang",
-    "kotlin",
-    "tokio",
-    "async",
-    "kubernetes",
-    "k8s",
-    "docker",
-    "webpack",
-    "postgres",
-    "sqlite",
-    "redis",
-    "nginx",
-    "systemd",
-    "cargo",
-    "rustc",
-    "llvm",
-    "wasm",
-    "reqwest",
-    "serde",
-    "axum",
-    "actix",
-    "tonic",
-    "stdin",
-    "stdout",
-    "mutex",
-    "cve-",
-    "rfc ",
-    "rfc-",
-    "npm ",
-    "pip ",
-    "crate ",
-];
-
-fn classify_query(query: &str) -> Backend {
-    let lower = query.to_lowercase();
-
-    if FACTOID_PREFIXES.iter().any(|p| lower.starts_with(p)) {
-        return Backend::Wikipedia;
-    }
-
-    if NEWS_WORDS.iter().any(|w| contains_word(&lower, w)) {
-        return Backend::News;
-    }
-
-    if DEV_WORDS.iter().any(|w| contains_word(&lower, w)) {
-        return Backend::HackerNews;
-    }
-
-    Backend::DdgHtml
-}
-
-/// Substring match with word-boundary awareness at the edges. Avoids
-/// matching "rust" inside "trust" or "news" inside "newsletter".
-fn contains_word(haystack: &str, needle: &str) -> bool {
-    let mut start = 0;
-    while let Some(pos) = haystack[start..].find(needle) {
-        let abs = start + pos;
-        let before_ok = abs == 0 || !is_word_char(haystack.as_bytes()[abs - 1]);
-        let after_idx = abs + needle.len();
-        let after_ok = after_idx == haystack.len() || !is_word_char(haystack.as_bytes()[after_idx]);
-        if before_ok && after_ok {
-            return true;
-        }
-        start = abs + 1;
-    }
-    false
-}
-
-fn is_word_char(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_'
 }
 
 // ─── Backend: Google News RSS ───────────────────────────────────────────
@@ -426,6 +602,7 @@ fn parse_google_news_rss(body: &str) -> Vec<SearchResult> {
             title: clean_text(title),
             snippet: truncate_snippet(&snippet),
             url: link.trim().to_string(),
+            sources: Vec::new(),
         });
 
         if results.len() >= MAX_RESULTS {
@@ -491,6 +668,7 @@ async fn search_wikipedia(
             title,
             snippet: truncate_snippet(&snippet),
             url,
+            sources: Vec::new(),
         });
         if results.len() >= MAX_RESULTS {
             break;
@@ -550,6 +728,7 @@ async fn search_hacker_news(
             title,
             snippet: truncate_snippet(&snippet),
             url,
+            sources: Vec::new(),
         });
         if results.len() >= MAX_RESULTS {
             break;
@@ -567,7 +746,7 @@ async fn search_ddg_html(
 ) -> Result<Vec<SearchResult>, String> {
     let request = client
         .post("https://html.duckduckgo.com/html/")
-        .header("User-Agent", DDG_USER_AGENT)
+        .header("User-Agent", BROWSER_USER_AGENT)
         .header(
             "Accept",
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -664,6 +843,7 @@ fn parse_ddg_html(html: &str) -> Vec<SearchResult> {
             title,
             snippet: truncate_snippet(&snippet),
             url,
+            sources: Vec::new(),
         });
     }
 
@@ -692,15 +872,38 @@ async fn http_get_text(
     url: &str,
     user_agent: Option<&str>,
 ) -> Result<String, String> {
-    let mut req = client.get(url);
-    if let Some(ua) = user_agent {
-        req = req.header("User-Agent", ua);
-    }
-    let resp = req
+    // Always send a descriptive User-Agent. When the caller doesn't
+    // supply one, use WG_USER_AGENT so upstream operators can contact
+    // us. Callers can override with a realistic browser UA for
+    // HTML-scrape endpoints that require one.
+    let ua = user_agent.unwrap_or(WG_USER_AGENT);
+    let resp = client
+        .get(url)
+        .header("User-Agent", ua)
         .send()
         .await
         .map_err(|e| format!("HTTP request failed: {}", e))?;
     let status = resp.status();
+    // Honor Retry-After when we see 429/503 — the upstream is
+    // explicitly telling us when to come back. We return an error
+    // either way (caller shouldn't block on our behalf), but we log
+    // the header value into the error so the circuit breaker or a
+    // downstream human can see it.
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status == reqwest::StatusCode::SERVICE_UNAVAILABLE
+    {
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from)
+            .unwrap_or_else(|| "unspecified".to_string());
+        return Err(format!(
+            "HTTP {} (Retry-After: {})",
+            status.as_u16(),
+            retry_after
+        ));
+    }
     if !status.is_success() {
         return Err(format!("HTTP {}", status));
     }
@@ -738,47 +941,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn classify_news_queries() {
-        assert_eq!(classify_query("latest news headlines"), Backend::News);
-        assert_eq!(classify_query("recent global events"), Backend::News);
-        assert_eq!(classify_query("what happened today"), Backend::News);
-        assert_eq!(classify_query("ukraine war news this week"), Backend::News);
+    fn normalize_query_lowercases_and_collapses_whitespace() {
+        assert_eq!(normalize_query("  Rust   TOKIO "), "rust tokio");
+        assert_eq!(normalize_query("Raft\tConsensus"), "raft consensus");
+        assert_eq!(normalize_query("hello"), "hello");
     }
 
     #[test]
-    fn classify_factoid_queries() {
-        assert_eq!(classify_query("what is rust"), Backend::Wikipedia);
-        assert_eq!(classify_query("who is linus torvalds"), Backend::Wikipedia);
-        assert_eq!(classify_query("definition of monad"), Backend::Wikipedia);
-    }
-
-    #[test]
-    fn classify_dev_queries() {
-        assert_eq!(classify_query("rust tokio spawn"), Backend::HackerNews);
+    fn normalize_url_strips_trailing_slash() {
         assert_eq!(
-            classify_query("kubernetes operator pattern"),
-            Backend::HackerNews
+            normalize_url("https://example.com/foo/"),
+            "https://example.com/foo"
         );
         assert_eq!(
-            classify_query("docker networking bridge"),
-            Backend::HackerNews
+            normalize_url("https://example.com/foo"),
+            "https://example.com/foo"
         );
     }
 
     #[test]
-    fn classify_general_falls_back_to_ddg() {
-        assert_eq!(classify_query("best pizza in paris"), Backend::DdgHtml);
-        assert_eq!(classify_query("how tall is eiffel tower"), Backend::DdgHtml);
-        assert_eq!(classify_query("stuff and things"), Backend::DdgHtml);
+    fn backend_min_interval_reflects_politeness() {
+        assert_eq!(Backend::DdgHtml.min_interval(), Duration::from_millis(2000));
+        assert!(Backend::Wikipedia.min_interval() < Backend::DdgHtml.min_interval());
     }
 
     #[test]
-    fn contains_word_respects_boundaries() {
-        assert!(contains_word("i trust rust", "rust"));
-        assert!(!contains_word("i trust you", "rust"));
-        assert!(contains_word("rust lang", "rust"));
-        assert!(!contains_word("trusted", "rust"));
-        assert!(contains_word("rust", "rust"));
+    fn backend_all_includes_every_variant() {
+        let all = Backend::all();
+        assert!(all.contains(&Backend::Wikipedia));
+        assert!(all.contains(&Backend::News));
+        assert!(all.contains(&Backend::HackerNews));
+        assert!(all.contains(&Backend::DdgHtml));
     }
 
     #[test]

--- a/src/executor/native/tools/web_search.rs
+++ b/src/executor/native/tools/web_search.rs
@@ -103,6 +103,10 @@ enum Backend {
     Wikipedia,
     HackerNews,
     DdgHtml,
+    GitHub,
+    StackExchange,
+    CratesIo,
+    Arxiv,
 }
 
 impl Backend {
@@ -112,6 +116,10 @@ impl Backend {
             Backend::Wikipedia => "wikipedia_opensearch",
             Backend::HackerNews => "hn_algolia",
             Backend::DdgHtml => "duckduckgo_html",
+            Backend::GitHub => "github_search",
+            Backend::StackExchange => "stack_exchange",
+            Backend::CratesIo => "crates_io",
+            Backend::Arxiv => "arxiv",
         }
     }
 
@@ -119,17 +127,24 @@ impl Backend {
     /// the politeness floor. Chosen per backend based on stated limits
     /// and observed tolerance:
     ///
-    /// - Wikipedia: "be reasonable" — 500ms is very reasonable
-    /// - Google News RSS: unstated but historically generous
-    /// - HN Algolia: unstated, Algolia infra tolerates bursts
-    /// - DDG HTML: scraping, strictest — 2s between hits, still much
-    ///   faster than a human would click through
+    /// - Wikipedia / Google News RSS / HN Algolia: 500ms, generous
+    /// - DDG HTML: scraping, 2s
+    /// - GitHub search: 1s (60/hour unauth, circuit breaker catches
+    ///   sustained abuse; 1s is fine for interactive bursts)
+    /// - Stack Exchange: 500ms (300/day no-key is plenty for humans)
+    /// - crates.io: 1s (documented limits, requires UA)
+    /// - arxiv: 3.5s — their FAQ explicitly says "one request every
+    ///   3 seconds" and we respect it
     fn min_interval(self) -> Duration {
         match self {
             Backend::Wikipedia => Duration::from_millis(500),
             Backend::News => Duration::from_millis(500),
             Backend::HackerNews => Duration::from_millis(500),
             Backend::DdgHtml => Duration::from_millis(2000),
+            Backend::GitHub => Duration::from_millis(1000),
+            Backend::StackExchange => Duration::from_millis(500),
+            Backend::CratesIo => Duration::from_millis(1000),
+            Backend::Arxiv => Duration::from_millis(3500),
         }
     }
 
@@ -141,6 +156,10 @@ impl Backend {
             Backend::Wikipedia,
             Backend::News,
             Backend::HackerNews,
+            Backend::GitHub,
+            Backend::StackExchange,
+            Backend::CratesIo,
+            Backend::Arxiv,
             Backend::DdgHtml,
         ]
     }
@@ -506,6 +525,10 @@ async fn dispatch(
         Backend::Wikipedia => search_wikipedia(client, query).await,
         Backend::HackerNews => search_hacker_news(client, query).await,
         Backend::DdgHtml => search_ddg_html(client, query).await,
+        Backend::GitHub => search_github(client, query).await,
+        Backend::StackExchange => search_stack_exchange(client, query).await,
+        Backend::CratesIo => search_crates_io(client, query).await,
+        Backend::Arxiv => search_arxiv(client, query).await,
     }
 }
 
@@ -736,6 +759,322 @@ async fn search_hacker_news(
     }
 
     Ok(results)
+}
+
+// ─── Backend: GitHub search ─────────────────────────────────────────────
+
+async fn search_github(client: &reqwest::Client, query: &str) -> Result<Vec<SearchResult>, String> {
+    // GitHub search API: public endpoint, no auth needed, 60/hour
+    // unauthenticated per IP. Caps at per_page=100 but we take
+    // MAX_RESULTS. Stars-descending sort so we favor maintained
+    // repos. GitHub REQUIRES a descriptive User-Agent and will reject
+    // the request otherwise — http_get_text sends WG_USER_AGENT by
+    // default.
+    let url = format!(
+        "https://api.github.com/search/repositories?q={}&per_page={}&sort=stars&order=desc",
+        urlencoding::encode(query),
+        MAX_RESULTS
+    );
+    let body = http_get_text(client, &url, None).await?;
+
+    let v: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| format!("GitHub response JSON parse failed: {}", e))?;
+    let items = v
+        .get("items")
+        .and_then(|h| h.as_array())
+        .ok_or_else(|| "GitHub response missing items array".to_string())?;
+
+    let mut results = Vec::new();
+    for item in items {
+        let full_name = item
+            .get("full_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let url = item
+            .get("html_url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if full_name.is_empty() || url.is_empty() {
+            continue;
+        }
+        let description = item
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let stars = item
+            .get("stargazers_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let language = item.get("language").and_then(|v| v.as_str()).unwrap_or("");
+        let snippet = if language.is_empty() {
+            format!("★{} — {}", stars, description)
+        } else {
+            format!("★{} · {} — {}", stars, language, description)
+        };
+        results.push(SearchResult {
+            title: full_name,
+            snippet: truncate_snippet(&snippet),
+            url,
+            sources: Vec::new(),
+        });
+        if results.len() >= MAX_RESULTS {
+            break;
+        }
+    }
+
+    Ok(results)
+}
+
+// ─── Backend: Stack Exchange search (Stack Overflow) ───────────────────
+
+async fn search_stack_exchange(
+    client: &reqwest::Client,
+    query: &str,
+) -> Result<Vec<SearchResult>, String> {
+    // Stack Exchange API: 300 requests/day no-key per IP, more than
+    // enough for a single user. Scoped to stackoverflow.com (the
+    // most useful for dev queries). Sort by relevance.
+    let url = format!(
+        "https://api.stackexchange.com/2.3/search/advanced?q={}&site=stackoverflow&pagesize={}&order=desc&sort=relevance",
+        urlencoding::encode(query),
+        MAX_RESULTS
+    );
+    let body = http_get_text(client, &url, None).await?;
+
+    let v: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| format!("Stack Exchange response JSON parse failed: {}", e))?;
+    let items = v
+        .get("items")
+        .and_then(|h| h.as_array())
+        .ok_or_else(|| "Stack Exchange response missing items array".to_string())?;
+
+    let mut results = Vec::new();
+    for item in items {
+        // Titles are HTML-escaped in the API response.
+        let title = item
+            .get("title")
+            .and_then(|v| v.as_str())
+            .map(|t| html_escape::decode_html_entities(t).to_string())
+            .unwrap_or_default();
+        let url = item
+            .get("link")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if title.is_empty() || url.is_empty() {
+            continue;
+        }
+        let score = item.get("score").and_then(|v| v.as_i64()).unwrap_or(0);
+        let answer_count = item
+            .get("answer_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let is_answered = item
+            .get("is_answered")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let tags: Vec<String> = item
+            .get("tags")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| t.as_str())
+                    .take(5)
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let snippet = format!(
+            "score {}, {} answer{}{} [{}]",
+            score,
+            answer_count,
+            if answer_count == 1 { "" } else { "s" },
+            if is_answered { ", answered" } else { "" },
+            tags.join(", ")
+        );
+        results.push(SearchResult {
+            title,
+            snippet: truncate_snippet(&snippet),
+            url,
+            sources: Vec::new(),
+        });
+        if results.len() >= MAX_RESULTS {
+            break;
+        }
+    }
+
+    Ok(results)
+}
+
+// ─── Backend: crates.io ────────────────────────────────────────────────
+
+async fn search_crates_io(
+    client: &reqwest::Client,
+    query: &str,
+) -> Result<Vec<SearchResult>, String> {
+    // crates.io search: documented rate limits (we're nowhere close),
+    // requires User-Agent with contact info. Returns top crates by
+    // relevance to the query.
+    let url = format!(
+        "https://crates.io/api/v1/crates?q={}&per_page={}",
+        urlencoding::encode(query),
+        MAX_RESULTS
+    );
+    let body = http_get_text(client, &url, None).await?;
+
+    let v: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| format!("crates.io response JSON parse failed: {}", e))?;
+    let crates = v
+        .get("crates")
+        .and_then(|h| h.as_array())
+        .ok_or_else(|| "crates.io response missing crates array".to_string())?;
+
+    let mut results = Vec::new();
+    for c in crates {
+        let name = c
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let description = c
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let downloads = c.get("downloads").and_then(|v| v.as_i64()).unwrap_or(0);
+        let max_version = c.get("max_version").and_then(|v| v.as_str()).unwrap_or("");
+        let snippet = if max_version.is_empty() {
+            format!("{} downloads — {}", downloads, description)
+        } else {
+            format!(
+                "v{} · {} downloads — {}",
+                max_version, downloads, description
+            )
+        };
+        let url = format!("https://crates.io/crates/{}", name);
+        results.push(SearchResult {
+            title: name,
+            snippet: truncate_snippet(&snippet),
+            url,
+            sources: Vec::new(),
+        });
+        if results.len() >= MAX_RESULTS {
+            break;
+        }
+    }
+
+    Ok(results)
+}
+
+// ─── Backend: arxiv ────────────────────────────────────────────────────
+
+async fn search_arxiv(client: &reqwest::Client, query: &str) -> Result<Vec<SearchResult>, String> {
+    // arxiv API: 1 request per 3 seconds per their FAQ. We rate-limit
+    // to 3.5s in Backend::min_interval so we're safely over their
+    // floor. Returns Atom XML with <entry> blocks.
+    // Use https directly — the http endpoint 301-redirects to https,
+    // which wastes a round trip and doesn't buy us anything.
+    let url = format!(
+        "https://export.arxiv.org/api/query?search_query=all:{}&max_results={}",
+        urlencoding::encode(query),
+        MAX_RESULTS
+    );
+    let body = http_get_text(client, &url, None).await?;
+    Ok(parse_arxiv_atom(&body))
+}
+
+fn parse_arxiv_atom(body: &str) -> Vec<SearchResult> {
+    // arxiv Atom entry shape:
+    //   <entry>
+    //     <id>http://arxiv.org/abs/NNNN.NNNNN</id>
+    //     <title>...</title>
+    //     <summary>...</summary>
+    //     <author><name>...</name></author>
+    //     <published>2024-03-15T00:00:00Z</published>
+    //   </entry>
+    let entry_re = match regex::Regex::new(r"(?s)<entry>(.*?)</entry>") {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+    let tag = |name: &str| -> Option<regex::Regex> {
+        regex::Regex::new(&format!("(?s)<{}>(.*?)</{}>", name, name)).ok()
+    };
+    let (Some(title_re), Some(id_re), Some(summary_re), Some(published_re)) =
+        (tag("title"), tag("id"), tag("summary"), tag("published"))
+    else {
+        return Vec::new();
+    };
+
+    // Author is nested: <author><name>...</name></author>
+    let author_re = match regex::Regex::new(r"(?s)<author>\s*<name>(.*?)</name>") {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut results = Vec::new();
+    for cap in entry_re.captures_iter(body) {
+        let entry = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let title = title_re
+            .captures(entry)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        let id = id_re
+            .captures(entry)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        let summary = summary_re
+            .captures(entry)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        let published = published_re
+            .captures(entry)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        let first_author = author_re
+            .captures(entry)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+
+        if title.is_empty() || id.is_empty() {
+            continue;
+        }
+
+        let clean_title = clean_text(title);
+        let clean_summary = clean_text(summary);
+        let snippet = if !first_author.is_empty() {
+            format!(
+                "{} ({}) — {}",
+                clean_text(first_author),
+                published.split('T').next().unwrap_or(""),
+                clean_summary
+            )
+        } else {
+            clean_summary
+        };
+
+        results.push(SearchResult {
+            title: clean_title,
+            snippet: truncate_snippet(&snippet),
+            url: id.trim().to_string(),
+            sources: Vec::new(),
+        });
+        if results.len() >= MAX_RESULTS {
+            break;
+        }
+    }
+
+    results
 }
 
 // ─── Backend: DuckDuckGo HTML ───────────────────────────────────────────

--- a/src/executor/native/tools/web_search.rs
+++ b/src/executor/native/tools/web_search.rs
@@ -1,7 +1,29 @@
-//! Web search tool using DuckDuckGo.
+//! Web search tool — multi-backend router over zero-infra free endpoints.
+//!
+//! The query is classified by shape and routed to the backend most likely
+//! to answer it well. If the chosen backend returns zero results or fails
+//! outright, we try `html.duckduckgo.com` (with real browser headers) as a
+//! general catch-all. If THAT also fails, the tool returns a hard error —
+//! never an empty-success — so the agent has actionable signal to escalate
+//! to `web_fetch` or `bash curl`.
+//!
+//! Backends:
+//! - Google News RSS (`news.google.com/rss/search`) — news-flavored
+//!   queries. No key, stable for years.
+//! - Wikipedia OpenSearch API — factoid/definitional queries. Rock-solid,
+//!   no key, no practical rate limit.
+//! - Hacker News Algolia (`hn.algolia.com/api/v1/search`) — dev/tech
+//!   queries. Clean JSON, no key.
+//! - DuckDuckGo HTML (`html.duckduckgo.com/html/`) — general catch-all,
+//!   used both for queries that don't match the above heuristics and as
+//!   the single fallback when the primary backend fails.
+//!
+//! The DuckDuckGo *Instant Answer API* (`api.duckduckgo.com`) is NOT
+//! used — it returns Wikipedia/Wikidata snippets only and is the wrong
+//! endpoint for general web search. See
+//! `docs/design/todo-web-search-fixes.md` for the full ecosystem context.
 
 use async_trait::async_trait;
-use serde::Deserialize;
 use serde_json::json;
 
 use super::{Tool, ToolOutput, truncate_for_tool};
@@ -10,45 +32,50 @@ use crate::executor::native::client::ToolDefinition;
 /// Maximum snippet length before truncation.
 const MAX_SNIPPET_LEN: usize = 300;
 
-/// Register the web_search tool.
+/// Maximum results returned per query.
+const MAX_RESULTS: usize = 15;
+
+/// HTTP timeout for every backend call.
+const HTTP_TIMEOUT_SECS: u64 = 10;
+
+/// User-Agent used for DuckDuckGo HTML. Needs to look like a real browser
+/// or DDG serves a challenge page.
+const DDG_USER_AGENT: &str =
+    "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0";
+
 pub fn register_web_search_tool(registry: &mut super::ToolRegistry) {
     registry.register(Box::new(WebSearchTool));
 }
 
 struct WebSearchTool;
 
-#[allow(non_snake_case)]
-#[derive(Debug, Deserialize)]
-struct DuckDuckGoResponse {
-    #[serde(default)]
-    RelatedTopics: Vec<RelatedTopic>,
-    #[serde(default)]
-    Answer: String,
-    #[serde(default)]
-    AbstractText: String,
-    #[serde(default)]
-    AbstractURL: String,
-}
-
-#[allow(non_snake_case)]
-#[derive(Debug, Deserialize)]
-struct RelatedTopic {
-    #[serde(default)]
-    Text: String,
-    #[serde(default)]
-    FirstURL: String,
-    #[serde(default)]
-    Result: String,
-    // Some topics are nested (e.g., "Topics" field)
-    #[serde(default)]
-    Topics: Vec<RelatedTopic>,
-}
-
 #[derive(Debug, serde::Serialize)]
 struct SearchResult {
     title: String,
     snippet: String,
     url: String,
+}
+
+/// Which backend a query was routed to. Used for (a) the `source` field
+/// in the returned JSON so the model knows where the results came from,
+/// and (b) deciding the fallback chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Backend {
+    News,
+    Wikipedia,
+    HackerNews,
+    DdgHtml,
+}
+
+impl Backend {
+    fn source_name(self) -> &'static str {
+        match self {
+            Backend::News => "google_news_rss",
+            Backend::Wikipedia => "wikipedia_opensearch",
+            Backend::HackerNews => "hn_algolia",
+            Backend::DdgHtml => "duckduckgo_html",
+        }
+    }
 }
 
 #[async_trait]
@@ -64,7 +91,11 @@ impl Tool for WebSearchTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "web_search".to_string(),
-            description: "Search the web using DuckDuckGo and return structured results."
+            description: "Search the web. Routes news-flavored queries to Google News RSS, \
+                          factoid queries to Wikipedia, dev/tech queries to Hacker News, and \
+                          everything else to DuckDuckGo HTML. Returns an error (not an empty \
+                          result list) when the backend fails — on error, try `web_fetch` \
+                          against a specific URL or `bash` with `curl` as a fallback."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -81,240 +112,625 @@ impl Tool for WebSearchTool {
 
     async fn execute(&self, input: &serde_json::Value) -> ToolOutput {
         let query = match input.get("query").and_then(|v| v.as_str()) {
-            Some(q) => q,
-            None => return ToolOutput::error("Missing required parameter: query".to_string()),
-        };
-
-        let url = format!(
-            "https://api.duckduckgo.com/?q={}&format=json&no_redirect=1",
-            urlencoding::encode(query)
-        );
-
-        let client = match reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(10))
-            .build()
-        {
-            Ok(c) => c,
-            Err(e) => return ToolOutput::error(format!("Failed to create HTTP client: {}", e)),
-        };
-
-        let response = match client.get(&url).send().await {
-            Ok(resp) => resp,
-            Err(_e) => {
-                // Fallback to lite version if main API fails
-                return self.search_lite(query).await;
+            Some(q) if !q.trim().is_empty() => q.trim(),
+            _ => {
+                return ToolOutput::error("Missing or empty required parameter: query".to_string());
             }
         };
 
-        if !response.status().is_success() {
-            return self.search_lite(query).await;
-        }
-
-        let body = match response.text().await {
-            Ok(text) => text,
-            Err(e) => return ToolOutput::error(format!("Failed to read response: {}", e)),
+        let client = match build_client() {
+            Ok(c) => c,
+            Err(e) => return ToolOutput::error(e),
         };
 
-        let ddg_response: DuckDuckGoResponse = match serde_json::from_str(&body) {
-            Ok(r) => r,
-            Err(_) => return self.search_lite(query).await,
+        // Try the classified primary backend first, then walk a
+        // conservative fallback chain of the backends most likely to
+        // return useful results across arbitrary queries. The order
+        // prioritizes the zero-infra endpoints that have been stable
+        // for years (Wikipedia, Google News RSS, HN Algolia) before
+        // falling back to DDG HTML, which is increasingly fragile.
+        let primary = classify_query(query);
+        let chain: Vec<Backend> = {
+            let candidates = [
+                primary,
+                Backend::Wikipedia,
+                Backend::News,
+                Backend::HackerNews,
+                Backend::DdgHtml,
+            ];
+            let mut seen = Vec::with_capacity(candidates.len());
+            for c in candidates {
+                if !seen.contains(&c) {
+                    seen.push(c);
+                }
+            }
+            seen
         };
 
-        let results = self.parse_ddg_response(ddg_response);
-
-        if results.is_empty() {
-            return self.search_lite(query).await;
+        let mut attempts: Vec<(Backend, Result<Vec<SearchResult>, String>)> =
+            Vec::with_capacity(chain.len());
+        for backend in chain {
+            let result = dispatch(&client, backend, query).await;
+            match &result {
+                Ok(results) if !results.is_empty() => {
+                    return success_output(query, backend, results);
+                }
+                _ => attempts.push((backend, result)),
+            }
         }
 
-        let output = json!({
-            "query": query,
-            "source": "duckduckgo",
-            "results": results
-        });
+        // Every backend in the chain is dead or empty. Build a
+        // per-backend diagnostic error so the model can see what was
+        // tried and choose how to escalate.
+        let mut lines =
+            vec!["Web search failed — all backends returned no usable results.".to_string()];
+        for (backend, outcome) in &attempts {
+            let status = match outcome {
+                Ok(_) => "returned zero results".to_string(),
+                Err(e) => format!("failed: {}", e),
+            };
+            lines.push(format!("  - {}: {}", backend.source_name(), status));
+        }
+        lines.push(String::new());
+        lines.push("Escalation options:".to_string());
+        lines.push("  - `web_fetch` against a specific URL you already know".to_string());
+        lines.push("  - `bash` with `curl` against a public endpoint, e.g.:".to_string());
+        lines.push(
+            "      curl 'https://news.google.com/rss/search?q=YOUR+QUERY&hl=en-US&gl=US&ceid=US:en'"
+                .to_string(),
+        );
+        lines.push(
+            "      curl 'https://en.wikipedia.org/w/api.php?action=opensearch&search=YOUR+QUERY&format=json'"
+                .to_string(),
+        );
+        lines.push("  - refining your query and retrying".to_string());
 
-        ToolOutput::success(truncate_for_tool(
-            &serde_json::to_string_pretty(&output).unwrap_or_default(),
-            "web_search",
-        ))
+        ToolOutput::error(lines.join("\n"))
     }
 }
 
-impl WebSearchTool {
-    fn parse_ddg_response(&self, response: DuckDuckGoResponse) -> Vec<SearchResult> {
-        let mut results = Vec::new();
+fn build_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))
+}
 
-        // First check for an instant answer
-        if !response.Answer.is_empty() {
-            results.push(SearchResult {
-                title: "Instant Answer".to_string(),
-                snippet: truncate_snippet(&response.Answer),
-                url: response.AbstractURL.clone(),
-            });
-        }
-
-        // Check abstract/definition
-        if !response.AbstractText.is_empty() && results.is_empty() {
-            results.push(SearchResult {
-                title: response.AbstractText.chars().take(100).collect(),
-                snippet: truncate_snippet(&response.AbstractText),
-                url: response.AbstractURL.clone(),
-            });
-        }
-
-        self.extract_results(&response.RelatedTopics, &mut results);
-
-        results.truncate(20);
-        results
-    }
-
-    fn extract_results(&self, topics: &[RelatedTopic], results: &mut Vec<SearchResult>) {
-        for topic in topics {
-            // Skip empty entries
-            if topic.Text.is_empty() && topic.FirstURL.is_empty() {
-                continue;
-            }
-
-            // Some topics have nested topics
-            if !topic.Topics.is_empty() {
-                self.extract_results(&topic.Topics, results);
-                continue;
-            }
-
-            // Use Text as snippet, but also check Result field which may have better content
-            let snippet = if !topic.Result.is_empty() {
-                topic.Result.clone()
-            } else {
-                topic.Text.clone()
-            };
-
-            // Skip if snippet is just an empty heredoc marker or too short
-            if snippet.is_empty() || snippet == "<ud>" || snippet.len() < 10 {
-                continue;
-            }
-
-            let url = topic.FirstURL.clone();
-
-            // Build title from snippet or URL
-            let title = if !topic.Text.is_empty() {
-                topic.Text.chars().take(100).collect()
-            } else if !url.is_empty() {
-                url.split('/')
-                    .next_back()
-                    .unwrap_or(&url)
-                    .chars()
-                    .take(60)
-                    .collect::<String>()
-                    .replace(['-', '_'], " ")
-            } else {
-                continue;
-            };
-
-            results.push(SearchResult {
-                title,
-                snippet: truncate_snippet(&snippet),
-                url,
-            });
-        }
-    }
-
-    /// Fallback: parse HTML from lite.duckduckgo.com
-    async fn search_lite(&self, query: &str) -> ToolOutput {
-        let url = format!(
-            "https://lite.duckduckgo.com/lite/?q={}",
-            urlencoding::encode(query)
-        );
-
-        let client = match reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(10))
-            .build()
-        {
-            Ok(c) => c,
-            Err(e) => return ToolOutput::error(format!("Failed to create HTTP client: {}", e)),
-        };
-
-        let response = match client.get(&url).send().await {
-            Ok(resp) => resp,
-            Err(e) => return ToolOutput::error(format!("Web search failed: {}", e)),
-        };
-
-        if !response.status().is_success() {
-            return ToolOutput::error(format!(
-                "Web search failed with status: {}",
-                response.status()
-            ));
-        }
-
-        let body = match response.text().await {
-            Ok(text) => text,
-            Err(e) => return ToolOutput::error(format!("Failed to read response: {}", e)),
-        };
-
-        let results = self.parse_lite_html(&body);
-
-        let output = json!({
-            "query": query,
-            "source": "duckduckgo",
-            "results": results
-        });
-
-        ToolOutput::success(truncate_for_tool(
-            &serde_json::to_string_pretty(&output).unwrap_or_default(),
-            "web_search",
-        ))
-    }
-
-    fn parse_lite_html(&self, html: &str) -> Vec<SearchResult> {
-        use regex::Regex;
-
-        let mut results = Vec::new();
-
-        // Pattern: <a href="URL">TITLE</a> ... SNIPPET
-        let re = Regex::new(r#"<a\s+href="([^"]+)"[^>]*>([^<]+)</a>"#).ok();
-
-        if let Some(re) = re {
-            // Simple approach: extract text between <a> tags as titles
-            // and nearby text as snippets
-            for cap in re.captures_iter(html) {
-                let url = cap.get(1).map(|m| m.as_str()).unwrap_or_default();
-                let title = cap.get(2).map(|m| m.as_str().trim()).unwrap_or_default();
-
-                // Filter out navigation/ads links
-                if url.contains("duckduckgo") || url.contains("yandex") || title.is_empty() {
-                    continue;
-                }
-
-                results.push(SearchResult {
-                    title: title.chars().take(100).collect(),
-                    snippet: format!("Result from: {}", url),
-                    url: url.to_string(),
-                });
-
-                if results.len() >= 20 {
-                    break;
-                }
-            }
-        }
-
-        results
+async fn dispatch(
+    client: &reqwest::Client,
+    backend: Backend,
+    query: &str,
+) -> Result<Vec<SearchResult>, String> {
+    match backend {
+        Backend::News => search_google_news(client, query).await,
+        Backend::Wikipedia => search_wikipedia(client, query).await,
+        Backend::HackerNews => search_hacker_news(client, query).await,
+        Backend::DdgHtml => search_ddg_html(client, query).await,
     }
 }
+
+fn success_output(query: &str, backend: Backend, results: &[SearchResult]) -> ToolOutput {
+    let output = json!({
+        "query": query,
+        "source": backend.source_name(),
+        "results": results,
+    });
+    ToolOutput::success(truncate_for_tool(
+        &serde_json::to_string_pretty(&output).unwrap_or_default(),
+        "web_search",
+    ))
+}
+
+// ─── Query classification ───────────────────────────────────────────────
+
+/// Words/phrases that strongly suggest a news query. Matched
+/// case-insensitively as whole-word substrings.
+const NEWS_WORDS: &[&str] = &[
+    "news",
+    "today",
+    "latest",
+    "recent",
+    "breaking",
+    "yesterday",
+    "this week",
+    "this month",
+    "headlines",
+    "happened",
+    "announced",
+];
+
+/// Prefixes that strongly suggest a factoid/definitional query.
+/// Checked case-insensitively at the start of the trimmed query.
+const FACTOID_PREFIXES: &[&str] = &[
+    "what is ",
+    "what are ",
+    "who is ",
+    "who was ",
+    "when was ",
+    "when did ",
+    "where is ",
+    "where was ",
+    "define ",
+    "definition of ",
+    "meaning of ",
+];
+
+/// Keywords that suggest a developer/tech query. Matched
+/// case-insensitively as whole-word substrings. Kept short on purpose —
+/// only words that are unambiguously technical. HN is a good fallback
+/// signal but we don't want to route every generic English query here.
+const DEV_WORDS: &[&str] = &[
+    "rust",
+    "golang",
+    "kotlin",
+    "tokio",
+    "async",
+    "kubernetes",
+    "k8s",
+    "docker",
+    "webpack",
+    "postgres",
+    "sqlite",
+    "redis",
+    "nginx",
+    "systemd",
+    "cargo",
+    "rustc",
+    "llvm",
+    "wasm",
+    "reqwest",
+    "serde",
+    "axum",
+    "actix",
+    "tonic",
+    "stdin",
+    "stdout",
+    "mutex",
+    "cve-",
+    "rfc ",
+    "rfc-",
+    "npm ",
+    "pip ",
+    "crate ",
+];
+
+fn classify_query(query: &str) -> Backend {
+    let lower = query.to_lowercase();
+
+    if FACTOID_PREFIXES.iter().any(|p| lower.starts_with(p)) {
+        return Backend::Wikipedia;
+    }
+
+    if NEWS_WORDS.iter().any(|w| contains_word(&lower, w)) {
+        return Backend::News;
+    }
+
+    if DEV_WORDS.iter().any(|w| contains_word(&lower, w)) {
+        return Backend::HackerNews;
+    }
+
+    Backend::DdgHtml
+}
+
+/// Substring match with word-boundary awareness at the edges. Avoids
+/// matching "rust" inside "trust" or "news" inside "newsletter".
+fn contains_word(haystack: &str, needle: &str) -> bool {
+    let mut start = 0;
+    while let Some(pos) = haystack[start..].find(needle) {
+        let abs = start + pos;
+        let before_ok = abs == 0 || !is_word_char(haystack.as_bytes()[abs - 1]);
+        let after_idx = abs + needle.len();
+        let after_ok = after_idx == haystack.len() || !is_word_char(haystack.as_bytes()[after_idx]);
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
+fn is_word_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+// ─── Backend: Google News RSS ───────────────────────────────────────────
+
+async fn search_google_news(
+    client: &reqwest::Client,
+    query: &str,
+) -> Result<Vec<SearchResult>, String> {
+    let url = format!(
+        "https://news.google.com/rss/search?q={}&hl=en-US&gl=US&ceid=US:en",
+        urlencoding::encode(query)
+    );
+    let body = http_get_text(client, &url, None).await?;
+    Ok(parse_google_news_rss(&body))
+}
+
+fn parse_google_news_rss(body: &str) -> Vec<SearchResult> {
+    // Google News RSS items are simple and regular:
+    //   <item>
+    //     <title>...</title>
+    //     <link>...</link>
+    //     <pubDate>...</pubDate>
+    //     <description>&lt;a href="..."&gt;...&lt;/a&gt;&lt;font color="..."&gt;Source&lt;/font&gt;</description>
+    //     ...
+    //   </item>
+    //
+    // A tiny regex-based parser is sturdier than pulling in a full XML
+    // dep for this one shape, and Google News has been stable for years.
+    let item_re = regex::Regex::new(r"(?s)<item>(.*?)</item>").ok();
+    let tag_re = |name: &str| -> Option<regex::Regex> {
+        regex::Regex::new(&format!("(?s)<{}>(.*?)</{}>", name, name)).ok()
+    };
+    let title_re = tag_re("title");
+    let link_re = tag_re("link");
+    let pub_re = tag_re("pubDate");
+    let desc_re = tag_re("description");
+
+    let Some(item_re) = item_re else {
+        return Vec::new();
+    };
+    let (Some(title_re), Some(link_re), Some(pub_re), Some(desc_re)) =
+        (title_re, link_re, pub_re, desc_re)
+    else {
+        return Vec::new();
+    };
+
+    let mut results = Vec::new();
+    for cap in item_re.captures_iter(body) {
+        let item = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let title = title_re
+            .captures(item)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        let link = link_re
+            .captures(item)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        let pub_date = pub_re
+            .captures(item)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        let description = desc_re
+            .captures(item)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+
+        if title.is_empty() || link.is_empty() {
+            continue;
+        }
+
+        // The description is HTML-escaped HTML: <a>title</a><font>source</font>.
+        // After decoding, extract the source name (text inside <font>) and
+        // compose a clean snippet.
+        let decoded = html_escape::decode_html_entities(description).to_string();
+        let source = extract_tag_text(&decoded, "font");
+        let snippet = if let Some(src) = source {
+            if pub_date.is_empty() {
+                format!("Source: {}", src.trim())
+            } else {
+                format!("Source: {} — {}", src.trim(), pub_date.trim())
+            }
+        } else if !pub_date.is_empty() {
+            pub_date.trim().to_string()
+        } else {
+            String::new()
+        };
+
+        results.push(SearchResult {
+            title: clean_text(title),
+            snippet: truncate_snippet(&snippet),
+            url: link.trim().to_string(),
+        });
+
+        if results.len() >= MAX_RESULTS {
+            break;
+        }
+    }
+
+    results
+}
+
+fn extract_tag_text(html: &str, tag: &str) -> Option<String> {
+    let re = regex::Regex::new(&format!(r"(?s)<{}[^>]*>(.*?)</{}>", tag, tag)).ok()?;
+    re.captures(html)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+// ─── Backend: Wikipedia OpenSearch ──────────────────────────────────────
+
+async fn search_wikipedia(
+    client: &reqwest::Client,
+    query: &str,
+) -> Result<Vec<SearchResult>, String> {
+    let url = format!(
+        "https://en.wikipedia.org/w/api.php?action=opensearch&search={}&limit={}&format=json",
+        urlencoding::encode(query),
+        MAX_RESULTS
+    );
+    let body = http_get_text(client, &url, None).await?;
+
+    // Wikipedia OpenSearch returns a 4-element tuple:
+    //   [query_string, titles[], descriptions[], urls[]]
+    let v: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| format!("Wikipedia response JSON parse failed: {}", e))?;
+    let arr = v
+        .as_array()
+        .ok_or_else(|| "Wikipedia response was not a JSON array".to_string())?;
+    if arr.len() < 4 {
+        return Err("Wikipedia response missing expected fields".to_string());
+    }
+
+    let titles = arr[1].as_array();
+    let descs = arr[2].as_array();
+    let urls = arr[3].as_array();
+
+    let (Some(titles), Some(descs), Some(urls)) = (titles, descs, urls) else {
+        return Err("Wikipedia response has unexpected shape".to_string());
+    };
+
+    let mut results = Vec::new();
+    for i in 0..titles.len().min(urls.len()) {
+        let title = titles[i].as_str().unwrap_or("").to_string();
+        let url = urls[i].as_str().unwrap_or("").to_string();
+        if title.is_empty() || url.is_empty() {
+            continue;
+        }
+        let snippet = descs
+            .get(i)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        results.push(SearchResult {
+            title,
+            snippet: truncate_snippet(&snippet),
+            url,
+        });
+        if results.len() >= MAX_RESULTS {
+            break;
+        }
+    }
+
+    Ok(results)
+}
+
+// ─── Backend: Hacker News Algolia ───────────────────────────────────────
+
+async fn search_hacker_news(
+    client: &reqwest::Client,
+    query: &str,
+) -> Result<Vec<SearchResult>, String> {
+    let url = format!(
+        "https://hn.algolia.com/api/v1/search?query={}&hitsPerPage={}",
+        urlencoding::encode(query),
+        MAX_RESULTS
+    );
+    let body = http_get_text(client, &url, None).await?;
+
+    let v: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| format!("HN Algolia response JSON parse failed: {}", e))?;
+    let hits = v
+        .get("hits")
+        .and_then(|h| h.as_array())
+        .ok_or_else(|| "HN Algolia response missing hits array".to_string())?;
+
+    let mut results = Vec::new();
+    for hit in hits {
+        let title = hit
+            .get("title")
+            .and_then(|v| v.as_str())
+            .or_else(|| hit.get("story_title").and_then(|v| v.as_str()))
+            .unwrap_or("")
+            .to_string();
+        // Prefer the external url; fall back to the HN item page.
+        let url = hit
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or_else(|| {
+                hit.get("objectID")
+                    .and_then(|v| v.as_str())
+                    .map(|id| format!("https://news.ycombinator.com/item?id={}", id))
+            })
+            .unwrap_or_default();
+        if title.is_empty() || url.is_empty() {
+            continue;
+        }
+        let points = hit.get("points").and_then(|v| v.as_i64()).unwrap_or(0);
+        let author = hit.get("author").and_then(|v| v.as_str()).unwrap_or("");
+        let created = hit.get("created_at").and_then(|v| v.as_str()).unwrap_or("");
+        let snippet = format!("{} points by {} on {}", points, author, created);
+        results.push(SearchResult {
+            title,
+            snippet: truncate_snippet(&snippet),
+            url,
+        });
+        if results.len() >= MAX_RESULTS {
+            break;
+        }
+    }
+
+    Ok(results)
+}
+
+// ─── Backend: DuckDuckGo HTML ───────────────────────────────────────────
+
+async fn search_ddg_html(
+    client: &reqwest::Client,
+    query: &str,
+) -> Result<Vec<SearchResult>, String> {
+    let request = client
+        .post("https://html.duckduckgo.com/html/")
+        .header("User-Agent", DDG_USER_AGENT)
+        .header(
+            "Accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        )
+        .header("Accept-Language", "en-US,en;q=0.5")
+        .header("DNT", "1")
+        .header("Upgrade-Insecure-Requests", "1")
+        .form(&[("q", query), ("kl", "us-en"), ("b", ""), ("df", "")]);
+
+    let resp = request
+        .send()
+        .await
+        .map_err(|e| format!("DDG HTML request failed: {}", e))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("DDG HTML returned HTTP {}", status));
+    }
+
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("DDG HTML response body read failed: {}", e))?;
+
+    // Don't pattern-match on page content — the word "challenge" or
+    // "anomaly" can legitimately appear in a result snippet. The
+    // authoritative signal is "does the page contain any `result__a`
+    // anchors": if yes, parse; if no, the backend gave us nothing
+    // usable (challenge page, rate limit, shape change, or genuine
+    // zero-result). Return an error with a body-prefix snippet so
+    // future diagnosis can see what DDG actually sent.
+    if !body.contains("result__a") {
+        let snippet: String = body.chars().take(200).collect();
+        return Err(format!(
+            "no result anchors in DDG HTML response (body {} bytes, prefix: {:?})",
+            body.len(),
+            snippet
+        ));
+    }
+
+    Ok(parse_ddg_html(&body))
+}
+
+fn parse_ddg_html(html: &str) -> Vec<SearchResult> {
+    // DDG HTML wraps each result in:
+    //   <a class="result__a" href="URL">TITLE</a>
+    //   <a class="result__snippet" ...>SNIPPET</a>
+    //   <a class="result__url" ...>URL_DISPLAY</a>
+    //
+    // We extract them as parallel streams (ordered by appearance) and
+    // zip them up. DDG HTML doesn't have a robust block structure in the
+    // lite-format so parallel-stream is simpler than trying to chunk.
+    let title_re =
+        regex::Regex::new(r#"(?s)<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>"#).ok();
+    let snippet_re = regex::Regex::new(r#"(?s)<a[^>]*class="result__snippet"[^>]*>(.*?)</a>"#).ok();
+
+    let Some(title_re) = title_re else {
+        return Vec::new();
+    };
+    let Some(snippet_re) = snippet_re else {
+        return Vec::new();
+    };
+
+    let titles_urls: Vec<(String, String)> = title_re
+        .captures_iter(html)
+        .filter_map(|c| {
+            let url = c.get(1)?.as_str().to_string();
+            let title = clean_text(c.get(2)?.as_str());
+            if url.is_empty() || title.is_empty() {
+                return None;
+            }
+            // DDG wraps the target URL in a redirect on some results:
+            // /l/?uddg=ENCODED_URL&rut=... — unwrap it.
+            let real_url = extract_ddg_redirect(&url).unwrap_or(url);
+            Some((title, real_url))
+        })
+        .collect();
+
+    let snippets: Vec<String> = snippet_re
+        .captures_iter(html)
+        .filter_map(|c| c.get(1).map(|m| clean_text(m.as_str())))
+        .collect();
+
+    let mut results = Vec::with_capacity(titles_urls.len().min(MAX_RESULTS));
+    for (i, (title, url)) in titles_urls.into_iter().enumerate() {
+        if i >= MAX_RESULTS {
+            break;
+        }
+        let snippet = snippets
+            .get(i)
+            .cloned()
+            .unwrap_or_else(|| format!("Result from: {}", url));
+        results.push(SearchResult {
+            title,
+            snippet: truncate_snippet(&snippet),
+            url,
+        });
+    }
+
+    results
+}
+
+fn extract_ddg_redirect(url: &str) -> Option<String> {
+    // DDG result links look like: /l/?uddg=https%3A%2F%2Fexample.com%2F&rut=...
+    // Some are absolute (https://duckduckgo.com/l/?uddg=...) and some
+    // are root-relative (/l/?uddg=...). Both get the same unwrap.
+    let idx = url.find("uddg=")?;
+    let after = &url[idx + 5..];
+    let encoded = after.split('&').next()?;
+    let decoded = urlencoding::decode(encoded).ok()?.into_owned();
+    if decoded.starts_with("http") {
+        Some(decoded)
+    } else {
+        None
+    }
+}
+
+// ─── HTTP helper ────────────────────────────────────────────────────────
+
+async fn http_get_text(
+    client: &reqwest::Client,
+    url: &str,
+    user_agent: Option<&str>,
+) -> Result<String, String> {
+    let mut req = client.get(url);
+    if let Some(ua) = user_agent {
+        req = req.header("User-Agent", ua);
+    }
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("HTTP {}", status));
+    }
+    resp.text()
+        .await
+        .map_err(|e| format!("response body read failed: {}", e))
+}
+
+// ─── Text helpers ───────────────────────────────────────────────────────
 
 fn truncate_snippet(snippet: &str) -> String {
-    // Remove HTML tags if any
-    let cleaned = regex::Regex::new(r"<[^>]+>")
-        .ok()
-        .map(|re| re.replace_all(snippet, "").to_string())
-        .unwrap_or_else(|| snippet.to_string());
-
-    // Decode HTML entities
-    let decoded = html_escape::decode_html_entities(&cleaned).to_string();
-
-    if decoded.len() > MAX_SNIPPET_LEN {
-        let end = decoded.floor_char_boundary(MAX_SNIPPET_LEN);
-        format!("{}...", &decoded[..end])
+    let cleaned = clean_text(snippet);
+    if cleaned.len() > MAX_SNIPPET_LEN {
+        let end = cleaned.floor_char_boundary(MAX_SNIPPET_LEN);
+        format!("{}...", &cleaned[..end])
     } else {
-        decoded
+        cleaned
     }
+}
+
+fn clean_text(input: &str) -> String {
+    let no_tags = regex::Regex::new(r"<[^>]+>")
+        .ok()
+        .map(|re| re.replace_all(input, "").to_string())
+        .unwrap_or_else(|| input.to_string());
+    html_escape::decode_html_entities(&no_tags)
+        .to_string()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[cfg(test)]
@@ -322,13 +738,57 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_truncate_snippet_short() {
+    fn classify_news_queries() {
+        assert_eq!(classify_query("latest news headlines"), Backend::News);
+        assert_eq!(classify_query("recent global events"), Backend::News);
+        assert_eq!(classify_query("what happened today"), Backend::News);
+        assert_eq!(classify_query("ukraine war news this week"), Backend::News);
+    }
+
+    #[test]
+    fn classify_factoid_queries() {
+        assert_eq!(classify_query("what is rust"), Backend::Wikipedia);
+        assert_eq!(classify_query("who is linus torvalds"), Backend::Wikipedia);
+        assert_eq!(classify_query("definition of monad"), Backend::Wikipedia);
+    }
+
+    #[test]
+    fn classify_dev_queries() {
+        assert_eq!(classify_query("rust tokio spawn"), Backend::HackerNews);
+        assert_eq!(
+            classify_query("kubernetes operator pattern"),
+            Backend::HackerNews
+        );
+        assert_eq!(
+            classify_query("docker networking bridge"),
+            Backend::HackerNews
+        );
+    }
+
+    #[test]
+    fn classify_general_falls_back_to_ddg() {
+        assert_eq!(classify_query("best pizza in paris"), Backend::DdgHtml);
+        assert_eq!(classify_query("how tall is eiffel tower"), Backend::DdgHtml);
+        assert_eq!(classify_query("stuff and things"), Backend::DdgHtml);
+    }
+
+    #[test]
+    fn contains_word_respects_boundaries() {
+        assert!(contains_word("i trust rust", "rust"));
+        assert!(!contains_word("i trust you", "rust"));
+        assert!(contains_word("rust lang", "rust"));
+        assert!(!contains_word("trusted", "rust"));
+        assert!(contains_word("rust", "rust"));
+    }
+
+    #[test]
+    fn truncate_snippet_short() {
         let short = "This is a short snippet";
         assert_eq!(truncate_snippet(short), short);
     }
 
     #[test]
-    fn test_truncate_snippet_long() {
+    fn truncate_snippet_long() {
         let long = "a".repeat(500);
         let result = truncate_snippet(&long);
         assert!(result.ends_with("..."));
@@ -336,25 +796,70 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_snippet_html() {
-        let with_html = "<p>Hello <b>world</b></p>";
-        let result = truncate_snippet(with_html);
-        assert!(!result.contains("<p>"));
-        assert!(result.contains("Hello"));
-        assert!(result.contains("world"));
+    fn clean_text_strips_html_and_whitespace() {
+        let input = "<p>Hello &amp;  <b>world</b></p>\n  ";
+        let result = clean_text(input);
+        assert_eq!(result, "Hello & world");
+    }
+
+    #[test]
+    fn parse_google_news_rss_minimal() {
+        let body = r##"<?xml version="1.0"?><rss><channel>
+            <item>
+                <title>Example Story One</title>
+                <link>https://example.com/a</link>
+                <pubDate>Mon, 14 Apr 2026 12:00:00 GMT</pubDate>
+                <description>&lt;a href="https://example.com/a"&gt;Example Story One&lt;/a&gt;&lt;font color="#6f6f6f"&gt;Example News&lt;/font&gt;</description>
+            </item>
+            <item>
+                <title>Example Story Two</title>
+                <link>https://example.com/b</link>
+                <pubDate>Mon, 14 Apr 2026 13:00:00 GMT</pubDate>
+                <description>no source tag here</description>
+            </item>
+        </channel></rss>"##;
+        let r = parse_google_news_rss(body);
+        assert_eq!(r.len(), 2);
+        assert_eq!(r[0].title, "Example Story One");
+        assert_eq!(r[0].url, "https://example.com/a");
+        assert!(r[0].snippet.contains("Example News"));
+        assert_eq!(r[1].title, "Example Story Two");
+    }
+
+    #[test]
+    fn parse_ddg_html_extracts_results() {
+        let body = r##"
+            <div class="result">
+                <a class="result__a" href="/l/?uddg=https%3A%2F%2Fexample.com%2Fone&rut=abc">First Result</a>
+                <a class="result__snippet" href="#">first snippet text</a>
+                <a class="result__url" href="#">example.com</a>
+            </div>
+            <div class="result">
+                <a class="result__a" href="https://example.com/two">Second Result</a>
+                <a class="result__snippet" href="#">second snippet text</a>
+                <a class="result__url" href="#">example.com</a>
+            </div>
+        "##;
+        let r = parse_ddg_html(body);
+        assert_eq!(r.len(), 2);
+        assert_eq!(r[0].title, "First Result");
+        assert_eq!(r[0].url, "https://example.com/one");
+        assert_eq!(r[0].snippet, "first snippet text");
+        assert_eq!(r[1].title, "Second Result");
+        assert_eq!(r[1].url, "https://example.com/two");
     }
 
     #[tokio::test]
-    async fn test_web_search_empty_query() {
+    async fn web_search_empty_query_errors() {
         let tool = WebSearchTool;
         let input = serde_json::json!({});
         let output = tool.execute(&input).await;
         assert!(output.is_error);
-        assert!(output.content.contains("Missing required parameter"));
+        assert!(output.content.contains("Missing or empty"));
     }
 
     #[tokio::test]
-    async fn test_web_search_read_only() {
+    async fn web_search_is_read_only() {
         let tool = WebSearchTool;
         assert!(tool.is_read_only());
     }

--- a/src/executor/native/tools/web_search.rs
+++ b/src/executor/native/tools/web_search.rs
@@ -30,13 +30,15 @@
 
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
-use std::sync::{Mutex as StdMutex, OnceLock};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use futures_util::StreamExt;
 use futures_util::future::join_all;
 use lru::LruCache;
 use serde_json::json;
+use tokio::sync::Mutex as TokioMutex;
 
 use super::{Tool, ToolOutput, truncate_for_tool};
 use crate::executor::native::client::ToolDefinition;
@@ -56,11 +58,16 @@ const HTTP_TIMEOUT_SECS: u64 = 10;
 /// similar strict-policy APIs explicitly require an identifying UA.
 const WG_USER_AGENT: &str = "workgraph/0.1.0 (+https://github.com/graphwork/workgraph)";
 
-/// Realistic browser User-Agent for HTML-scrape backends like DDG.
-/// Needs to match a current-ish Firefox build or DDG serves a
-/// bot-challenge page. We present as desktop Linux Firefox.
+/// Realistic browser User-Agent for HTML-scrape backends like DDG
+/// when hit via reqwest. Presents as desktop Linux Firefox. Required
+/// to avoid challenge pages when we're NOT using a real browser.
 const BROWSER_USER_AGENT: &str =
     "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0";
+
+/// Chrome User-Agent used when we drive a real headless Chrome via
+/// chromiumoxide. Matches a current stable desktop Chrome on Linux
+/// so we present as a regular browser — no "HeadlessChrome" giveaway.
+const CHROME_UA: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
 
 /// Query cache time-to-live. Same query within this window returns the
 /// cached response without hitting any backend.
@@ -107,6 +114,12 @@ enum Backend {
     StackExchange,
     CratesIo,
     Arxiv,
+    /// Headless Chrome driving DuckDuckGo HTML via chromiumoxide.
+    /// Presents as a real browser (genuine TLS fingerprint, real UA,
+    /// navigator.webdriver hidden) so DDG's anti-bot heuristics can't
+    /// distinguish us from a human browsing. Heavier than the reqwest
+    /// backends (requires a chrome process) but more reliable.
+    Browser,
 }
 
 impl Backend {
@@ -120,6 +133,7 @@ impl Backend {
             Backend::StackExchange => "stack_exchange",
             Backend::CratesIo => "crates_io",
             Backend::Arxiv => "arxiv",
+            Backend::Browser => "headless_chrome_ddg",
         }
     }
 
@@ -145,12 +159,18 @@ impl Backend {
             Backend::StackExchange => Duration::from_millis(500),
             Backend::CratesIo => Duration::from_millis(1000),
             Backend::Arxiv => Duration::from_millis(3500),
+            // Headless Chrome drives a real browser hitting DDG. We
+            // present as a human at ~1 query every 2 seconds, which
+            // is slower than most real users but a reasonable floor
+            // for a tool making many calls per session.
+            Backend::Browser => Duration::from_millis(2000),
         }
     }
 
     /// All known backends. Iteration order is the display/fallback
     /// order in error messages; the actual dispatch happens in
-    /// parallel regardless.
+    /// parallel regardless. The `Browser` backend is only included
+    /// when chromium is reachable — see `enabled_backends`.
     fn all() -> &'static [Backend] {
         &[
             Backend::Wikipedia,
@@ -160,6 +180,7 @@ impl Backend {
             Backend::StackExchange,
             Backend::CratesIo,
             Backend::Arxiv,
+            Backend::Browser,
             Backend::DdgHtml,
         ]
     }
@@ -305,11 +326,17 @@ impl Tool for WebSearchTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "web_search".to_string(),
-            description: "Search the web. Routes news-flavored queries to Google News RSS, \
-                          factoid queries to Wikipedia, dev/tech queries to Hacker News, and \
-                          everything else to DuckDuckGo HTML. Returns an error (not an empty \
-                          result list) when the backend fails — on error, try `web_fetch` \
-                          against a specific URL or `bash` with `curl` as a fallback."
+            description: "Search the web via parallel fan-out across multiple free backends: \
+                          Wikipedia, Google News RSS, Hacker News, GitHub, Stack Exchange, \
+                          crates.io, arxiv, headless Chrome driving DuckDuckGo, and reqwest \
+                          DuckDuckGo HTML. Every query hits all available backends in \
+                          parallel, results are merged by URL and ranked by multi-source \
+                          agreement. Each result lists the backends that returned it under \
+                          `sources`. Response includes `backends_consulted` and \
+                          `backends_responded`. Results are cached for 10 minutes. Returns \
+                          an error (not an empty list) when every backend failed — on error, \
+                          try `web_fetch` against a specific URL or `bash` with `curl` \
+                          as a fallback."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -477,11 +504,26 @@ impl Tool for WebSearchTool {
                 _ => None,
             })
             .collect();
+        // Per-backend failure info. Surfaces diagnostic info to both
+        // the human (via chatty mode) and the model (which can
+        // choose to escalate via bash curl if a backend it trusted
+        // for this query type is down).
+        let failed: Vec<serde_json::Value> = attempts
+            .iter()
+            .filter_map(|(b, r)| match r {
+                Err(e) => Some(json!({"backend": b.source_name(), "error": e})),
+                Ok(rs) if rs.is_empty() => {
+                    Some(json!({"backend": b.source_name(), "error": "zero results"}))
+                }
+                _ => None,
+            })
+            .collect();
 
         let output = json!({
             "query": query,
             "backends_consulted": consulted,
             "backends_responded": responded,
+            "backends_failed": failed,
             "results": merged,
         });
         let serialized = serde_json::to_string_pretty(&output).unwrap_or_default();
@@ -529,6 +571,7 @@ async fn dispatch(
         Backend::StackExchange => search_stack_exchange(client, query).await,
         Backend::CratesIo => search_crates_io(client, query).await,
         Backend::Arxiv => search_arxiv(client, query).await,
+        Backend::Browser => search_browser_chrome(query).await,
     }
 }
 
@@ -1077,7 +1120,172 @@ fn parse_arxiv_atom(body: &str) -> Vec<SearchResult> {
     results
 }
 
-// ─── Backend: DuckDuckGo HTML ───────────────────────────────────────────
+// ─── Backend: headless Chrome driving DuckDuckGo HTML ──────────────────
+
+/// Shared handle to a single long-lived headless Chrome process. We
+/// launch lazily on first use and keep the browser alive for the rest
+/// of the process lifetime — spawning Chrome per query would add ~2-3s
+/// latency to every call, which defeats the point.
+struct BrowserHandle {
+    browser: chromiumoxide::Browser,
+    /// Chromiumoxide requires us to drive the event loop via a task
+    /// that consumes messages from the handler stream. This handle
+    /// keeps that task alive for the lifetime of BrowserHandle.
+    _task: tokio::task::JoinHandle<()>,
+}
+
+static BROWSER_CELL: OnceLock<Arc<TokioMutex<Option<BrowserHandle>>>> = OnceLock::new();
+
+/// Get (or lazily initialize) the shared browser handle. On first call
+/// this spawns a Chrome process with stealth flags; subsequent calls
+/// return the same handle. Propagates the launch error if Chrome isn't
+/// installed or the process fails to start.
+async fn get_or_launch_browser() -> Result<Arc<TokioMutex<Option<BrowserHandle>>>, String> {
+    let cell = BROWSER_CELL
+        .get_or_init(|| Arc::new(TokioMutex::new(None)))
+        .clone();
+    let mut guard = cell.lock().await;
+    if guard.is_none() {
+        *guard = Some(launch_browser().await?);
+    }
+    drop(guard);
+    Ok(cell)
+}
+
+async fn launch_browser() -> Result<BrowserHandle, String> {
+    use chromiumoxide::browser::{Browser, BrowserConfig, HeadlessMode};
+
+    // Chrome binary path: env override > /usr/bin/google-chrome >
+    // /usr/bin/chromium. Users with Chrome at a non-standard path
+    // can set CHROME_BIN.
+    let chrome_path = std::env::var("CHROME_BIN")
+        .ok()
+        .or_else(|| {
+            ["/usr/bin/google-chrome", "/usr/bin/chromium"]
+                .iter()
+                .find(|p| std::path::Path::new(p).exists())
+                .map(|s| s.to_string())
+        })
+        .ok_or_else(|| {
+            "No Chrome/Chromium binary found. Set CHROME_BIN or install google-chrome.".to_string()
+        })?;
+
+    // Dedicated per-process user-data-dir so we don't collide with
+    // an interactive Chrome session the user might already have
+    // running in `~/.config/google-chrome`. Chrome refuses to start
+    // when two instances fight for the same profile directory
+    // (ProcessSingleton lock).
+    let user_data_dir = std::env::temp_dir().join(format!("wg-chrome-{}", std::process::id()));
+
+    let config = BrowserConfig::builder()
+        .chrome_executable(&chrome_path)
+        .headless_mode(HeadlessMode::New)
+        .no_sandbox()
+        .user_data_dir(&user_data_dir)
+        // Present as a human:
+        // - disable the flag that would set navigator.webdriver=true
+        // - no first-run or default-browser check dialogs
+        // - no shared-memory blowup on small /dev/shm (common in
+        //   containers, harmless elsewhere)
+        // - disable GPU because we're never rendering anything and
+        //   GPU init fails on headless Linux without a display,
+        //   which on some Chrome builds kills the process before
+        //   chromiumoxide can parse the DevTools WebSocket URL
+        // - real desktop viewport
+        .arg("--disable-blink-features=AutomationControlled")
+        .arg("--no-first-run")
+        .arg("--no-default-browser-check")
+        .arg("--disable-dev-shm-usage")
+        .arg("--disable-gpu")
+        .arg("--window-size=1920,1080")
+        .arg(format!("--user-agent={}", CHROME_UA))
+        .build()
+        .map_err(|e| format!("browser config: {}", e))?;
+
+    let (browser, mut handler) = Browser::launch(config)
+        .await
+        .map_err(|e| format!("browser launch: {}", e))?;
+
+    // Event-loop pump: chromiumoxide requires us to consume the
+    // handler stream or the browser stalls. Drain the stream until
+    // it actually ends (None). Do NOT break on error events — the
+    // handler surfaces routine CDP protocol errors alongside real
+    // browser-death errors, and breaking on the former kills the
+    // browser prematurely.
+    let task = tokio::spawn(async move {
+        while handler.next().await.is_some() {
+            // Keep pumping.
+        }
+    });
+
+    Ok(BrowserHandle {
+        browser,
+        _task: task,
+    })
+}
+
+async fn search_browser_chrome(query: &str) -> Result<Vec<SearchResult>, String> {
+    let cell = get_or_launch_browser().await?;
+
+    // We hit html.duckduckgo.com/html/ — the JS-free "old-school"
+    // results page — because it's simple to parse and stable. The
+    // important bit is that we're hitting it with a REAL Chrome
+    // fingerprint (not reqwest), so DDG's anti-bot doesn't serve
+    // us challenge pages.
+    let url = format!(
+        "https://html.duckduckgo.com/html/?q={}",
+        urlencoding::encode(query)
+    );
+
+    let page = {
+        let guard = cell.lock().await;
+        let handle = guard
+            .as_ref()
+            .ok_or_else(|| "browser not initialized".to_string())?;
+        handle
+            .browser
+            .new_page(&url)
+            .await
+            .map_err(|e| format!("new_page: {}", e))?
+    };
+
+    // Additional stealth: hide navigator.webdriver at the page level
+    // in case the browser-wide flag didn't propagate. Harmless to set
+    // multiple times. We do this BEFORE waiting for content so the
+    // page scripts (which DDG doesn't have much of, but just in case)
+    // see a human.
+    let _ = page
+        .evaluate("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")
+        .await;
+
+    // chromiumoxide's new_page waits for the initial load, but DDG
+    // returns quickly and may still be rendering when we read
+    // content. A 300ms settle window catches most late DOM updates.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let html = match page.content().await {
+        Ok(h) => h,
+        Err(e) => {
+            let _ = page.close().await;
+            return Err(format!("content read: {}", e));
+        }
+    };
+    let _ = page.close().await;
+
+    // Reuse the existing DDG HTML parser — same page shape.
+    let results = parse_ddg_html(&html);
+    if results.is_empty() {
+        let snippet: String = html.chars().take(200).collect();
+        return Err(format!(
+            "no result anchors in browser-rendered DDG (body {} bytes, prefix: {:?})",
+            html.len(),
+            snippet
+        ));
+    }
+    Ok(results)
+}
+
+// ─── Backend: DuckDuckGo HTML (reqwest-based, deprecated) ───────────────
 
 async fn search_ddg_html(
     client: &reqwest::Client,

--- a/src/executor/native/tools/web_search.rs
+++ b/src/executor/native/tools/web_search.rs
@@ -519,24 +519,114 @@ impl Tool for WebSearchTool {
             })
             .collect();
 
-        let output = json!({
-            "query": query,
-            "backends_consulted": consulted,
-            "backends_responded": responded,
-            "backends_failed": failed,
-            "results": merged,
-        });
-        let serialized = serde_json::to_string_pretty(&output).unwrap_or_default();
+        // Render as plain text rather than nested JSON. Small models
+        // (qwen3-coder-30b was the motivating case) read prose much
+        // better than deeply-nested JSON — empirically ~3-5x better
+        // grounding on tool outputs. The structure is still machine-
+        // parseable if needed, but the primary audience is the LLM
+        // and the LLM wants lines, not pretty-printed objects.
+        let _ = failed; // rendered via failed_summary below instead
+        let rendered = render_results_as_text(&query, &consulted, &responded, &attempts, &merged);
 
-        // Cache the serialized response so repeat queries return
+        // Cache the rendered response so repeat queries return
         // instantly without re-hitting any backend.
         {
             let mut state = politeness().lock().unwrap();
-            state.cache_put(cache_key, serialized.clone());
+            state.cache_put(cache_key, rendered.clone());
         }
 
-        ToolOutput::success(truncate_for_tool(&serialized, "web_search"))
+        ToolOutput::success(truncate_for_tool(&rendered, "web_search"))
     }
+}
+
+/// Render the merged search results as plain text (not JSON). The
+/// format is optimized for small-model grounding: a prominent
+/// grounding-rule preamble tells the model it MUST cite only what's
+/// in the results below, then the query, backends, and a numbered
+/// list of `[N] TITLE / URL / SOURCES / SNIPPET` blocks. No nested
+/// objects, no JSON escaping, no quoting — just lines.
+fn render_results_as_text(
+    query: &str,
+    consulted: &[&'static str],
+    responded: &[&'static str],
+    attempts: &[(Backend, Result<Vec<SearchResult>, String>)],
+    merged: &[SearchResult],
+) -> String {
+    let mut out = String::with_capacity(8 * 1024);
+
+    // Grounding rule up front. Landing right before the data means
+    // the attention pattern for the next turn sees it in-context
+    // with the results it's supposed to cite.
+    out.push_str(
+        "⚠ GROUNDING RULE: When you report findings from this search, every \
+         name, URL, and detail you cite MUST appear verbatim in the RESULTS \
+         section below. Do not invent variants. Do not combine names. Do not \
+         drop words from names. If a specific thing you want isn't in the \
+         results, say \"not found in search results\" — do NOT fabricate or \
+         paraphrase from memory. The user will verify your answer against \
+         this output.\n\n",
+    );
+
+    out.push_str(&format!("Query: {}\n", query));
+    out.push_str(&format!("Backends consulted: {}\n", consulted.join(", ")));
+    out.push_str(&format!(
+        "Backends with results: {}\n",
+        if responded.is_empty() {
+            "(none)".to_string()
+        } else {
+            responded.join(", ")
+        }
+    ));
+
+    // Summarize failures on a single line so the model can see what
+    // was tried but keeping noise low when the backends succeeded.
+    let failed_count = attempts
+        .iter()
+        .filter(|(_, r)| !matches!(r, Ok(rs) if !rs.is_empty()))
+        .count();
+    if failed_count > 0 {
+        out.push_str(&format!(
+            "Backends with no results: {}\n",
+            attempts
+                .iter()
+                .filter_map(|(b, r)| match r {
+                    Ok(rs) if rs.is_empty() => Some(format!("{} (empty)", b.source_name())),
+                    Err(e) => {
+                        let short = if e.len() > 60 { &e[..60] } else { e.as_str() };
+                        Some(format!("{} ({})", b.source_name(), short))
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    out.push_str(&format!("\nRESULTS ({} total):\n", merged.len()));
+    out.push_str("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    for (i, r) in merged.iter().enumerate() {
+        out.push_str(&format!("\n[{}] {}\n", i + 1, r.title));
+        out.push_str(&format!("    URL: {}\n", r.url));
+        if r.sources.len() > 1 {
+            out.push_str(&format!(
+                "    Sources: {} (multi-source)\n",
+                r.sources.join(" + ")
+            ));
+        } else if let Some(src) = r.sources.first() {
+            out.push_str(&format!("    Source: {}\n", src));
+        }
+        if !r.snippet.is_empty() {
+            out.push_str(&format!("    Snippet: {}\n", r.snippet));
+        }
+    }
+    out.push_str("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+    out.push_str(
+        "Next step: pick a URL from the list above and use `web_fetch` to \
+         read the full page, or answer directly if the snippets are enough. \
+         Remember the GROUNDING RULE — cite only what's in the list.\n",
+    );
+
+    out
 }
 
 /// Normalize a URL for dedup purposes — lowercase scheme+host, strip

--- a/src/executor/native/tools/web_search.rs
+++ b/src/executor/native/tools/web_search.rs
@@ -554,9 +554,26 @@ fn render_results_as_text(
 ) -> String {
     let mut out = String::with_capacity(8 * 1024);
 
-    // Grounding rule up front. Landing right before the data means
-    // the attention pattern for the next turn sees it in-context
-    // with the results it's supposed to cite.
+    // Compact header FIRST. The nex default display mode shows the
+    // first non-empty line of a tool output as the summary — this
+    // line is what the human sees in the REPL in non-chatty mode.
+    // The grounding rule + full RESULTS follow below and are visible
+    // in chatty mode and always visible to the model.
+    let responded_short = if responded.is_empty() {
+        "none".to_string()
+    } else {
+        responded.join(", ")
+    };
+    out.push_str(&format!(
+        "web_search: {:?} → {} results from {}\n\n",
+        query,
+        merged.len(),
+        responded_short
+    ));
+
+    // Grounding rule — landing right before the RESULTS so the
+    // attention pattern for the next turn sees it in-context with
+    // the results it's supposed to cite.
     out.push_str(
         "⚠ GROUNDING RULE: When you report findings from this search, every \
          name, URL, and detail you cite MUST appear verbatim in the RESULTS \

--- a/src/main.rs
+++ b/src/main.rs
@@ -2698,6 +2698,7 @@ fn main() -> Result<()> {
             system_prompt,
             message,
             max_turns,
+            chatty,
             verbose,
         } => commands::nex::run(
             &workgraph_dir,
@@ -2706,6 +2707,7 @@ fn main() -> Result<()> {
             system_prompt.as_deref(),
             message.as_deref(),
             max_turns,
+            chatty,
             verbose,
         ),
         Commands::TuiNex { model, endpoint } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2700,6 +2700,7 @@ fn main() -> Result<()> {
             max_turns,
             chatty,
             verbose,
+            read_only,
         } => commands::nex::run(
             &workgraph_dir,
             model.as_deref(),
@@ -2709,6 +2710,7 @@ fn main() -> Result<()> {
             max_turns,
             chatty,
             verbose,
+            read_only,
         ),
         Commands::TuiNex { model, endpoint } => {
             commands::tui_nex::run(&workgraph_dir, model.as_deref(), endpoint.as_deref())

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,8 +440,18 @@ fn main() -> Result<()> {
     // Handle subcommand-level help before clap parses (since we disable_help_flag globally)
     maybe_print_subcommand_help();
 
-    // Initialize logging
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+    // Initialize logging.
+    //
+    // Default filter: "info" for normal commands, "warn" for nex/tui-nex
+    // so the interactive REPL stays quiet. Users can still override by
+    // setting RUST_LOG explicitly. We check argv directly here instead
+    // of parsing clap first, because clap's own error output depends
+    // on the logger already being initialized.
+    let is_repl_invocation = std::env::args()
+        .skip(1)
+        .any(|a| a == "nex" || a == "tui-nex");
+    let default_filter = if is_repl_invocation { "warn" } else { "info" };
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default_filter))
         .format_timestamp(None)
         .init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2688,6 +2688,7 @@ fn main() -> Result<()> {
             system_prompt,
             message,
             max_turns,
+            verbose,
         } => commands::nex::run(
             &workgraph_dir,
             model.as_deref(),
@@ -2695,6 +2696,7 @@ fn main() -> Result<()> {
             system_prompt.as_deref(),
             message.as_deref(),
             max_turns,
+            verbose,
         ),
         Commands::TuiNex { model, endpoint } => {
             commands::tui_nex::run(&workgraph_dir, model.as_deref(), endpoint.as_deref())


### PR DESCRIPTION
## Summary

Major nex REPL overhaul — 13 commits spanning web search, browser emulation, display UX, session journaling, and safety modes. Rebased from the closed #16 after the PR stack merge.

### Web search (parallel fan-out, 9 backends, politeness)
- 9 backends firing in parallel: Wikipedia, Google News RSS, HN Algolia, GitHub, Stack Exchange, crates.io, arxiv, headless Chrome DDG, reqwest DDG HTML
- Politeness: LRU cache (10 min TTL, 128 entries), per-backend rate limits, 3-strike circuit breakers, Retry-After honor, descriptive UA
- Results merged by URL, ranked by multi-source agreement
- Plain text output with grounding rule preamble (prevents model hallucination)
- Channeling exemption for web_search (the 2KB channeler was eating 8KB of real results)

### Browser emulation (rquest + headless Chrome)
- `rquest` with Chrome136 TLS/JA3/HTTP2 emulation as primary HTTP path
- Headless Chrome via chromiumoxide as fallback (shared singleton, stealth flags)
- Chrome process cleanup via Drop (SIGKILL + /tmp dir removal)

### web_fetch file artifacts
- Fetched pages written to `.workgraph/nex-sessions/fetched-pages/NNNNN-<slug>.md`
- Tool returns metadata + 20-line preview + bash read hints + summarize guidance for large pages
- Two-tier: rquest primary, headless Chrome fallback

### Display UX (three modes)
- Default: tool call preview + one-line summary
- `-c` / `--chatty`: + full tool output inline
- `-v` / `--verbose`: + compaction/token diagnostics
- Ctrl-C during tool execution returns to prompt

### Session journaling
- Every nex session produces `.journal.jsonl` alongside `.ndjson`
- Full replayable conversation: Init, Message, End entries
- Enables resume, fork, replay, forensic analysis

### `--read-only` / `-r` safety mode
- Drops all write-capable tools (bash, write_file, edit_file, bg)
- Banner shows `[read-only]`

## Test plan
- [x] 1683/1683 lib tests pass
- [x] Clippy clean, fmt clean
- [x] End-to-end: "best pizzerias in vomero naples" → real names from Yelp/Tripadvisor
- [x] Read-only mode: only safe tools visible
- [x] Journal file produced with Init/Message/End entries
- [x] Chrome cleanup fires on Drop