### PR TITLE
feat(auth): home the Claude Code OAuth token in config + Windows README

### DIFF
--- a/docs/README-windows.md
+++ b/docs/README-windows.md
@@ -1,0 +1,198 @@
+# Running workgraph on Windows
+
+Workgraph runs natively on Windows (tested on Windows 11 ARM64; x86_64 via
+emulation works too). This page is the "what's different" guide — if you've
+already run workgraph on Linux or macOS, read it top-to-bottom once, then keep
+it as a reference for gotchas.
+
+## TL;DR
+
+1. Install prerequisites: Rust, Git for Windows (bash + git), MSVC Build
+   Tools, LLVM (`clang.exe`), CMake.
+2. Clone the repo and run `cargo install --path . --force --locked` from a
+   shell that has the MSVC env loaded (`VsDevCmd.bat -arch=arm64` or
+   `-arch=x64`). For native ARM64 also set `OPENSSL_NO_ASM=YES`; see
+   [the boring-sys2 note](#boring-sys2-and-native-arm64) below.
+3. Configure authentication (one of):
+   - `claude login` — writes `~/.claude/credentials.json`; the daemon picks
+     it up automatically.
+   - Headless: put your `sk-ant-oat01-…` token in a file and reference it
+     from `.workgraph/config.toml` under `[auth]`. See
+     [Auth](#authentication) below.
+4. `wg init` in your project, then `wg service start` — daemon runs, agents
+   dispatch, graph progresses.
+
+## What works
+
+| Area | Status |
+|---|---|
+| Task graph CLI (`wg init`, `add`, `list`, `show`, `done`, `artifact`, etc.) | ✅ |
+| Service daemon (`start`, `status`, `stop`, `restart`, `reload`, `pause`, `resume`) | ✅ |
+| IPC over Windows named pipes (`interprocess` crate) | ✅ |
+| Coordinator agent spawn + clean interrupt via `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT)` | ✅ |
+| Per-agent isolated git worktrees | ✅ |
+| `wg` CLI from inside a worktree (directory junction instead of symlink — no Developer Mode needed) | ✅ |
+| Key-file ACLs via `icacls` (instead of `chmod 600`) | ✅ |
+| TUI (`wg tui`) | ✅ |
+
+## What doesn't work yet
+
+| Feature | Why | Workaround |
+|---|---|---|
+| `wg service freeze` / `thaw` | Uses `SIGSTOP` / `SIGCONT`. No clean Windows equivalent. `NtSuspendProcess` is the rough analog but hasn't been wired up. | Use `wg service pause` (doesn't stop running agents but blocks new spawns). |
+| `wg service install` | Generates a systemd user unit file — Linux-only. | Use Windows Task Scheduler. See [Autostart](#autostart) below. |
+| Native-executor `ANTHROPIC_API_KEY` with `sk-ant-oat01-…` tokens | The native Anthropic client uses the `x-api-key` header, which only accepts `sk-ant-api03-…` console keys. | Use the `claude` executor (the default) with `CLAUDE_CODE_OAUTH_TOKEN` in `[auth]`. See [Auth](#authentication). |
+
+## Shell requirements
+
+**Git for Windows bash is required.** The daemon shells out to `bash` to run
+spawned task-agent wrapper scripts (`.workgraph/agents/<id>/run.sh`). The
+bash binary is typically at `C:\Program Files\Git\usr\bin\bash.exe`; make
+sure it's on your `PATH`. WSL bash won't work — it runs inside the WSL VFS
+and can't see your Windows working tree the way Git for Windows' mingw
+bash does.
+
+The wrapper scripts also use GNU `timeout` (as a command wrapper) and
+standard coreutils (`cat`, `tee`, `grep`); all of these ship in
+`C:\Program Files\Git\usr\bin\`. Windows' own `TIMEOUT.EXE` is an
+interactive wait utility, not a command wrapper — **do not** put
+`C:\Windows\System32` ahead of Git's bin in PATH in the daemon's
+environment.
+
+## Authentication
+
+The daemon spawns three kinds of `claude` subprocesses (coordinator,
+lightweight LLM calls, task agents). All three need credentials. Your
+options, in order of preference:
+
+### Option A: `claude login` (recommended)
+
+Run `claude login` once on the machine. It writes `~/.claude/credentials.json`
+with a refreshable token. The CLI reads that file automatically — workgraph
+doesn't need to know about your token at all. This is the normal path when
+you're a Claude Code subscriber.
+
+### Option B: headless OAuth token via `[auth]` in config.toml
+
+If you can't run `claude login` (e.g., the daemon starts at boot before any
+user is logged in), store a bare `sk-ant-oat01-…` token somewhere workgraph
+can read and point `.workgraph/config.toml` at it:
+
+```toml
+[auth]
+claude_code_oauth_token_file = "~/.config/workgraph/oauth-token"
+```
+
+The file should contain the token on a single line, with nothing else. Lock
+it down:
+
+```
+icacls "%USERPROFILE%\.config\workgraph\oauth-token" /inheritance:r /grant "%USERNAME%:R"
+```
+
+(On Unix: `chmod 600 ~/.config/workgraph/oauth-token`.)
+
+Inline form (`claude_code_oauth_token = "..."`) also works, but means the
+token lives in `.workgraph/config.toml` — keep that file out of version
+control if you use this form.
+
+### Option C: env var (ad-hoc)
+
+Export `CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-…` before `wg service start`.
+The daemon propagates it to all child processes. Fine for interactive
+development; doesn't survive reboot.
+
+### The `ANTHROPIC_API_KEY` trap
+
+Do **not** put `sk-ant-oat01-…` tokens in `ANTHROPIC_API_KEY`. The CLI
+sends `ANTHROPIC_API_KEY` values as the `x-api-key` header — correct for
+`sk-ant-api03-…` console keys but rejected by the server as invalid for
+OAuth tokens. Symptom is a 401 on every Claude call and "Invalid API key"
+showing up in outbox messages (an SDK-side synthetic placeholder, not a
+real model response).
+
+`ANTHROPIC_API_KEY` is the right variable only for keys you pulled from
+[console.anthropic.com](https://console.anthropic.com/) (pay-per-token
+billing), not for subscription OAuth tokens.
+
+## Autostart
+
+No Windows autostart is installed by default. Two options:
+
+### Task Scheduler (recommended)
+
+Create a scheduled task that runs `wg service start` at logon. A minimal
+trigger+action XML can be imported via `schtasks /create /xml`. The task
+should run **as the current user** (not SYSTEM) so it finds your
+`~/.claude/credentials.json` or `[auth]`-configured token file. A Windows
+port of `wg service install` that emits this XML is tracked — until it
+lands, wire it up by hand.
+
+### Windows Service (heavier, needs admin)
+
+Wrap `wg service start` with [WinSW](https://github.com/winsw/winsw) or
+`sc create` if you need it to start before login or run under LocalService.
+Remember credentials need to live where that service account can read them.
+
+## boring-sys2 and native ARM64
+
+The `boring-sys2` crate (via `rquest`) pulls in a BoringSSL build that
+requires a vendored patch on native ARM64. You need
+`OPENSSL_NO_ASM=YES` set at build time, and a small tweak to
+`~/.cargo/registry/src/index.crates.io-*/boring-sys2-4.15.15/build/main.rs`
+that skips a native-ARM64 asm path. The escape hatch is to target
+`x86_64-pc-windows-msvc` and let Windows' x64 emulation run the binary —
+that build is clean.
+
+## Extended-length paths (`\\?\C:\…`)
+
+`PathBuf::canonicalize` on Windows returns paths in verbatim form
+(`\\?\C:\src\…`). Most Windows APIs accept that, but two consumers don't:
+
+- Git for Windows `bash.exe` can't open such a path passed as a command
+  argument (`cat '\\?\C:\…'` fails with "No such file or directory") and
+  can't use it as a redirect target.
+- `git worktree add` bails trying to create leading directories because
+  it renders the prefix as forward slashes (`//?/C:/…`).
+
+Workgraph strips the `\\?\` prefix before handing paths to either. If you
+see it in a log line, that's fine for diagnostic context; if you see it
+on the *left* of a command failing with "No such file or directory",
+file a bug — something missed the sanitizer.
+
+## Performance notes
+
+- The `wg` binary is ~45 MB. First-run startup is ~300 ms on a reasonable
+  machine, dominated by env var + config parsing.
+- The daemon keeps a long-running `claude` subprocess for the coordinator.
+  The Anthropic prompt cache has a 5-minute TTL; with the default 60s
+  heartbeat interval the cached ~10-15 k token block stays warm and each
+  heartbeat turn is cheap (~1-3 k new cache tokens).
+- Agent spawn takes ~2 s: create worktree → generate run.sh → start bash
+  subprocess → bash starts claude CLI → claude loads tools.
+
+## Troubleshooting
+
+**`wg init` says "HOME environment variable not set"**
+Fixed in #21. If you're on an older build, set
+`HOME=%USERPROFILE%` in the env first.
+
+**Daemon log full of `Invalid argument` on worktree create**
+Fixed in #25. Symptom is also "falling back to shared working directory"
+on every agent spawn.
+
+**Agents dying immediately, empty `output.log`, daemon log shows nothing useful**
+The `claude` CLI emits its synthetic error placeholders (including
+"Invalid API key · Fix external API key") on stdout as model-less
+"assistant" messages when auth fails. They look like real model output
+but `model` is `"<synthetic>"` and `isApiErrorMessage` is `true`. Enable
+#23 for better logging of CLI failures, and re-check your [auth
+config](#authentication) — the most common cause is an `sk-ant-oat01-…`
+token in `ANTHROPIC_API_KEY`.
+
+**Coordinator stuck repeating a phrase every heartbeat**
+Its conversation context has gotten into a local attractor. Stop the
+service, archive `.workgraph/chat/0/chat.log` and `outbox.jsonl`, rewrite
+`context-summary.md` with fresh accurate state (avoid quoting whatever
+phrase it's stuck on — the model pattern-completes on salient strings in
+its context), restart.

--- a/src/commands/service/coordinator_agent.rs
+++ b/src/commands/service/coordinator_agent.rs
@@ -2420,6 +2420,15 @@ fn spawn_claude_process(
     let mut cmd = Command::new(command);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    // If the user configured an OAuth token in [auth] of config.toml
+    // (and didn't already export CLAUDE_CODE_OAUTH_TOKEN), surface it
+    // into the child's env. Otherwise the CLI resolves auth itself.
+    if let Ok(cfg) = workgraph::config::Config::load_merged(dir)
+        && let Some(token) = cfg.auth.resolve_claude_oauth_token()
+    {
+        cmd.env("CLAUDE_CODE_OAUTH_TOKEN", token);
+    }
     cmd.args([
         "--print",
         "--input-format",

--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -578,6 +578,17 @@ pub(crate) fn spawn_agent_inner(
         }
     }
 
+    // Pass through the Claude Code OAuth token (if configured in [auth]
+    // of config.toml and not already in the daemon's env). Task agents
+    // shell out to the `claude` CLI for the claude executor; without
+    // this, agents on a headless Windows install either can't
+    // authenticate or the user has to export the token in every shell
+    // before starting the daemon. No-op when `claude login` has been
+    // run — the CLI picks up `~/.claude/credentials.json` on its own.
+    if let Some(token) = config.auth.resolve_claude_oauth_token() {
+        cmd.env("CLAUDE_CODE_OAUTH_TOKEN", token);
+    }
+
     // Set working directory: worktree overrides settings.working_dir
     if let Some(ref wt) = worktree_info {
         cmd.current_dir(&wt.path);

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,13 @@ pub struct Config {
     #[serde(default)]
     pub mcp: McpConfig,
 
+    /// Authentication credentials for child processes the daemon spawns
+    /// (coordinator agent, task agents, lightweight LLM calls). Only
+    /// consulted when the matching env var isn't already set; explicit
+    /// env always wins.
+    #[serde(default)]
+    pub auth: AuthConfig,
+
     /// True when `agent.model` was explicitly set in local config.
     /// Used by `resolve_model_for_role` to skip tier defaults in favor of agent.model.
     #[serde(skip)]
@@ -440,6 +447,89 @@ impl Default for OpenRouterConfig {
             track_session_costs: default_track_session_costs(),
             persist_cost_history: false,
         }
+    }
+}
+
+/// Authentication credentials for child processes the daemon spawns.
+///
+/// The daemon runs `claude` subprocesses for three things: the long-running
+/// coordinator agent (`spawn_claude_process`), lightweight LLM calls
+/// (`call_claude_cli` — chat compaction, triage, evaluation), and per-task
+/// agent wrappers (`spawn/execution.rs`). All three read credentials from
+/// the same places the Claude CLI itself does (env vars, `~/.claude/
+/// credentials.json`). If `claude login` has been run on the machine, this
+/// section can stay empty — the CLI resolves auth on its own.
+///
+/// This section only exists for headless setups where no interactive
+/// login happened (e.g. a daemon started via Task Scheduler / systemd at
+/// boot) and the user has a bare `sk-ant-oat01-…` token from
+/// `claude setup-token` or a subscription dashboard.
+///
+/// **Important:** `sk-ant-oat01-…` tokens are OAuth access tokens. They
+/// go in `CLAUDE_CODE_OAUTH_TOKEN` (Bearer scheme). Passing them in
+/// `ANTHROPIC_API_KEY` produces a 401 because the CLI sends that env
+/// with the `x-api-key` header, which is only valid for `sk-ant-api03-…`
+/// keys.
+///
+/// ```toml
+/// [auth]
+/// # Preferred: point at a file, leave the token out of git.
+/// claude_code_oauth_token_file = "~/.config/workgraph/oauth-token"
+///
+/// # Or inline (discouraged — keep `.workgraph/config.toml` out of VCS
+/// # if you use this form):
+/// # claude_code_oauth_token = "sk-ant-oat01-…"
+/// ```
+///
+/// Resolution order when the daemon spawns a claude subprocess:
+///   1. `CLAUDE_CODE_OAUTH_TOKEN` already in env → use as-is
+///   2. `[auth] claude_code_oauth_token` inline → inject into env
+///   3. `[auth] claude_code_oauth_token_file` → read file, inject
+///   4. Nothing here → Claude CLI falls back to `~/.claude/credentials.json`
+///      / its own refresh loop (the normal logged-in path)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AuthConfig {
+    /// Inline OAuth token (`sk-ant-oat01-…`). Discouraged because the file
+    /// ends up on disk in `.workgraph/config.toml`; prefer `_file` below.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_oauth_token: Option<String>,
+
+    /// Path to a file containing the OAuth token on a single line.
+    /// Supports `~/` and `$HOME/` expansion. ACL the file to your user
+    /// (`icacls <path> /inheritance:r /grant %USERNAME%:R` on Windows,
+    /// `chmod 600 <path>` on Unix) and keep it out of version control.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_oauth_token_file: Option<String>,
+}
+
+impl AuthConfig {
+    /// Resolve the Claude Code OAuth token from env → inline → file.
+    ///
+    /// Returns `None` if nothing is configured; callers should treat that
+    /// as "let the Claude CLI handle auth" rather than an error, because
+    /// `~/.claude/credentials.json` (written by `claude login`) is the
+    /// normal path.
+    pub fn resolve_claude_oauth_token(&self) -> Option<String> {
+        if let Ok(v) = std::env::var("CLAUDE_CODE_OAUTH_TOKEN")
+            && !v.is_empty()
+        {
+            return Some(v);
+        }
+        if let Some(v) = self.claude_code_oauth_token.as_ref()
+            && !v.is_empty()
+        {
+            return Some(v.clone());
+        }
+        if let Some(path) = self.claude_code_oauth_token_file.as_ref() {
+            let expanded = expand_tilde(path);
+            if let Ok(content) = std::fs::read_to_string(&expanded) {
+                let trimmed = content.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_string());
+                }
+            }
+        }
+        None
     }
 }
 

