### PR TITLE
fix: use dirs::home_dir() instead of $HOME for portability

### DIFF
--- a/src/commands/service/mod.rs
+++ b/src/commands/service/mod.rs
@@ -722,11 +722,8 @@ WantedBy=default.target
     );
 
     // Write to ~/.config/systemd/user/wg-{project_name}.service
-    let home = std::env::var("HOME").context("HOME not set")?;
-    let service_dir = std::path::PathBuf::from(&home)
-        .join(".config")
-        .join("systemd")
-        .join("user");
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    let service_dir = home.join(".config").join("systemd").join("user");
 
     std::fs::create_dir_all(&service_dir)?;
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -230,8 +230,8 @@ pub fn has_workgraph_directives(path: &Path) -> bool {
 ///
 /// Returns a status string for display and whether changes were made.
 pub fn configure_claude_md() -> Result<(String, bool)> {
-    let home = std::env::var("HOME").context("HOME environment variable not set")?;
-    let claude_dir = PathBuf::from(&home).join(".claude");
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    let claude_dir = home.join(".claude");
     let claude_md = claude_dir.join("CLAUDE.md");
 
     configure_claude_md_at(&claude_md)
@@ -1374,10 +1374,8 @@ fn default_openrouter_registry() -> Vec<ModelRegistryEntry> {
 
 /// Check if the wg Claude Code skill is installed.
 pub fn is_claude_skill_installed() -> bool {
-    if let Ok(home) = std::env::var("HOME") {
-        PathBuf::from(home)
-            .join(".claude/skills/wg/SKILL.md")
-            .exists()
+    if let Some(home) = dirs::home_dir() {
+        home.join(".claude/skills/wg/SKILL.md").exists()
     } else {
         false
     }
@@ -1385,8 +1383,8 @@ pub fn is_claude_skill_installed() -> bool {
 
 /// Check if the amplifier-bundle-workgraph setup script exists in common locations.
 fn find_amplifier_bundle_setup() -> Option<PathBuf> {
-    if let Ok(home) = std::env::var("HOME") {
-        let candidate = PathBuf::from(&home).join("amplifier-bundle-workgraph/setup.sh");
+    if let Some(home) = dirs::home_dir() {
+        let candidate = home.join("amplifier-bundle-workgraph/setup.sh");
         if candidate.exists() {
             return Some(candidate);
         }
@@ -1617,8 +1615,8 @@ pub fn format_detection_summary(det: &DetectionResult) -> String {
 /// Guide the user through configuring ~/.claude/CLAUDE.md.
 /// Returns a status string for the summary.
 fn guide_claude_md_install() -> Result<String> {
-    let home = std::env::var("HOME").context("HOME environment variable not set")?;
-    let claude_md = PathBuf::from(&home).join(".claude/CLAUDE.md");
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    let claude_md = home.join(".claude/CLAUDE.md");
 
     if has_workgraph_directives(&claude_md) {
         return Ok("already configured ✓".to_string());

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -118,11 +118,8 @@ pub fn run_find(dir: &Path, skill: &str, json: bool) -> Result<()> {
 
 /// Install the wg Claude Code skill to ~/.claude/skills/wg/
 pub fn run_install() -> Result<()> {
-    let home = std::env::var("HOME").context("HOME environment variable not set")?;
-    let skill_dir = std::path::PathBuf::from(&home)
-        .join(".claude")
-        .join("skills")
-        .join("wg");
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    let skill_dir = home.join(".claude").join("skills").join("wg");
 
     std::fs::create_dir_all(&skill_dir)
         .with_context(|| format!("Failed to create directory: {}", skill_dir.display()))?;

--- a/src/commands/telegram.rs
+++ b/src/commands/telegram.rs
@@ -448,8 +448,8 @@ fn save_last_update_id(update_id: i64) -> Result<()> {
 
 /// Get the path to the update_id state file.
 fn get_state_file_path() -> Result<std::path::PathBuf> {
-    let home = std::env::var("HOME").context("HOME environment variable not set")?;
-    Ok(std::path::Path::new(&home)
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home
         .join(".config")
         .join("workgraph")
         .join("telegram_update_id"))


### PR DESCRIPTION
## Summary

`std::env::var(\"HOME\")` is POSIX; native Windows shells (cmd.exe, PowerShell) don't set it — they expose `%USERPROFILE%`. So on a fresh Windows install:

- `wg init` → `Error: HOME environment variable not set` (via project CLAUDE.md check)
- `wg skill install` → same
- `wg telegram *` → same
- `wg service install` → `Error: HOME not set`

These all fail before doing any useful work.

## Fix

Swap the seven remaining `std::env::var(\"HOME\")` call sites for `dirs::home_dir()`, which is already a dependency and the pattern used in 20+ other sites in this crate. `dirs` resolves via `%USERPROFILE%` / `SHGetKnownFolderPath` on Windows and `\$HOME` on Unix, so no behavior change on Linux/macOS.

Sites converted:

- `commands/setup.rs` — `configure_claude_md`, `is_claude_skill_installed`, `find_amplifier_bundle_setup`, `guide_claude_md_install`
- `commands/skills.rs` — `run_install`
- `commands/telegram.rs` — `get_state_file_path`
- `commands/service/mod.rs` — systemd install target path

The two best-effort lookups (`is_claude_skill_installed`, `find_amplifier_bundle_setup`) keep their \"silently return none if home is unknown\" semantics — just swap `Ok(home)` for `Some(home)`.

## Test plan

- [ ] Linux: `cargo build` and existing test suite pass (no behavioural change)
- [ ] Windows: `wg init` in a fresh directory from cmd.exe with only `USERPROFILE` set completes without the HOME error
- [ ] Windows: `wg skill install` drops the skill into `%USERPROFILE%\.claude\skills\wg\SKILL.md`

Independent of #19 (Windows port) and #20 (heartbeat spin). Full Windows `cargo check` on this branch is blocked by the same unrelated build errors on upstream/main that #19 resolves — this PR is purely a mechanical substitution using the same pattern already dominant in the codebase.