### PR TITLE
fix(platform): cross-platform replacement for timeout(1)

### DIFF
--- a/src/executor/native/tools/map.rs
+++ b/src/executor/native/tools/map.rs
@@ -920,13 +920,20 @@ impl Tool for BashTool {
         let s = self.state.lock().unwrap();
         let cwd = s.working_dir.clone();
         drop(s);
-        let output = Command::new("timeout")
-            .arg(format!("{}s", timeout_secs))
-            .arg("bash")
-            .arg("-c")
-            .arg(&command)
-            .current_dir(&cwd)
-            .output();
+        // Cross-platform `timeout(1)` replacement — Windows has no equivalent.
+        let output = crate::platform_timeout::spawn_with_timeout(
+            "bash",
+            |cmd| {
+                cmd.arg("-c")
+                    .arg(&command)
+                    .current_dir(&cwd)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped())
+            },
+            timeout_secs,
+        )
+        .and_then(|(child, _killer)| child.wait_with_output());
         let output = match output {
             Ok(o) => o,
             Err(e) => return ToolOutput::error(format!("bash exec: {}", e)),

--- a/src/executor/native/tools/reader.rs
+++ b/src/executor/native/tools/reader.rs
@@ -1063,14 +1063,21 @@ impl Tool for BashTool {
         let cwd = s.working_dir.clone();
         drop(s);
         // Wrap in `timeout` to enforce the budget. Same pattern as the
-        // main bash tool uses for runaway commands.
-        let output = Command::new("timeout")
-            .arg(format!("{}s", timeout_secs))
-            .arg("bash")
-            .arg("-c")
-            .arg(&command)
-            .current_dir(&cwd)
-            .output();
+        // main bash tool uses for runaway commands. Uses a cross-platform
+        // helper because Windows has no `timeout(1)` equivalent.
+        let output = crate::platform_timeout::spawn_with_timeout(
+            "bash",
+            |cmd| {
+                cmd.arg("-c")
+                    .arg(&command)
+                    .current_dir(&cwd)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped())
+            },
+            timeout_secs,
+        )
+        .and_then(|(child, _killer)| child.wait_with_output());
         let output = match output {
             Ok(o) => o,
             Err(e) => return ToolOutput::error(format!("bash exec: {}", e)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod model_benchmarks;
 pub mod models;
 pub mod notify;
 pub mod parser;
+pub mod platform_timeout;
 pub mod plan_validator;
 pub mod profile;
 pub mod provenance;

--- a/src/platform_timeout.rs
+++ b/src/platform_timeout.rs
@@ -1,0 +1,105 @@
+//! Cross-platform replacement for `timeout(1)`.
+//!
+//! Unix has `timeout(1)`, which wraps a command and kills it (exit code 124)
+//! if it runs past a deadline. Windows has no equivalent — `TIMEOUT.EXE` is an
+//! interactive "press any key to continue, else wait N seconds" utility, and
+//! fails with "Default option is not allowed more than '1' time(s)" when
+//! invoked with `timeout(1)`-style arguments. Any workgraph code that shells
+//! out to `timeout` therefore breaks on native Windows.
+//!
+//! [`spawn_with_timeout`] hides the platform difference behind one API:
+//!
+//! - On Unix: prefixes the command with `timeout <secs>s`, preserving the
+//!   exit-code-124-on-timeout semantics callers may be relying on.
+//! - On Windows: spawns the program directly and arms a background thread
+//!   that runs `taskkill /F /T /PID <pid>` at the deadline. The thread is
+//!   disarmed (via an atomic flag) when the returned [`TimeoutGuard`] drops,
+//!   so children that exit in time don't risk a PID-reuse race.
+//!
+//! Callers bind the guard to a `_killer` local that lives as long as the
+//! child-wait call:
+//!
+//! ```ignore
+//! let (mut child, _killer) = platform_timeout::spawn_with_timeout(
+//!     "claude",
+//!     |cmd| cmd.arg("--print").stdin(Stdio::piped()),
+//!     30,
+//! )?;
+//! let output = child.wait_with_output()?;
+//! // _killer drops here; disarms the Windows kill-thread if still pending.
+//! ```
+
+use std::ffi::OsStr;
+use std::io;
+use std::process::{Child, Command};
+
+#[cfg(windows)]
+use std::sync::Arc;
+#[cfg(windows)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// RAII guard that disarms the Windows kill-thread when dropped.
+///
+/// Zero-sized on Unix (there's no kill-thread — `timeout(1)` handles it).
+pub struct TimeoutGuard {
+    #[cfg(windows)]
+    done: Arc<AtomicBool>,
+}
+
+#[cfg(windows)]
+impl Drop for TimeoutGuard {
+    fn drop(&mut self) {
+        self.done.store(true, Ordering::Release);
+    }
+}
+
+/// Spawn `program`, with the `Command` further configured by `configure`,
+/// subject to a time budget of `timeout_secs`.
+///
+/// See the module-level docs for the semantics on each platform. The
+/// returned guard must outlive the child-wait call; bind it to a `_killer`
+/// local so it drops at the right point.
+pub fn spawn_with_timeout<P, F>(
+    program: P,
+    configure: F,
+    timeout_secs: u64,
+) -> io::Result<(Child, TimeoutGuard)>
+where
+    P: AsRef<OsStr>,
+    F: FnOnce(&mut Command) -> &mut Command,
+{
+    #[cfg(unix)]
+    {
+        let mut cmd = Command::new("timeout");
+        cmd.arg(format!("{}s", timeout_secs)).arg(program);
+        configure(&mut cmd);
+        let child = cmd.spawn()?;
+        Ok((child, TimeoutGuard {}))
+    }
+    #[cfg(windows)]
+    {
+        use std::thread;
+        use std::time::Duration;
+
+        let mut cmd = Command::new(program);
+        configure(&mut cmd);
+        let child = cmd.spawn()?;
+        let pid = child.id();
+
+        let done = Arc::new(AtomicBool::new(false));
+        let done_clone = Arc::clone(&done);
+        thread::spawn(move || {
+            thread::sleep(Duration::from_secs(timeout_secs));
+            if !done_clone.load(Ordering::Acquire) {
+                // Best-effort: kill the process tree. /T walks children,
+                // /F forces. We ignore the exit status — the child may
+                // have just finished on its own, which is fine.
+                let _ = Command::new("taskkill")
+                    .args(["/F", "/T", "/PID", &pid.to_string()])
+                    .output();
+            }
+        });
+
+        Ok((child, TimeoutGuard { done }))
+    }
+}

--- a/src/service/llm.rs
+++ b/src/service/llm.rs
@@ -111,25 +111,27 @@ fn call_claude_cli(model: &str, prompt: &str, timeout_secs: u64) -> Result<LlmCa
     // Eval prompts can be very large (30KB+ with diffs, logs, artifacts) and
     // passing them as arguments can hit OS arg-length limits or cause the
     // `timeout` wrapper to fail with exit 124 before the API call even starts.
-    let mut child = process::Command::new("timeout")
-        .arg(format!("{}s", timeout_secs))
-        .arg("claude")
-        .arg("--model")
-        .arg(model)
-        .arg("--print")
-        .arg("--output-format")
-        .arg("json")
-        .arg("--dangerously-skip-permissions")
-        // Strip CLAUDECODE env var so the CLI doesn't refuse to run
-        // when invoked from within a Claude Code session (e.g. daemon
-        // spawned by a coordinator agent). This is a headless --print
-        // call, not an interactive nested session.
-        .env_remove("CLAUDECODE")
-        .stdin(process::Stdio::piped())
-        .stdout(process::Stdio::piped())
-        .stderr(process::Stdio::piped())
-        .spawn()
-        .context("Failed to spawn claude CLI for lightweight LLM call")?;
+    let (mut child, _killer) = crate::platform_timeout::spawn_with_timeout(
+        "claude",
+        |cmd| {
+            cmd.arg("--model")
+                .arg(model)
+                .arg("--print")
+                .arg("--output-format")
+                .arg("json")
+                .arg("--dangerously-skip-permissions")
+                // Strip CLAUDECODE env var so the CLI doesn't refuse to run
+                // when invoked from within a Claude Code session (e.g. daemon
+                // spawned by a coordinator agent). This is a headless --print
+                // call, not an interactive nested session.
+                .env_remove("CLAUDECODE")
+                .stdin(process::Stdio::piped())
+                .stdout(process::Stdio::piped())
+                .stderr(process::Stdio::piped())
+        },
+        timeout_secs,
+    )
+    .context("Failed to spawn claude CLI for lightweight LLM call")?;
 
     // Write prompt to stdin and close the pipe to signal EOF.
     if let Some(mut stdin) = child.stdin.take() {


### PR DESCRIPTION
## Summary

Three spots shell out to `timeout(1)` to put a wall-clock budget on a child:

- `service/llm.rs::call_claude_cli` — the headless `claude --print` call used for assignment/evaluation LLM turns
- `executor/native/tools/reader.rs` — the reader bash tool
- `executor/native/tools/map.rs` — the map bash tool

On native Windows those invocations fail immediately:

```
ERROR: Invalid syntax. Default option is not allowed more than '1' time(s).
Type \"TIMEOUT /?\" for usage.
```

`TIMEOUT.EXE` on Windows is an interactive \"wait N seconds or key press\" utility; it isn't a command wrapper and the `timeout(1)`-style arguments fail parse. The assignment LLM call bails with exit 1 and coordinator tick spam reads:

```
[coordinator] Lightweight assignment failed for '…': Assignment LLM call failed, will retry next tick
```

Agents get spawned, die immediately (no metadata.json written), get cleaned up, and no real work moves.

## Fix

New `platform_timeout` module with one helper:

```rust
pub fn spawn_with_timeout<P, F>(
    program: P,
    configure: F,
    timeout_secs: u64,
) -> io::Result<(Child, TimeoutGuard)>
```

- **Unix**: prefixes `timeout <secs>s` so exit-code-124-on-timeout semantics survive.
- **Windows**: spawns the program directly and arms a background thread that runs `taskkill /F /T /PID <pid>` at the deadline. The thread is disarmed via an atomic flag by the returned `TimeoutGuard` on drop, so normal-exit paths don't race PID reuse.

Rewire the three call sites through the helper. No behavior change on Unix.

## Test plan

- [ ] Unix: `cargo test` passes (pure refactor — same `timeout` command under the hood)
- [ ] Windows: coordinator assignment stops failing with the TIMEOUT.EXE parse error
- [ ] Windows: a bash tool command that sleeps past its budget actually gets killed (taskkill /T walks children)
- [ ] Windows: a bash tool command that finishes under budget doesn't get killed after (guard disarms the thread)

Separate from #19 (Windows port), #20 (heartbeat), #21 (HOME lookup). Full Windows `cargo check` on this branch is blocked by the same unrelated upstream errors that #19 resolves; my changes introduce zero errors of their own.