### PR TITLE
Windows support for the full daemon and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7395,6 +7395,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "walkdir",
+ "windows-sys 0.60.2",
  "workgraph",
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,6 +1441,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "dptree"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2850,6 +2856,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4c3c8f298ee3d5467f2616384e3560c750226cc3c620e5456d3b95783156f6"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4578,6 +4597,12 @@ checksum = "fc7e264f9ec4f3d112e8e2f214e8e7cb5cf3b83278f3570b7e00bfe13d3bd8ff"
 dependencies = [
  "tokio",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -6810,6 +6835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "wildmatch"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7329,6 +7360,7 @@ dependencies = [
  "hmac",
  "html-escape",
  "insta",
+ "interprocess",
  "lettre",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ llm-tests = []  # gates tests that call Claude CLI
 test-support = []  # exposes test helpers for cross-crate use
 
 [dependencies]
+interprocess = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,16 @@ hex = "0.4.3"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.60", features = [
+    "Win32_System_Console",
+    "Win32_System_Threading",
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+] }
+
 [dev-dependencies]
 tempfile = "3.10"
 serial_test = "3"

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -545,12 +545,19 @@ fn attempt_manual_worktree_cleanup(
 
 /// Fix permissions on a file and retry removal
 fn fix_permissions_and_retry_removal(file_path: &Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
     // Try to make the file writable
     if let Ok(metadata) = fs::metadata(file_path) {
         let mut perms = metadata.permissions();
-        perms.set_mode(0o644); // Read/write for owner, read for others
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            perms.set_mode(0o644); // Read/write for owner, read for others
+        }
+        #[cfg(not(unix))]
+        {
+            perms.set_readonly(false);
+        }
 
         if let Err(e) = fs::set_permissions(file_path, perms) {
             return Err(anyhow!("Failed to fix file permissions: {}", e));
@@ -565,8 +572,6 @@ fn fix_permissions_and_retry_removal(file_path: &Path) -> Result<()> {
 
 /// Fix permissions on a directory and its contents, then retry removal
 fn fix_directory_permissions_and_retry(dir_path: &Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
     if !dir_path.exists() {
         return Ok(());
     }
@@ -577,7 +582,15 @@ fn fix_directory_permissions_and_retry(dir_path: &Path) -> Result<()> {
             // Make directory executable/readable
             if let Ok(metadata) = fs::metadata(path) {
                 let mut perms = metadata.permissions();
-                perms.set_mode(0o755);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    perms.set_mode(0o755);
+                }
+                #[cfg(not(unix))]
+                {
+                    perms.set_readonly(false);
+                }
                 let _ = fs::set_permissions(path, perms);
             }
 
@@ -591,7 +604,15 @@ fn fix_directory_permissions_and_retry(dir_path: &Path) -> Result<()> {
             // Make file writable
             if let Ok(metadata) = fs::metadata(path) {
                 let mut perms = metadata.permissions();
-                perms.set_mode(0o644);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    perms.set_mode(0o644);
+                }
+                #[cfg(not(unix))]
+                {
+                    perms.set_readonly(false);
+                }
                 let _ = fs::set_permissions(path, perms);
             }
         }

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -52,20 +52,28 @@ pub fn run_set(
                 .join(".workgraph")
                 .join("keys");
             fs::create_dir_all(&keys_dir)?;
-            // Set directory permissions to 700 (Unix only; Windows uses ACLs)
+            // Restrict directory and key file to the current user only.
+            // On Unix: chmod 700/600. On Windows: remove inherited ACEs
+            // and grant full control only to the current user via icacls.
             #[cfg(unix)]
             fs::set_permissions(&keys_dir, fs::Permissions::from_mode(0o700))?;
+            #[cfg(windows)]
+            restrict_windows_acl(&keys_dir);
 
             let key_path = keys_dir.join(format!("{}.key", provider));
             fs::write(&key_path, key_value)?;
-            // Set file permissions to 600 (Unix only; Windows uses ACLs)
             #[cfg(unix)]
             fs::set_permissions(&key_path, fs::Permissions::from_mode(0o600))?;
+            #[cfg(windows)]
+            restrict_windows_acl(&key_path);
 
             #[cfg(unix)]
             println!("Stored key securely in {} (mode 600)", key_path.display());
-            #[cfg(not(unix))]
-            println!("Stored key in {}", key_path.display());
+            #[cfg(windows)]
+            println!(
+                "Stored key in {} (ACL restricted to current user)",
+                key_path.display()
+            );
             (None, Some(key_path.to_string_lossy().to_string()))
         } else {
             unreachable!()
@@ -413,6 +421,63 @@ fn check_openrouter_key_live(
     } else {
         let status = resp.status();
         bail!("HTTP {}", status);
+    }
+}
+
+/// Restrict a file or directory so only the current user can access it.
+///
+/// Uses `icacls` to wipe inherited ACEs (`/inheritance:r`) and grant full
+/// control to the current user (`/grant:r "%USERNAME%":(F)`). This is the
+/// Windows analogue of `chmod 600`/`700` for a single-user setup.
+///
+/// Best-effort: any failure (missing icacls, elevated parent folder, etc.)
+/// is reported to stderr but does not fail the overall operation — the key
+/// is still written and usable, just with the parent folder's default ACL.
+#[cfg(windows)]
+fn restrict_windows_acl(path: &Path) {
+    use std::process::Command;
+    // `%USERNAME%` isn't expanded by Command::new (no shell); pull it from
+    // the environment and pass literally.
+    let user = match std::env::var("USERNAME") {
+        Ok(u) if !u.is_empty() => u,
+        _ => {
+            eprintln!(
+                "warning: USERNAME env var unset; skipping ACL tightening on {}",
+                path.display()
+            );
+            return;
+        }
+    };
+
+    let run = |args: &[&str]| -> std::io::Result<std::process::Output> {
+        use std::os::windows::process::CommandExt;
+        Command::new("icacls")
+            .args(args)
+            .creation_flags(0x0800_0000) // CREATE_NO_WINDOW
+            .output()
+    };
+
+    let p = path.to_string_lossy().into_owned();
+    // Step 1: disable inheritance and convert inherited ACEs to explicit
+    // so we can then wipe them cleanly.
+    if let Err(e) = run(&[&p, "/inheritance:r"]) {
+        eprintln!(
+            "warning: icacls /inheritance:r failed on {}: {}",
+            path.display(),
+            e
+        );
+        return;
+    }
+    // Step 2: grant full control to current user, replacing any existing
+    // grants for that principal.
+    let grant = format!("{}:(F)", user);
+    if let Err(e) = run(&[&p, "/grant:r", &grant]) {
+        eprintln!(
+            "warning: icacls /grant:r {} failed on {}: {}",
+            grant,
+            path.display(),
+            e
+        );
     }
 }
 

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -3,6 +3,7 @@
 use anyhow::{Result, bail};
 use reqwest::blocking::Client;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use workgraph::config::{Config, EndpointConfig};
@@ -51,15 +52,20 @@ pub fn run_set(
                 .join(".workgraph")
                 .join("keys");
             fs::create_dir_all(&keys_dir)?;
-            // Set directory permissions to 700
+            // Set directory permissions to 700 (Unix only; Windows uses ACLs)
+            #[cfg(unix)]
             fs::set_permissions(&keys_dir, fs::Permissions::from_mode(0o700))?;
 
             let key_path = keys_dir.join(format!("{}.key", provider));
             fs::write(&key_path, key_value)?;
-            // Set file permissions to 600
+            // Set file permissions to 600 (Unix only; Windows uses ACLs)
+            #[cfg(unix)]
             fs::set_permissions(&key_path, fs::Permissions::from_mode(0o600))?;
 
+            #[cfg(unix)]
             println!("Stored key securely in {} (mode 600)", key_path.display());
+            #[cfg(not(unix))]
+            println!("Stored key in {}", key_path.display());
             (None, Some(key_path.to_string_lossy().to_string()))
         } else {
             unreachable!()

--- a/src/commands/service/coordinator_agent.rs
+++ b/src/commands/service/coordinator_agent.rs
@@ -496,8 +496,19 @@ impl CoordinatorAgent {
             return false;
         }
         // Send SIGINT (not SIGKILL) — Claude CLI treats this as "stop generating"
+        #[cfg(unix)]
         unsafe {
             libc::kill(pid as i32, libc::SIGINT);
+        }
+        // Windows has no clean SIGINT equivalent for an arbitrary process.
+        // GenerateConsoleCtrlEvent only works on processes sharing our console.
+        // Fall back to taskkill (hard terminate); the agent will restart from
+        // the last persisted conversation turn.
+        #[cfg(windows)]
+        {
+            let _ = std::process::Command::new("taskkill")
+                .args(["/PID", &pid.to_string()])
+                .output();
         }
         true
     }

--- a/src/commands/service/coordinator_agent.rs
+++ b/src/commands/service/coordinator_agent.rs
@@ -495,20 +495,28 @@ impl CoordinatorAgent {
         if pid == 0 {
             return false;
         }
-        // Send SIGINT (not SIGKILL) — Claude CLI treats this as "stop generating"
+        // Send SIGINT (Unix) or Ctrl+Break (Windows) — Claude CLI treats
+        // either as "stop generating and emit TurnComplete", preserving
+        // conversation context.
         #[cfg(unix)]
         unsafe {
             libc::kill(pid as i32, libc::SIGINT);
         }
-        // Windows has no clean SIGINT equivalent for an arbitrary process.
-        // GenerateConsoleCtrlEvent only works on processes sharing our console.
-        // Fall back to taskkill (hard terminate); the agent will restart from
-        // the last persisted conversation turn.
         #[cfg(windows)]
         {
-            let _ = std::process::Command::new("taskkill")
-                .args(["/PID", &pid.to_string()])
-                .output();
+            // `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)` delivers
+            // Ctrl+Break to the target process group. This requires the
+            // child to have been spawned with `CREATE_NEW_PROCESS_GROUP`,
+            // which `spawn_claude_process` sets. If that flag is missing
+            // the call silently no-ops (a non-zero return from the API
+            // wouldn't indicate "child didn't get a signal", so we don't
+            // check it).
+            use windows_sys::Win32::System::Console::{
+                CTRL_BREAK_EVENT, GenerateConsoleCtrlEvent,
+            };
+            unsafe {
+                GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid);
+            }
         }
         true
     }
@@ -2487,6 +2495,18 @@ fn spawn_claude_process(
     cmd.current_dir(dir.parent().unwrap_or(dir));
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
+
+    // On Windows, put the Claude process in its own process group so we can
+    // send it a Ctrl+Break via `GenerateConsoleCtrlEvent` later. Without this
+    // flag, signals would propagate to the whole process tree (including our
+    // daemon). `interrupt()` relies on this — if the flag is missing the
+    // console-ctrl call silently no-ops.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NEW_PROCESS_GROUP = 0x00000200
+        cmd.creation_flags(0x0000_0200);
+    }
 
     // Redirect stderr to a log file for debugging (using Stdio::null() swallows errors)
     let stderr_path = dir.join("service").join("coordinator-stderr.log");

--- a/src/commands/service/ipc.rs
+++ b/src/commands/service/ipc.rs
@@ -1,13 +1,11 @@
 //! IPC protocol: message types and request handlers for the service daemon.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+use interprocess::local_socket::{Stream, prelude::*};
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::time::Duration;
-
-#[cfg(unix)]
-use std::os::unix::net::UnixStream;
 
 use workgraph::config::Config;
 use workgraph::cron::{calculate_next_fire, parse_cron_expression};
@@ -181,11 +179,15 @@ impl IpcResponse {
 }
 
 /// Handle a single IPC connection
-#[cfg(unix)]
+///
+/// Uses `&Stream` for both reading and writing — `interprocess::local_socket::Stream`
+/// exposes `Read`/`Write` on shared references, so we can run a `BufReader<&Stream>`
+/// and write responses via `(&stream).write_all(...)` in the same scope without
+/// needing a `try_clone`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_connection(
     dir: &Path,
-    stream: UnixStream,
+    stream: Stream,
     running: &mut bool,
     wake_coordinator: &mut bool,
     urgent_wake: &mut bool,
@@ -195,21 +197,18 @@ pub(crate) fn handle_connection(
     daemon_cfg: &mut DaemonConfig,
     logger: &DaemonLogger,
 ) -> Result<()> {
-    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    // Ensure reads block (the accepting listener is non-blocking, but we want
+    // straightforward request/response on the accepted connection).
+    stream.set_nonblocking(false)?;
 
-    // Clone stream for writing
-    let mut write_stream = stream
-        .try_clone()
-        .context("Failed to clone stream for writing")?;
-    let reader = BufReader::new(stream);
+    let reader = BufReader::new(&stream);
 
     for line in reader.lines() {
         let line = match line {
             Ok(l) => l,
             Err(e) => {
                 let response = IpcResponse::error(&format!("Read error: {}", e));
-                if let Err(we) = write_response(&mut write_stream, &response) {
+                if let Err(we) = write_response(&stream, &response) {
                     logger.warn(&format!("Failed to send error response: {}", we));
                 }
                 return Ok(());
@@ -225,7 +224,7 @@ pub(crate) fn handle_connection(
             Err(e) => {
                 logger.warn(&format!("Invalid IPC request: {}", e));
                 let response = IpcResponse::error(&format!("Invalid request: {}", e));
-                write_response(&mut write_stream, &response)?;
+                write_response(&stream, &response)?;
                 continue;
             }
         };
@@ -242,7 +241,7 @@ pub(crate) fn handle_connection(
             daemon_cfg,
             logger,
         );
-        write_response(&mut write_stream, &response)?;
+        write_response(&stream, &response)?;
 
         // Check if we should stop
         if !*running {
@@ -253,11 +252,11 @@ pub(crate) fn handle_connection(
     Ok(())
 }
 
-#[cfg(unix)]
-fn write_response(stream: &mut UnixStream, response: &IpcResponse) -> Result<()> {
+fn write_response(stream: &Stream, response: &IpcResponse) -> Result<()> {
     let json = serde_json::to_string(response)?;
-    writeln!(stream, "{}", json)?;
-    stream.flush()?;
+    let mut w = stream;
+    writeln!(w, "{}", json)?;
+    w.flush()?;
     Ok(())
 }
 

--- a/src/commands/service/mod.rs
+++ b/src/commands/service/mod.rs
@@ -789,6 +789,7 @@ pub fn run_tick(
     Ok(())
 }
 
+#[cfg(unix)]
 pub fn find_orphan_daemon_pids(dir: &Path, exclude_pid: Option<u32>) -> Vec<u32> {
     let canonical = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
     let dir_str = canonical.to_string_lossy().to_string();

--- a/src/commands/service/mod.rs
+++ b/src/commands/service/mod.rs
@@ -37,8 +37,61 @@ use std::process;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-#[cfg(unix)]
-use std::os::unix::net::{UnixListener, UnixStream};
+use interprocess::local_socket::{
+    Listener, ListenerNonblockingMode, ListenerOptions, Stream, prelude::*,
+};
+
+/// Derive the local-socket name for the daemon at the given filesystem path.
+///
+/// On Unix, this is the filesystem path itself — the socket is a real UDS
+/// file at that location, so existing tooling (`ls`, `rm`, etc.) keeps
+/// working and multiple daemons on the same machine get distinct sockets
+/// naturally via distinct paths.
+///
+/// On Windows, named pipes live in a flat `\\.\pipe\*` namespace rather
+/// than the filesystem, and `interprocess` rejects filesystem-style paths
+/// with "not a named pipe path". We hash the full path into a short stable
+/// name so each workgraph directory still gets its own pipe.
+fn socket_name(
+    path: &Path,
+) -> std::io::Result<interprocess::local_socket::Name<'static>> {
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+        path.as_os_str()
+            .to_os_string()
+            .to_fs_name::<GenericFilePath>()
+    }
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        // Normalise so the client and the daemon derive the same hash even
+        // when one side got an msys-style path and the other got a Windows
+        // one. `std::path::absolute` resolves `.` components and returns a
+        // platform-native absolute path without requiring the path to exist.
+        let abs = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+        let mut hasher = DefaultHasher::new();
+        abs.hash(&mut hasher);
+        let name = format!("workgraph-daemon-{:016x}", hasher.finish());
+        name.to_ns_name::<GenericNamespaced>()
+    }
+}
+
+/// Connect to the daemon's local socket.
+fn connect_to_socket(path: &Path) -> std::io::Result<Stream> {
+    Stream::connect(socket_name(path)?)
+}
+
+/// Bind a listener for the daemon's local socket.
+///
+/// On Unix this creates a real UDS file at `path`. On Windows the path
+/// seeds a namespaced named-pipe identifier and no filesystem entry is
+/// created.
+fn bind_socket(path: &Path) -> std::io::Result<Listener> {
+    ListenerOptions::new().name(socket_name(path)?).create_sync()
+}
 
 use chrono::{DateTime, Utc};
 
@@ -848,7 +901,6 @@ pub fn find_orphan_daemon_pids(_dir: &Path, _exclude_pid: Option<u32>) -> Vec<u3
 }
 
 /// Start the service daemon
-#[cfg(unix)]
 #[allow(clippy::too_many_arguments)]
 pub fn run_start(
     dir: &Path,
@@ -878,7 +930,7 @@ pub fn run_start(
                 // Send shutdown via IPC first (graceful)
                 let socket = PathBuf::from(&state.socket_path);
                 if socket.exists()
-                    && let Ok(mut stream) = UnixStream::connect(&socket)
+                    && let Ok(mut stream) = connect_to_socket(&socket)
                 {
                     let request = IpcRequest::Shutdown {
                         force: false,
@@ -1164,22 +1216,6 @@ pub fn run_start(
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_start(
-    _dir: &Path,
-    _socket_path: Option<&str>,
-    _port: Option<u16>,
-    _max_agents: Option<usize>,
-    _executor: Option<&str>,
-    _interval: Option<u64>,
-    _model: Option<&str>,
-    _json: bool,
-    _force: bool,
-    _no_coordinator_agent: bool,
-) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Reap zombie child processes (non-blocking).
 ///
 /// The daemon spawns agent processes via `Command::spawn()`. When an agent
@@ -1194,6 +1230,12 @@ fn reap_zombies() {
             break; // No more zombies (0) or error (-1, e.g. no children)
         }
     }
+}
+
+#[cfg(not(unix))]
+fn reap_zombies() {
+    // Windows has no zombie-process concept: the kernel finalises exited
+    // processes without requiring a parent `waitpid`. No-op.
 }
 
 /// Mutable coordinator runtime config, updated by Reconfigure IPC.
@@ -1780,7 +1822,6 @@ fn do_registry_refresh(dir: &Path) -> Result<String> {
 }
 
 /// Run the actual daemon loop (called by forked process)
-#[cfg(unix)]
 pub fn run_daemon(
     dir: &Path,
     socket_path: &str,
@@ -1848,11 +1889,12 @@ pub fn run_daemon(
         fs::remove_file(&socket)?;
     }
 
-    // Bind to socket
-    let listener = UnixListener::bind(&socket)
+    // Bind the daemon socket (UDS on Unix, named pipe on Windows).
+    let listener = bind_socket(&socket)
         .with_context(|| format!("Failed to bind to socket {:?}", socket))?;
 
-    // Set socket permissions
+    // Tighten Unix socket permissions to owner-only (Windows named pipes
+    // default to the creator's security descriptor, which is equivalent).
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -1860,8 +1902,8 @@ pub fn run_daemon(
         fs::set_permissions(&socket, perms)?;
     }
 
-    // Set non-blocking for graceful shutdown
-    listener.set_nonblocking(true)?;
+    // Non-blocking so the accept loop can also service timers/tick checks.
+    listener.set_nonblocking(ListenerNonblockingMode::Both)?;
 
     let dir = dir.to_path_buf();
     let mut running = true;
@@ -2061,20 +2103,13 @@ pub fn run_daemon(
     let mut archival_error_count: u64 = 0;
     let mut refresh_error_count: u64 = 0;
 
-    // Obtain the raw fd for poll()-based waiting. This lets the daemon
-    // sleep until an IPC connection arrives OR a timeout expires, instead
-    // of busy-polling with a fixed sleep.
-    let listener_fd = {
-        use std::os::unix::io::AsRawFd;
-        listener.as_raw_fd()
-    };
-
     while running {
         // Reap zombie child processes (agents that have exited).
         // Even though agents call setsid() to create a new session, they are
         // still children of the daemon (parent-child is set at fork, not
         // affected by setsid). Without reaping, killed agents remain as
-        // zombies and is_process_alive(pid) keeps returning true.
+        // zombies and is_process_alive(pid) keeps returning true. No-op on
+        // Windows — the OS cleans up exited children without parent action.
         reap_zombies();
 
         // Calculate how long to sleep. We wake on: incoming IPC connection,
@@ -2102,22 +2137,38 @@ pub fn run_daemon(
         // Floor: don't spin faster than 50ms even with a deadline in the past.
         poll_timeout_ms = poll_timeout_ms.max(50);
 
-        // Wait for an incoming connection or timeout.
-        let mut pollfd = libc::pollfd {
-            fd: listener_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        let poll_ret = unsafe { libc::poll(&mut pollfd, 1, poll_timeout_ms) };
-
-        if poll_ret < 0 {
-            // EINTR (e.g. SIGCHLD) — just loop back to reap and retry.
-            continue;
+        // Wait for an incoming connection or the computed timeout. The
+        // listener is non-blocking, so we try accept, sleep briefly if it
+        // returns WouldBlock, and loop until either a connection arrives or
+        // the timeout elapses. On Unix this used `libc::poll` directly on
+        // the listener fd, but `interprocess` doesn't expose a raw fd/HANDLE
+        // for named pipes, so we poll in userspace. At 10ms per poll this
+        // costs ~100 wakeups per second at steady state — a fine trade for
+        // portability.
+        let poll_start = Instant::now();
+        let poll_timeout = Duration::from_millis(poll_timeout_ms as u64);
+        let mut accepted: Option<Stream> = None;
+        loop {
+            match listener.accept() {
+                Ok(stream) => {
+                    accepted = Some(stream);
+                    break;
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    if poll_start.elapsed() >= poll_timeout {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => {
+                    logger.error(&format!("Accept error: {}", e));
+                    break;
+                }
+            }
         }
 
-        // Try to accept; may still get WouldBlock if poll was a timeout.
-        match listener.accept() {
-            Ok((stream, _)) => {
+        if let Some(stream) = accepted {
+            {
                 let mut wake_coordinator = false;
                 let mut conn_urgent_wake = false;
                 let mut conn_delete_coordinator_ids = Vec::new();
@@ -2185,14 +2236,8 @@ pub fn run_daemon(
                     }
                 }
             }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                // poll() timed out — no connection pending, fall through to
-                // tick checks.
-            }
-            Err(e) => {
-                logger.error(&format!("Accept error: {}", e));
-            }
         }
+        // (No connection within the timeout falls through to tick checks.)
 
         // Keep coordinator chat history compacted so native coordinator sessions
         // can reset their in-memory conversation between exchanges.
@@ -2507,13 +2552,33 @@ pub fn run_daemon(
                                             original_args[1..].join(" "),
                                         ));
 
-                                        // exec() replaces the process image — only
-                                        // returns on error.
-                                        use std::os::unix::process::CommandExt;
-                                        let err = process::Command::new(path)
+                                        // Hot-restart: on Unix, exec() replaces the
+                                        // process image in-place (same PID, cheap).
+                                        // On Windows there's no exec, so we spawn
+                                        // the new binary as a child and exit —
+                                        // the PID changes but state is on disk,
+                                        // so the new daemon picks up where we
+                                        // left off. In both cases the call returns
+                                        // only on error.
+                                        #[cfg(unix)]
+                                        let err = {
+                                            use std::os::unix::process::CommandExt;
+                                            process::Command::new(path)
+                                                .args(&original_args[1..])
+                                                .exec()
+                                        };
+                                        #[cfg(windows)]
+                                        let err: std::io::Error = match process::Command::new(path)
                                             .args(&original_args[1..])
-                                            .exec();
-                                        // If we get here, exec failed.
+                                            .spawn()
+                                        {
+                                            Ok(_) => {
+                                                logger.info("New daemon spawned, exiting old one");
+                                                std::process::exit(0);
+                                            }
+                                            Err(e) => e,
+                                        };
+                                        // If we get here, the restart failed.
                                         logger.error(&format!(
                                             "Exec-restart failed: {}. Continuing with old binary.",
                                             err
@@ -2566,19 +2631,6 @@ pub fn run_daemon(
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_daemon(
-    _dir: &Path,
-    _socket_path: &str,
-    _max_agents: Option<usize>,
-    _executor: Option<&str>,
-    _interval: Option<u64>,
-    _model: Option<&str>,
-    _no_coordinator_agent: bool,
-) -> Result<()> {
-    anyhow::bail!("Daemon is only supported on Unix systems")
-}
-
 /// Check if the caller is an agent and refuse stop/pause operations.
 /// Returns `Err` if `WG_AGENT_ID` is set, `Ok(())` otherwise.
 fn guard_agent_stop_pause() -> Result<()> {
@@ -2589,14 +2641,12 @@ fn guard_agent_stop_pause() -> Result<()> {
 }
 
 /// Stop the service daemon
-#[cfg(unix)]
 pub fn run_stop(dir: &Path, force: bool, kill_agents: bool, json: bool) -> Result<()> {
     guard_agent_stop_pause()?;
     run_stop_inner(dir, force, kill_agents, json)
 }
 
 /// Inner stop logic (no agent guard) — used by `run_restart` to bypass the guard.
-#[cfg(unix)]
 fn run_stop_inner(dir: &Path, force: bool, kill_agents: bool, json: bool) -> Result<()> {
     let state = match ServiceState::load(dir)? {
         Some(s) => s,
@@ -2614,7 +2664,7 @@ fn run_stop_inner(dir: &Path, force: bool, kill_agents: bool, json: bool) -> Res
     // Try to send shutdown command via socket
     let socket = PathBuf::from(&state.socket_path);
     if socket.exists()
-        && let Ok(mut stream) = UnixStream::connect(&socket)
+        && let Ok(mut stream) = connect_to_socket(&socket)
     {
         let request = IpcRequest::Shutdown { force, kill_agents };
         let json_req = serde_json::to_string(&request)?;
@@ -2684,17 +2734,11 @@ fn run_stop_inner(dir: &Path, force: bool, kill_agents: bool, json: bool) -> Res
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_stop(_dir: &Path, _force: bool, _kill_agents: bool, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Restart the service daemon: graceful stop (agents kept alive) then start.
 ///
 /// Reads the running daemon's effective config (max_agents, executor, model,
 /// poll_interval) before stopping, and passes it to the new daemon so the
 /// restart is transparent.
-#[cfg(unix)]
 pub fn run_restart(dir: &Path, json: bool) -> Result<()> {
     // Capture the current daemon's effective config before stopping.
     let prior_config = CoordinatorState::load(dir);
@@ -2724,13 +2768,7 @@ pub fn run_restart(dir: &Path, json: bool) -> Result<()> {
     )
 }
 
-#[cfg(not(unix))]
-pub fn run_restart(_dir: &Path, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Show service status
-#[cfg(unix)]
 pub fn run_status(dir: &Path, json: bool) -> Result<()> {
     let state = match ServiceState::load(dir)? {
         Some(s) => s,
@@ -2947,13 +2985,7 @@ pub fn run_status(dir: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_status(_dir: &Path, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Reload service daemon configuration at runtime
-#[cfg(unix)]
 pub fn run_reload(
     dir: &Path,
     max_agents: Option<usize>,
@@ -3022,20 +3054,7 @@ pub fn run_reload(
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_reload(
-    _dir: &Path,
-    _max_agents: Option<usize>,
-    _executor: Option<&str>,
-    _interval: Option<u64>,
-    _model: Option<&str>,
-    _json: bool,
-) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Pause the coordinator (no new agent spawns, running agents unaffected)
-#[cfg(unix)]
 pub fn run_pause(dir: &Path, json: bool) -> Result<()> {
     guard_agent_stop_pause()?;
 
@@ -3065,13 +3084,7 @@ pub fn run_pause(dir: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_pause(_dir: &Path, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Resume the coordinator (triggers immediate tick) and clear provider health pauses
-#[cfg(unix)]
 pub fn run_resume(dir: &Path, json: bool) -> Result<()> {
     // Clear provider health pause state before resuming coordinator
     match workgraph::service::ProviderHealth::load(dir) {
@@ -3135,13 +3148,7 @@ pub fn run_resume(dir: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_resume(_dir: &Path, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Freeze all running agents (SIGSTOP) and pause the coordinator
-#[cfg(unix)]
 pub fn run_freeze(dir: &Path, json: bool) -> Result<()> {
     guard_agent_stop_pause()?;
 
@@ -3188,13 +3195,7 @@ pub fn run_freeze(dir: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_freeze(_dir: &Path, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Thaw all frozen agents (SIGCONT) and resume the coordinator
-#[cfg(unix)]
 pub fn run_thaw(dir: &Path, json: bool) -> Result<()> {
     let response = send_request(dir, &IpcRequest::Thaw)?;
 
@@ -3250,13 +3251,7 @@ pub fn run_thaw(dir: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_thaw(_dir: &Path, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Create a new coordinator session via IPC
-#[cfg(unix)]
 pub fn run_create_coordinator(
     dir: &Path,
     name: Option<&str>,
@@ -3293,19 +3288,7 @@ pub fn run_create_coordinator(
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_create_coordinator(
-    _dir: &Path,
-    _name: Option<&str>,
-    _model: Option<&str>,
-    _executor: Option<&str>,
-    _json: bool,
-) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Delete a coordinator session via IPC
-#[cfg(unix)]
 pub fn run_delete_coordinator(dir: &Path, coordinator_id: u32, json: bool) -> Result<()> {
     let response = send_request(dir, &IpcRequest::DeleteCoordinator { coordinator_id })?;
 
@@ -3329,13 +3312,7 @@ pub fn run_delete_coordinator(dir: &Path, coordinator_id: u32, json: bool) -> Re
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_delete_coordinator(_dir: &Path, _coordinator_id: u32, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Archive a coordinator session via IPC (mark as Done)
-#[cfg(unix)]
 pub fn run_archive_coordinator(dir: &Path, coordinator_id: u32, json: bool) -> Result<()> {
     let response = send_request(dir, &IpcRequest::ArchiveCoordinator { coordinator_id })?;
 
@@ -3359,13 +3336,7 @@ pub fn run_archive_coordinator(dir: &Path, coordinator_id: u32, json: bool) -> R
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_archive_coordinator(_dir: &Path, _coordinator_id: u32, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Stop a coordinator session via IPC (kill agent, reset to Open)
-#[cfg(unix)]
 pub fn run_stop_coordinator(dir: &Path, coordinator_id: u32, json: bool) -> Result<()> {
     let response = send_request(dir, &IpcRequest::StopCoordinator { coordinator_id })?;
 
@@ -3389,13 +3360,7 @@ pub fn run_stop_coordinator(dir: &Path, coordinator_id: u32, json: bool) -> Resu
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_stop_coordinator(_dir: &Path, _coordinator_id: u32, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Interrupt a coordinator's current generation via IPC (sends SIGINT, does NOT kill).
-#[cfg(unix)]
 pub fn run_interrupt_coordinator(dir: &Path, coordinator_id: u32, json: bool) -> Result<()> {
     let response = send_request(dir, &IpcRequest::InterruptCoordinator { coordinator_id })?;
 
@@ -3419,15 +3384,9 @@ pub fn run_interrupt_coordinator(dir: &Path, coordinator_id: u32, json: bool) ->
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn run_interrupt_coordinator(_dir: &Path, _coordinator_id: u32, _json: bool) -> Result<()> {
-    anyhow::bail!("Service daemon is only supported on Unix systems")
-}
-
 /// Check if a Unix socket is accepting connections by doing a quick connect+drop.
-#[cfg(unix)]
 fn socket_accepting(socket: &Path) -> bool {
-    UnixStream::connect(socket).is_ok()
+    connect_to_socket(socket).is_ok()
 }
 
 /// Public wrapper: check if the service process is alive
@@ -3445,7 +3404,6 @@ pub fn is_service_paused(dir: &Path) -> bool {
 /// Retries transient connection failures (ECONNREFUSED, broken pipe) up to 2
 /// times with short exponential backoff (50ms, 100ms) before giving up.
 /// Distinguishes "daemon not running" from "daemon unreachable" in errors.
-#[cfg(unix)]
 pub fn send_request(dir: &Path, request: &IpcRequest) -> Result<IpcResponse> {
     let state = ServiceState::load(dir)?.ok_or_else(|| {
         anyhow::anyhow!("Service not running (no state file). Start it with 'wg service start'.")
@@ -3482,10 +3440,13 @@ pub fn send_request(dir: &Path, request: &IpcRequest) -> Result<IpcResponse> {
             ));
         }
 
-        match UnixStream::connect(&socket) {
+        match connect_to_socket(&socket) {
             Ok(mut stream) => {
-                stream.set_read_timeout(Some(Duration::from_secs(30)))?;
-                stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+                // `interprocess::local_socket::Stream` doesn't expose per-op
+                // read/write timeouts portably (they mean different things for
+                // UDS vs named pipes). For local IPC on the same machine these
+                // were a belt-and-braces safety net; dropping them is fine in
+                // practice, and Ctrl+C still interrupts a truly hung daemon.
 
                 let json = serde_json::to_string(&request)?;
                 writeln!(stream, "{}", json)?;
@@ -3526,11 +3487,6 @@ pub fn send_request(dir: &Path, request: &IpcRequest) -> Result<IpcResponse> {
         MAX_RETRIES,
         err
     )
-}
-
-#[cfg(not(unix))]
-pub fn send_request(_dir: &Path, _request: &IpcRequest) -> Result<IpcResponse> {
-    anyhow::bail!("IPC is only supported on Unix systems")
 }
 
 #[cfg(test)]

--- a/src/commands/spawn/worktree.rs
+++ b/src/commands/spawn/worktree.rs
@@ -62,7 +62,11 @@ pub fn create_worktree(
         anyhow::bail!("git worktree add failed: {}", stderr.trim());
     }
 
-    // Symlink .workgraph so wg CLI works from the worktree
+    // Link .workgraph into the worktree so `wg` CLI commands resolve to the
+    // same graph. On Unix this is a symlink; on Windows it's a directory
+    // junction (via `mklink /J`), which — unlike a symlink — doesn't require
+    // Developer Mode or admin. Junctions resolve identically for all the
+    // path operations workgraph performs.
     let symlink_target = workgraph_dir
         .canonicalize()
         .context("Failed to canonicalize .workgraph path")?;
@@ -71,8 +75,8 @@ pub fn create_worktree(
     std::os::unix::fs::symlink(&symlink_target, &symlink_path)
         .context("Failed to symlink .workgraph into worktree")?;
     #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(&symlink_target, &symlink_path)
-        .context("Failed to symlink .workgraph into worktree (requires Developer Mode or admin)")?;
+    create_windows_link(&symlink_target, &symlink_path)
+        .context("Failed to link .workgraph into worktree")?;
 
     // Run worktree-setup.sh if it exists
     let setup_script = workgraph_dir.join("worktree-setup.sh");
@@ -124,6 +128,40 @@ pub fn remove_worktree(project_root: &Path, worktree_path: &Path, branch: &str) 
     // temporarily missing during concurrent cleanup, causing data loss.
 
     Ok(())
+}
+
+/// Create a directory-link at `link_path` pointing to `target` on Windows.
+///
+/// Prefers a junction (`mklink /J`) over a symlink because junctions work for
+/// every user without Developer Mode or admin privileges. A junction only
+/// supports absolute local paths and only links directories, both of which
+/// are true for `.workgraph`. If `mklink` isn't available we fall back to
+/// `symlink_dir`, which will fail helpfully if the user doesn't have the
+/// required privileges.
+#[cfg(windows)]
+fn create_windows_link(target: &Path, link_path: &Path) -> Result<()> {
+    use std::os::windows::process::CommandExt;
+    // `mklink` is a cmd.exe builtin, not an .exe; must invoke through cmd.
+    // `/J` = directory junction. CREATE_NO_WINDOW = 0x08000000 suppresses the
+    // flashing console window when running from a GUI context.
+    let status = Command::new("cmd")
+        .args([
+            "/C",
+            "mklink",
+            "/J",
+            &link_path.to_string_lossy(),
+            &target.to_string_lossy(),
+        ])
+        .creation_flags(0x0800_0000)
+        .status();
+
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        _ => std::os::windows::fs::symlink_dir(target, link_path).context(
+            "mklink /J failed and symlink_dir fallback also failed; \
+             junctions normally work without admin — is cmd.exe on PATH?",
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -276,8 +314,14 @@ mod tests {
 
         let info = create_worktree(&project, &wg_dir, "agent-2", "task-bar").unwrap();
         let symlink = info.path.join(".workgraph");
+        // On Unix this is a symlink; on Windows it's a directory junction
+        // (a reparse point that isn't classified as a symlink by the stdlib
+        // but resolves identically for I/O).
+        #[cfg(unix)]
         assert!(symlink.is_symlink());
-        // The marker file should be readable through the symlink
+        #[cfg(windows)]
+        assert!(symlink.exists(), "link should be readable");
+        // The marker file should be readable through the link
         assert_eq!(
             std::fs::read_to_string(symlink.join("marker")).unwrap(),
             "test"

--- a/src/commands/spawn/worktree.rs
+++ b/src/commands/spawn/worktree.rs
@@ -67,8 +67,12 @@ pub fn create_worktree(
         .canonicalize()
         .context("Failed to canonicalize .workgraph path")?;
     let symlink_path = worktree_dir.join(".workgraph");
+    #[cfg(unix)]
     std::os::unix::fs::symlink(&symlink_target, &symlink_path)
         .context("Failed to symlink .workgraph into worktree")?;
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&symlink_target, &symlink_path)
+        .context("Failed to symlink .workgraph into worktree (requires Developer Mode or admin)")?;
 
     // Run worktree-setup.sh if it exists
     let setup_script = workgraph_dir.join("worktree-setup.sh");

--- a/src/executor/native/background.rs
+++ b/src/executor/native/background.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -25,15 +25,38 @@ pub use registry::{AgentEntry, AgentRegistry, AgentStatus, LockedRegistry};
 /// Check if a process with the given PID is alive.
 ///
 /// Uses `kill(pid, 0)` on Unix to probe without sending a signal.
-/// On non-Unix platforms, conservatively assumes the process is alive.
+/// On Windows, uses `tasklist` to check for the PID.
 #[cfg(unix)]
 pub fn is_process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 
-#[cfg(not(unix))]
-pub fn is_process_alive(_pid: u32) -> bool {
-    true
+#[cfg(windows)]
+pub fn is_process_alive(pid: u32) -> bool {
+    // `tasklist /FI "PID eq <pid>" /NH /FO CSV` prints a row per matching
+    // process and "INFO: No tasks are running which match the specified
+    // criteria." on stderr when nothing matches. A quick sentinel check on
+    // stdout is cheaper than parsing.
+    use std::process::Command;
+    let out = Command::new("tasklist")
+        .args([
+            "/FI",
+            &format!("PID eq {}", pid),
+            "/NH",
+            "/FO",
+            "CSV",
+        ])
+        .output();
+    match out {
+        Ok(o) if o.status.success() => {
+            let s = String::from_utf8_lossy(&o.stdout);
+            // When there's a match the output contains the PID in a CSV cell;
+            // when nothing matches tasklist prints the "No tasks..." line to
+            // stderr and produces empty stdout.
+            !s.trim().is_empty() && s.contains(&pid.to_string())
+        }
+        _ => false,
+    }
 }
 
 /// Collect all descendant PIDs of `root_pid` by walking `/proc/*/stat`.
@@ -174,9 +197,37 @@ pub fn kill_process_graceful(pid: u32, wait_secs: u64) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn kill_process_graceful(_pid: u32, _wait_secs: u64) -> anyhow::Result<()> {
-    anyhow::bail!("Process killing is only supported on Unix systems")
+#[cfg(windows)]
+pub fn kill_process_graceful(pid: u32, wait_secs: u64) -> anyhow::Result<()> {
+    use std::process::Command;
+    use std::thread;
+    use std::time::Duration;
+
+    if !is_process_alive(pid) {
+        return Ok(());
+    }
+
+    // `taskkill /T` without /F requests a graceful WM_CLOSE + tree kill on
+    // the process and its descendants. This is the closest Windows analogue
+    // to SIGTERM-on-a-process-group. Console-only processes often ignore it
+    // since they have no window, but it's still worth trying first.
+    let _ = Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T"])
+        .output();
+
+    for _ in 0..wait_secs {
+        thread::sleep(Duration::from_secs(1));
+        if !is_process_alive(pid) {
+            return Ok(());
+        }
+    }
+
+    // Still alive — force kill the tree.
+    let _ = Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .output();
+
+    Ok(())
 }
 
 /// Send SIGKILL to `pid` and all its descendants.
@@ -199,9 +250,14 @@ pub fn kill_process_force(pid: u32) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn kill_process_force(_pid: u32) -> anyhow::Result<()> {
-    anyhow::bail!("Process killing is only supported on Unix systems")
+#[cfg(windows)]
+pub fn kill_process_force(pid: u32) -> anyhow::Result<()> {
+    use std::process::Command;
+    // `taskkill /F /T /PID` hard-terminates the whole tree.
+    let _ = Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .output();
+    Ok(())
 }
 
 /// SIGKILL every descendant of `root_pid` *without* touching `root_pid`
@@ -221,8 +277,37 @@ pub fn kill_descendants(root_pid: u32) {
     }
 }
 
-#[cfg(not(unix))]
-pub fn kill_descendants(_root_pid: u32) {}
+#[cfg(windows)]
+pub fn kill_descendants(root_pid: u32) {
+    // `taskkill /T` without listing the parent PID target isn't possible;
+    // `taskkill /F /T /PID <root>` kills the root AND its tree. We want the
+    // tree only. Walk the tree via `wmic` and kill each child.
+    use std::process::Command;
+    let Ok(out) = Command::new("wmic")
+        .args([
+            "process",
+            "where",
+            &format!("ParentProcessId={}", root_pid),
+            "get",
+            "ProcessId",
+            "/format:value",
+        ])
+        .output()
+    else {
+        return;
+    };
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for line in stdout.lines() {
+        if let Some(pid_str) = line.strip_prefix("ProcessId=")
+            && let Ok(pid) = pid_str.trim().parse::<u32>()
+            && pid != 0
+        {
+            let _ = Command::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/T", "/F"])
+                .output();
+        }
+    }
+}
 
 /// Read a process's start time from `/proc/<pid>/stat` as seconds since epoch.
 ///

--- a/src/tui/viz_viewer/screen_dump.rs
+++ b/src/tui/viz_viewer/screen_dump.rs
@@ -13,9 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
-use interprocess::local_socket::{
-    GenericFilePath, ListenerOptions, Stream, ToFsName, prelude::*,
-};
+use interprocess::local_socket::{ListenerOptions, Stream, prelude::*};
 use ratatui::buffer::Buffer;
 use serde::{Deserialize, Serialize};
 
@@ -180,6 +178,37 @@ pub fn tui_socket_path(workgraph_dir: &Path) -> PathBuf {
     workgraph_dir.join("service").join("tui.sock")
 }
 
+/// Derive the local-socket name for the TUI dump server at the given path.
+///
+/// See the equivalent helper in `commands::service::mod` for the reasoning:
+/// Unix UDS uses the filesystem path directly, while Windows named pipes
+/// live in a flat namespace and need a stable hashed name derived from the
+/// path to keep multiple workgraph dirs separate.
+fn tui_socket_name(
+    path: &Path,
+) -> std::io::Result<interprocess::local_socket::Name<'static>> {
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+        path.as_os_str()
+            .to_os_string()
+            .to_fs_name::<GenericFilePath>()
+    }
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        // Normalise so client and server derive the same hash regardless of
+        // how their path was given to them (msys vs Windows form).
+        let abs = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+        let mut hasher = DefaultHasher::new();
+        abs.hash(&mut hasher);
+        let name = format!("workgraph-tui-{:016x}", hasher.finish());
+        name.to_ns_name::<GenericNamespaced>()
+    }
+}
+
 /// Start the screen dump server in a background thread.
 ///
 /// Returns `Ok(())` after spawning the listener.  The listener runs until
@@ -206,9 +235,7 @@ pub fn start_server(
         let _ = std::fs::remove_file(&socket_path);
     }
 
-    let name = socket_path
-        .as_os_str()
-        .to_fs_name::<GenericFilePath>()?;
+    let name = tui_socket_name(&socket_path)?;
     let listener = ListenerOptions::new().name(name).create_sync()?;
 
     // Non-blocking so we can check the shutdown flag periodically.
@@ -299,7 +326,7 @@ pub fn client_dump(workgraph_dir: &Path) -> Result<ScreenSnapshot> {
         );
     }
 
-    let name = socket_path.as_os_str().to_fs_name::<GenericFilePath>()?;
+    let name = tui_socket_name(&socket_path)?;
     let stream = Stream::connect(name).map_err(|e| {
         anyhow::anyhow!(
             "Failed to connect to TUI dump server at {}: {}. Is `wg tui` running?",

--- a/src/tui/viz_viewer/screen_dump.rs
+++ b/src/tui/viz_viewer/screen_dump.rs
@@ -1,22 +1,23 @@
 //! TUI screen dump server: provides an IPC mechanism for external agents to
 //! read the current TUI screen contents as structured plain text.
 //!
-//! The server listens on a Unix domain socket at `.workgraph/service/tui.sock`.
-//! After each frame render, the event loop updates a shared buffer.  Clients
-//! connect, send a JSON request, and receive a JSON response containing the
-//! current screen text plus metadata (dimensions, active tab, selected task,
-//! input mode).
+//! The server listens on a local socket — a Unix domain socket on Unix, and
+//! a named pipe on Windows — addressed by the path
+//! `.workgraph/service/tui.sock`.  After each frame render, the event loop
+//! updates a shared buffer.  Clients connect, send a JSON request, and
+//! receive a JSON response containing the current screen text plus metadata
+//! (dimensions, active tab, selected task, input mode).
 
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
+use interprocess::local_socket::{
+    GenericFilePath, ListenerOptions, Stream, ToFsName, prelude::*,
+};
 use ratatui::buffer::Buffer;
 use serde::{Deserialize, Serialize};
-
-#[cfg(unix)]
-use std::os::unix::net::UnixListener;
 
 // ── Shared screen state ─────────────────────────────────────────────────────
 
@@ -183,7 +184,9 @@ pub fn tui_socket_path(workgraph_dir: &Path) -> PathBuf {
 ///
 /// Returns `Ok(())` after spawning the listener.  The listener runs until
 /// `shutdown` is set to `true` (typically when the TUI exits).
-#[cfg(unix)]
+///
+/// Uses a Unix domain socket on Unix and a named pipe on Windows, both
+/// addressed by the filesystem path from `tui_socket_path`.
 pub fn start_server(
     workgraph_dir: &Path,
     shared: SharedScreen,
@@ -196,15 +199,20 @@ pub fn start_server(
         std::fs::create_dir_all(parent)?;
     }
 
-    // Remove stale socket file if present.
+    // Remove stale socket file if present (Unix only — Windows named pipes
+    // aren't filesystem objects).
+    #[cfg(unix)]
     if socket_path.exists() {
         let _ = std::fs::remove_file(&socket_path);
     }
 
-    let listener = UnixListener::bind(&socket_path)?;
+    let name = socket_path
+        .as_os_str()
+        .to_fs_name::<GenericFilePath>()?;
+    let listener = ListenerOptions::new().name(name).create_sync()?;
 
     // Non-blocking so we can check the shutdown flag periodically.
-    listener.set_nonblocking(true)?;
+    listener.set_nonblocking(interprocess::local_socket::ListenerNonblockingMode::Both)?;
 
     let socket_path_clone = socket_path.clone();
     std::thread::Builder::new()
@@ -212,7 +220,7 @@ pub fn start_server(
         .spawn(move || {
             while !shutdown.load(std::sync::atomic::Ordering::Relaxed) {
                 match listener.accept() {
-                    Ok((stream, _)) => {
+                    Ok(stream) => {
                         // Handle connection inline (fast — just reading/writing a snapshot).
                         let _ = handle_dump_connection(stream, &shared);
                     }
@@ -226,50 +234,50 @@ pub fn start_server(
                     }
                 }
             }
-            // Clean up socket file.
+            // Clean up socket file on Unix.
+            #[cfg(unix)]
             let _ = std::fs::remove_file(&socket_path_clone);
+            #[cfg(not(unix))]
+            let _ = &socket_path_clone;
         })?;
 
     Ok(())
 }
 
-#[cfg(unix)]
-fn handle_dump_connection(
-    stream: std::os::unix::net::UnixStream,
-    shared: &SharedScreen,
-) -> Result<()> {
-    use std::time::Duration;
+fn handle_dump_connection(stream: Stream, shared: &SharedScreen) -> Result<()> {
+    // Switch this connection back to blocking mode — the listener is
+    // non-blocking but the accepted stream should block so we can do a
+    // straightforward request/response exchange.
+    stream.set_nonblocking(false)?;
 
-    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(2)))?;
-
-    let mut write_stream = stream.try_clone()?;
-    let reader = BufReader::new(stream);
-
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => break,
-        };
-
-        if line.is_empty() {
-            continue;
-        }
-
-        let response = match serde_json::from_str::<DumpRequest>(&line) {
-            Ok(DumpRequest::Dump) => {
-                let snap = shared.lock().map_err(|e| anyhow::anyhow!("{}", e))?;
-                DumpResponse::success(&snap)
-            }
-            Err(e) => DumpResponse::error(&format!("invalid request: {}", e)),
-        };
-
-        let mut json = serde_json::to_string(&response)?;
-        json.push('\n');
-        write_stream.write_all(json.as_bytes())?;
-        write_stream.flush()?;
-        break; // One request per connection.
+    // Read one JSON line from the client.
+    let mut reader = BufReader::new(&stream);
+    let mut line = String::new();
+    if reader.read_line(&mut line)? == 0 {
+        return Ok(());
     }
+    let line = line.trim();
+    if line.is_empty() {
+        return Ok(());
+    }
+
+    let response = match serde_json::from_str::<DumpRequest>(line) {
+        Ok(DumpRequest::Dump) => {
+            let snap = shared.lock().map_err(|e| anyhow::anyhow!("{}", e))?;
+            DumpResponse::success(&snap)
+        }
+        Err(e) => DumpResponse::error(&format!("invalid request: {}", e)),
+    };
+
+    // Write the JSON response. `Stream` implements `Write` via `&Stream`, so
+    // we drop the BufReader (which held an &stream borrow) and then borrow it
+    // again mutably via the &mut on write_all.
+    drop(reader);
+    let mut writer = &stream;
+    let mut json = serde_json::to_string(&response)?;
+    json.push('\n');
+    writer.write_all(json.as_bytes())?;
+    writer.flush()?;
 
     Ok(())
 }
@@ -277,12 +285,13 @@ fn handle_dump_connection(
 // ── Client (for `wg tui dump`) ──────────────────────────────────────────────
 
 /// Connect to a running TUI and retrieve the current screen dump.
-#[cfg(unix)]
 pub fn client_dump(workgraph_dir: &Path) -> Result<ScreenSnapshot> {
-    use std::os::unix::net::UnixStream;
-    use std::time::Duration;
-
     let socket_path = tui_socket_path(workgraph_dir);
+
+    // On Unix the socket is a real filesystem object, so we can pre-check.
+    // On Windows named pipes don't exist on the filesystem, so skip the check
+    // and let `Stream::connect` return a helpful error.
+    #[cfg(unix)]
     if !socket_path.exists() {
         anyhow::bail!(
             "TUI is not running (no socket at {}). Start it with `wg tui`.",
@@ -290,45 +299,48 @@ pub fn client_dump(workgraph_dir: &Path) -> Result<ScreenSnapshot> {
         );
     }
 
-    let mut stream = UnixStream::connect(&socket_path)?;
-    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    let name = socket_path.as_os_str().to_fs_name::<GenericFilePath>()?;
+    let stream = Stream::connect(name).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to connect to TUI dump server at {}: {}. Is `wg tui` running?",
+            socket_path.display(),
+            e
+        )
+    })?;
 
     // Send dump request.
-    let request = r#"{"cmd":"dump"}"#;
-    stream.write_all(request.as_bytes())?;
-    stream.write_all(b"\n")?;
-    stream.flush()?;
+    let mut writer = &stream;
+    writer.write_all(br#"{"cmd":"dump"}"#)?;
+    writer.write_all(b"\n")?;
+    writer.flush()?;
 
     // Read response.
-    let reader = BufReader::new(stream);
-    for line in reader.lines() {
-        let line = line?;
-        if line.is_empty() {
-            continue;
-        }
-
-        let resp: DumpResponse = serde_json::from_str(&line)?;
-        if !resp.ok {
-            anyhow::bail!(
-                "TUI dump failed: {}",
-                resp.error.unwrap_or_else(|| "unknown error".into())
-            );
-        }
-
-        return Ok(ScreenSnapshot {
-            text: resp.text.unwrap_or_default(),
-            width: resp.width.unwrap_or(0),
-            height: resp.height.unwrap_or(0),
-            active_tab: resp.active_tab.unwrap_or_default(),
-            focused_panel: resp.focused_panel.unwrap_or_default(),
-            selected_task: resp.selected_task,
-            input_mode: resp.input_mode.unwrap_or_default(),
-            coordinator_id: resp.coordinator_id.unwrap_or(0),
-        });
+    let mut reader = BufReader::new(&stream);
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    let line = line.trim();
+    if line.is_empty() {
+        anyhow::bail!("no response from TUI dump server");
     }
 
-    anyhow::bail!("no response from TUI dump server")
+    let resp: DumpResponse = serde_json::from_str(line)?;
+    if !resp.ok {
+        anyhow::bail!(
+            "TUI dump failed: {}",
+            resp.error.unwrap_or_else(|| "unknown error".into())
+        );
+    }
+
+    Ok(ScreenSnapshot {
+        text: resp.text.unwrap_or_default(),
+        width: resp.width.unwrap_or(0),
+        height: resp.height.unwrap_or(0),
+        active_tab: resp.active_tab.unwrap_or_default(),
+        focused_panel: resp.focused_panel.unwrap_or_default(),
+        selected_task: resp.selected_task,
+        input_mode: resp.input_mode.unwrap_or_default(),
+        coordinator_id: resp.coordinator_id.unwrap_or(0),
+    })
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Makes workgraph compile, link, install, and run the full daemon on Windows (tested on Windows 11 ARM64 native with MSVC). Before this PR the service daemon and everything it controls was `#[cfg(unix)]`-only; after it, `wg init` / `add` / `list` / `service start`/`status`/`stop` / `add`-triggered dispatch / `tui dump` all work identically to Unix, and the parts that fundamentally can't map (SIGSTOP/SIGCONT for freeze/thaw) produce a clear error message from the daemon instead of refusing at the client.

## Commits, in review order

1. **Gate Unix-specific APIs** — cfg gates and Windows code paths for chmod (→ readonly flag), `libc::kill(SIGINT)` (→ taskkill as initial fallback; replaced later), Unix-only symlinks (→ symlink_dir initially; replaced later), a duplicate `find_orphan_daemon_pids` definition, and a missing `Command` import.

2. **Port TUI dump to cross-platform local sockets** — replaces the UDS-only TUI dump IPC with `interprocess`, removing the `#[cfg(unix)]` split in `tui/viz_viewer/screen_dump.rs`.

3. **Port the service daemon to cross-platform local sockets** — the big one. Removes the `#[cfg(unix)]` gate on the whole `wg service` command family. IPC transport goes through `interprocess` on both platforms; the daemon's `libc::poll`-based accept wait becomes a portable non-blocking accept + sleep loop; `reap_zombies` becomes a Windows no-op; `is_process_alive`/`kill_process_graceful`/`kill_process_force`/`kill_descendants` get real Windows implementations via `tasklist`/`taskkill`/`wmic`; the hot-restart path uses `spawn + exit` on Windows where there's no `exec`. Freeze/thaw still return Unix-only errors from the daemon since they need SIGSTOP/SIGCONT.

4. **Deliver clean interrupts to coordinator agents on Windows** — spawns Claude with `CREATE_NEW_PROCESS_GROUP` and replaces the taskkill fallback in `CoordinatorAgent::interrupt()` with `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)`. Adds `windows-sys` as a Windows-only dep.

5. **Use directory junctions on Windows so worktrees don't need Developer Mode** — `wg spawn --worktree` now uses `mklink /J` which doesn't require elevation, falling back to `symlink_dir` if `mklink` isn't available.

6. **Restrict key files via ACLs on Windows, equivalent to chmod 600** — `wg key set --value` runs `icacls /inheritance:r` + `icacls /grant:r "<user>:(F)"` on both the keys dir and the key file.

7. **Fix TUI dump socket naming on Windows** — same bug as the daemon socket (filesystem paths aren't valid named-pipe names on Windows); same fix (derive a stable hashed name via `std::path::absolute` so server and client agree).

## Socket naming on Windows

`interprocess`'s `GenericFilePath` expects Windows named-pipe paths (`\.\pipe\...`) rather than filesystem paths, and rejects the latter. The daemon uses the full filesystem path to its socket file as its identity on Unix, and rather than inventing a separate config surface for Windows, both the daemon and its clients now derive a stable namespaced name on Windows by hashing `std::path::absolute(path)`. The absolute-path normalisation is important: the daemon may see a Windows-style path from its `--socket` argument while the client sees an msys-style path from its CWD, and they need to land on the same hash.

On Unix the socket is unchanged — still a real UDS file at `.workgraph/service/daemon.sock`, so existing tooling keeps working.

## Behavioural notes

- Pre-existing CPU-spin bug: with `--no-coordinator-agent` and a non-zero `heartbeat_interval`, the daemon's tick-trigger fires forever because `last_heartbeat` is only reset inside the `enable_coordinator_agent` block. Predates this PR and surfaces identically on Unix; worked around in my smoke tests by setting `heartbeat_interval = 0`. Worth a separate fix.

- Removed IPC read/write timeouts because `interprocess::local_socket::Stream` doesn't expose a portable way to set them — named pipes and UDS don't share semantics here. For local same-machine IPC this was a belt-and-braces safety net; Ctrl+C still interrupts a truly hung daemon.

- `interrupt()` on Windows requires the Claude process to be spawned with `CREATE_NEW_PROCESS_GROUP` or the console-ctrl call is a silent no-op. That flag is now set in `spawn_claude_process`.

- Worktree symlinks become junctions on Windows. Junctions aren't classified as symlinks by stdlib (they're reparse points), so the existing `is_symlink()` assertion in the worktree test is relaxed to `exists()` on Windows. The more meaningful assertion — that a marker file is readable through the link — still runs on both platforms.

- Key files: `icacls` failures are reported to stderr but don't fail the overall key-set operation. The key is still written and usable, just with the default ACL.

## Test plan

- [x] `cargo build` on Windows 11 ARM64 (native `aarch64-pc-windows-msvc`) — passes cleanly.
- [x] `cargo build` on x86_64-pc-windows-msvc — passes.
- [x] `cargo install --path .` succeeds; `wg init` → `wg service start --no-coordinator-agent` → `wg service status` → `wg add` → `wg list` → `wg agents` → `wg service stop` exercised end-to-end, with correct 60s coordinator tick spacing and clean shutdown.
- [ ] Linux/macOS — unchanged code paths, but a CI run would be reassuring. Happy to adjust if CI flags anything.
- [ ] Actually using `wg spawn --worktree` and `wg key set --value` on Windows — I built and tested the build/compile paths but didn't exercise these end-to-end in this session.

## Unrelated (noise in the tree)

There's a pre-existing case-insensitive filename collision between `PROMPT_CONSTRUCTION_ANALYSIS.md` and `prompt_construction_analysis.md`. Not touched in this PR — worth a separate cleanup.

## `boring-sys2` upstream note

Unrelated to this PR, but for other Windows ARM64 users: `boring-sys2` silently miscompiles on native Windows ARM64 due to a skipped `OPENSSL_NO_ASM=YES` workaround. Filed upstream at 0x676e67/btls#151 with a proposed one-line fix. Building for `x86_64-pc-windows-msvc` also works (x64 emulation). Either way, with that workaround in place, workgraph as modified by this PR runs natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)