### PR TITLE
fix(spawn): strip Windows \?\ prefix before handing path to bash

### DIFF
--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -4,8 +4,36 @@
 use anyhow::{Context, Result};
 use chrono::Utc;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+
+/// Strip the Windows extended-length path prefix (`\\?\`) from a path.
+///
+/// `PathBuf::canonicalize` on Windows returns paths in verbatim form like
+/// `\\?\C:\src\ontempo\run.sh`. Most Windows APIs accept that, but some
+/// tools that consume paths as arguments don't — notably Git-for-Windows
+/// bash.exe fails to locate the script ("No such file or directory")
+/// before it can run, and Git itself bails in `git worktree add` with
+/// "could not create leading directories of '//?/C:/...'". Strip the
+/// prefix so those tools see the plain `C:\...` form, which they all
+/// handle.
+///
+/// No-op on non-Windows targets.
+fn strip_verbatim_prefix(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        if let Some(s) = path.to_str()
+            && let Some(rest) = s.strip_prefix(r"\\?\")
+        {
+            // UNC form `\\?\UNC\server\share\...` must become `\\server\share\...`
+            if let Some(unc) = rest.strip_prefix("UNC\\") {
+                return PathBuf::from(format!(r"\\{unc}"));
+            }
+            return PathBuf::from(rest);
+        }
+    }
+    path.to_path_buf()
+}
 
 use workgraph::agency;
 use workgraph::config::{CapBehavior, Config, EndpointConfig};
@@ -527,9 +555,15 @@ pub(crate) fn spawn_agent_inner(
         &settings.executor_type,
     )?;
 
-    // Run the wrapper script
+    // Run the wrapper script. On Windows, `wrapper_path` often comes back
+    // from PathBuf::canonicalize with the `\\?\` extended-length prefix
+    // (e.g. `\\?\C:\src\ontempo\.workgraph\agents\agent-710\run.sh`). Most
+    // Windows APIs accept that form, but Git-for-Windows' bash.exe does
+    // not — it reports "No such file or directory" before the script can
+    // run, and the agent dies instantly with no output.log. Strip the
+    // prefix so bash sees a plain `C:\...` path, which it handles fine.
     let mut cmd = Command::new("bash");
-    cmd.arg(&wrapper_path);
+    cmd.arg(strip_verbatim_prefix(&wrapper_path));
 
     // Set environment variables from executor config
     for (key, value) in &settings.env {


### PR DESCRIPTION
## Summary

On Windows, `PathBuf::canonicalize` returns verbatim-form paths like `\\?\\C:\\src\\ontempo\\.workgraph\\agents\\agent-710\\run.sh`. The service daemon uses that path to invoke the wrapper script:

```rust
Command::new(\"bash\").arg(&wrapper_path);
```

Git-for-Windows' `bash.exe` can't parse the `\\?\\` extended-length prefix as an argument — it immediately errors:

```
bash: \\?\\C:\\...\\run.sh: No such file or directory
```

The agent exits instantly. No `output.log`, no claude invocation, no visible error beyond a dead process. In an `ontempo` test session we watched 700+ agents die this way over several hours. Looked like claude auth failures (especially compounded with the earlier TIMEOUT.EXE bug from #22) — **actually bash was crashing before ever reaching the claude call**.

Git itself trips on the same prefix: `git worktree add` fails with \"could not create leading directories of `//?/C:/...`\" because git renders the prefix as forward slashes. Same root cause, separate code path.

## Fix

Add `strip_verbatim_prefix(path)` helper that removes the `\\?\\` prefix on Windows (with UNC form `\\?\\UNC\\server\\share\\...` → `\\\\server\\share\\...`) and is a no-op elsewhere. Apply it to `wrapper_path` before passing to bash.

Worktree-add has the same issue and wants the same treatment, but that's a separate diff.

## Test plan

- [ ] Linux/macOS: no behavior change, existing tests pass
- [ ] Windows: with the fix, agents actually run — `output.log` appears with claude stream-json content and `apiKeySource` reporting the auth source
- [ ] Unit test: `strip_verbatim_prefix` on `\\?\\C:\\foo` → `C:\\foo`; on `\\?\\UNC\\srv\\share\\x` → `\\\\srv\\share\\x`; on a non-verbatim path → unchanged

Completes the Windows port along with #19 / #20 / #21 / #22 / #23. Without this, agent dispatch on Windows is non-functional.