--- a/src/service/llm.rs
+++ b/src/service/llm.rs
@@ -27,6 +27,27 @@ pub struct LlmCallResult {
 /// can easily exceed 1024 tokens. 4096 provides comfortable headroom.
 const LIGHTWEIGHT_MAX_TOKENS: u32 = 4096;
 
+/// If the daemon has a Claude OAuth token configured via `[auth]` in
+/// config.toml, inject it into the child's env so the spawned `claude`
+/// CLI can authenticate without requiring the caller to have exported
+/// `CLAUDE_CODE_OAUTH_TOKEN` beforehand. No-op when the token is already
+/// present in the env or not configured (falls back to the CLI's own
+/// credential resolution — `~/.claude/credentials.json`, etc.).
+fn inject_claude_oauth_token(cmd: &mut process::Command) {
+    // Best-effort: load config from cwd's workgraph dir. This is a pure
+    // read of the file and can silently skip on any failure.
+    let dir = std::env::current_dir()
+        .ok()
+        .map(|p| p.join(".workgraph"))
+        .filter(|p| p.exists());
+    if let Some(dir) = dir
+        && let Ok(cfg) = Config::load_merged(&dir)
+        && let Some(token) = cfg.auth.resolve_claude_oauth_token()
+    {
+        cmd.env("CLAUDE_CODE_OAUTH_TOKEN", token);
+    }
+}
+
 /// Run a lightweight (no tool-use) LLM call for an internal dispatch role.
 ///
 /// Resolves the model and provider for the given role, then dispatches via:
@@ -111,8 +132,8 @@ fn call_claude_cli(model: &str, prompt: &str, timeout_secs: u64) -> Result<LlmCa
     // Eval prompts can be very large (30KB+ with diffs, logs, artifacts) and
     // passing them as arguments can hit OS arg-length limits or cause the
     // `timeout` wrapper to fail with exit 124 before the API call even starts.
-    let mut child = process::Command::new("timeout")
-        .arg(format!("{}s", timeout_secs))
+    let mut cmd = process::Command::new("timeout");
+    cmd.arg(format!("{}s", timeout_secs))
         .arg("claude")
         .arg("--model")
         .arg(model)
@@ -127,7 +148,9 @@ fn call_claude_cli(model: &str, prompt: &str, timeout_secs: u64) -> Result<LlmCa
         .env_remove("CLAUDECODE")
         .stdin(process::Stdio::piped())
         .stdout(process::Stdio::piped())
-        .stderr(process::Stdio::piped())
+        .stderr(process::Stdio::piped());
+    inject_claude_oauth_token(&mut cmd);
+    let mut child = cmd
         .spawn()
         .context("Failed to spawn claude CLI for lightweight LLM call")?;
 


### PR DESCRIPTION
## Summary

Two related pieces for running workgraph on headless/autostart setups that use Claude Code subscription credentials rather than `sk-ant-api03-…` console API keys.

### 1. `[auth]` section in `config.toml`

The daemon spawns three kinds of `claude` subprocesses — coordinator agent, lightweight LLM calls (chat compaction, triage, eval), and per-task agent wrappers. All three currently rely on the CLI's own credential resolution (env vars or `~/.claude/credentials.json`). That works fine when someone has run `claude login`, but if the only credential available is a bare `sk-ant-oat01-…` token (from `claude setup-token` or a subscription dashboard), the user has to export `CLAUDE_CODE_OAUTH_TOKEN` in every shell that starts the daemon. Task Scheduler / boot-time launch has no good answer.

New optional `[auth]` section:

```toml
[auth]
# Preferred: external file, leave the token out of git
claude_code_oauth_token_file = \"~/.config/workgraph/oauth-token\"

# Or inline (discouraged):
# claude_code_oauth_token = \"sk-ant-oat01-…\"
```

Resolution order at spawn time: **env → inline → file → nothing**. `nothing` falls through to the CLI's own resolution (i.e., `~/.claude/credentials.json`), which is the normal logged-in path. The `[auth]` section is entirely optional; existing configs keep working.

Wired into three sites, each a `cmd.env(\"CLAUDE_CODE_OAUTH_TOKEN\", token)`:

- `service/llm.rs::call_claude_cli`
- `commands/service/coordinator_agent.rs::spawn_claude_process`
- `commands/spawn/execution.rs::spawn_agent_inner`

### 2. `docs/README-windows.md`

New doc covering:

- What works (daemon, CLI, worktrees, agents, TUI) vs. what doesn't (`freeze`/`thaw`, `service install`)
- The three auth options in order of preference: `claude login`, `[auth]` config, ad-hoc env
- **The `ANTHROPIC_API_KEY` trap** — `sk-ant-oat01-…` tokens go in `CLAUDE_CODE_OAUTH_TOKEN` (Bearer scheme). Passing them in `ANTHROPIC_API_KEY` (x-api-key scheme) 401s on every call and surfaces as \"Invalid API key · Fix external API key\" synthetic placeholders in the outbox (not real model output). This trap bit us for the better part of a day on a real setup; anyone on a subscription-only plan is going to hit it.
- Shell requirements (Git-for-Windows bash is required; not WSL)
- Autostart pointers (Task Scheduler; a native-Windows `wg service install` is the obvious follow-up)
- `boring-sys2` / native-ARM64 build notes
- The `\?\` extended-path footgun + what workgraph already sanitizes
- Troubleshooting the three error shapes we kept hitting

## Test plan

- [ ] Config parsing: `Config::load_merged` on a file with no `[auth]` section parses cleanly (default empty)
- [ ] Resolution order: env set → env wins; env unset + inline set → inline used; neither + file set → file used; none → `None`
- [ ] `~/` and `$HOME/` expansion on the file path (uses the existing `expand_tilde` helper in config.rs)
- [ ] Daemon spawn with only `[auth] claude_code_oauth_token_file` set — subprocess succeeds on the first turn (verified on Windows 11 ARM64 with a real token)
- [ ] `claude login`-only machine — daemon still works with no `[auth]` section (verified by leaving config empty and letting the CLI read `~/.claude/credentials.json`)

## Sequencing

Companion to the Windows-port arc (#19 / #20 / #21 / #22 / #23 / #24 / #25). The README points at these PRs by number — if any merge in a different order or get renumbered, I'll update the cross-references.

Deliberately excluded from this PR:
- Windows-native `wg service install` that emits Task Scheduler XML (follow-up)
- Detecting `sk-ant-oat01-…` in `ANTHROPIC_API_KEY` and warning at daemon startup (nice-to-have; the README already calls out the trap)