### PR TITLE
fix(llm): log claude CLI stdout alongside stderr on failure

### DIFF
--- a/src/service/llm.rs
+++ b/src/service/llm.rs
@@ -144,10 +144,12 @@ fn call_claude_cli(model: &str, prompt: &str, timeout_secs: u64) -> Result<LlmCa
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
         anyhow::bail!(
-            "Claude CLI call failed (exit {:?}): {}",
+            "Claude CLI call failed (exit {:?}): stderr={:?} stdout={:?}",
             output.status.code(),
-            stderr.chars().take(500).collect::<String>()
+            stderr.chars().take(500).collect::<String>(),
+            stdout.chars().take(500).collect::<String>()
         );
     }
 


### PR DESCRIPTION
## Summary

When `claude --print --output-format json` fails authentication (and some other error paths), it writes a *success-shaped* JSON envelope to **stdout** with `is_error: true` / `api_error_status: 401` inside it — not to stderr. The existing error path only captured stderr, so the daemon log ended up full of:

```
Claude CLI call failed (exit Some(1)):
```

…with nothing after the colon, no clue what went wrong.

Hit this today on a Windows box where the daemon's subprocess env didn't inherit Claude Code's host-managed auth bridge. Would have been obvious with the stdout body logged; was invisible without it.

## Fix

Grab the first 500 chars of stdout too and include both in the bail message:

```
Claude CLI call failed (exit Some(1)): stderr=\"\" stdout=\"{\\\"type\\\":\\\"result\\\",\\\"is_error\\\":true,\\\"api_error_status\\\":401,\\\"result\\\":\\\"Failed to authenticate. API Error: 401 …\\\"}\"
```

Four-line patch. No behavior change on success.

## Test plan

- [ ] Set a bogus `ANTHROPIC_API_KEY`, trigger any lightweight LLM call, confirm the 401 body now appears in the log
- [ ] Confirm successful calls still work unchanged (the only change is in the `!status.success()` branch)

Independent of #19 / #20 / #21 / #22.