### PR TITLE
fix(spawn): strip \?\ prefix on prompt + output-log paths in wrapper script

### DIFF
--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -20,6 +20,7 @@ use super::context::{
     resolve_task_scope,
 };
 use super::worktree;
+use super::sanitize_bash_path;
 use super::{
     SpawnResult, agent_output_dir, graph_path, parse_timeout_secs, prompt_file_command,
     shell_escape,
@@ -580,10 +581,15 @@ pub(crate) fn spawn_agent_inner(
 
     // Set working directory: worktree overrides settings.working_dir
     if let Some(ref wt) = worktree_info {
-        cmd.current_dir(&wt.path);
-        cmd.env("WG_WORKTREE_PATH", &wt.path);
+        // Strip `\\?\` verbatim prefix: bash.exe (MinGW/Git-for-Windows) silently
+        // produces no output when its CWD is a verbatim extended-length path like
+        // `\\?\C:\...`. Rust's PathBuf::canonicalize returns these on Windows.
+        let clean_worktree_path = sanitize_bash_path(&wt.path.to_string_lossy());
+        let clean_project_root = sanitize_bash_path(&wt.project_root.to_string_lossy());
+        cmd.current_dir(&clean_worktree_path);
+        cmd.env("WG_WORKTREE_PATH", &clean_worktree_path);
         cmd.env("WG_BRANCH", &wt.branch);
-        cmd.env("WG_PROJECT_ROOT", &wt.project_root);
+        cmd.env("WG_PROJECT_ROOT", &clean_project_root);
         // Signal to Claude Code (and other tools) that this session is already
         // inside a managed worktree — do not create a competing one.
         cmd.env("WG_WORKTREE_ACTIVE", "1");
@@ -1168,11 +1174,12 @@ fn write_wrapper_script(
             let raw_stream_file = output_dir.join("raw_stream.jsonl");
             let raw_str = raw_stream_file.to_string_lossy().to_string();
             // Capture JSONL stdout to raw_stream.jsonl and also copy to output.log.
-            // stderr goes to output.log only.
+            // stderr goes to output.log only. `tee -a <path>` opens the file
+            // itself and fails on `\\?\C:\...` verbatim paths, so sanitize.
             let cmd = format!(
                 "{timed_command} > >(tee -a {raw} >> \"$OUTPUT_FILE\") 2>> \"$OUTPUT_FILE\"",
                 timed_command = timed_command,
-                raw = shell_escape(&raw_str),
+                raw = shell_escape(&sanitize_bash_path(&raw_str)),
             );
             (cmd, String::new(), String::new())
         }
@@ -1323,7 +1330,11 @@ fi
 exit $EXIT_CODE
 "#,
         escaped_task_id = shell_escape(task_id),
-        escaped_output_file = shell_escape(output_file_str),
+        // `$OUTPUT_FILE` is used throughout the wrapper as a `>>` redirect
+        // target. Bash on Windows (Git-for-Windows) refuses `\\?\C:\...`
+        // verbatim paths for redirects with "No such file or directory",
+        // so output.log never appears and the agent looks silently dead.
+        escaped_output_file = shell_escape(&sanitize_bash_path(output_file_str)),
         run_command = run_command,
         timeout_note = timeout_note,
         debug_env_vars = debug_env_vars,

--- a/src/commands/spawn/mod.rs
+++ b/src/commands/spawn/mod.rs
@@ -30,7 +30,31 @@ fn shell_escape(s: &str) -> String {
 /// Generate a command that reads prompt from a file
 /// This is more reliable than heredoc when output redirection is involved
 fn prompt_file_command(prompt_file: &str, command: &str) -> String {
-    format!("cat {} | {}", shell_escape(prompt_file), command)
+    format!("cat {} | {}", shell_escape(&sanitize_bash_path(prompt_file)), command)
+}
+
+/// Strip the Windows extended-length path prefix (`\\?\`) so bash can
+/// open the path. Git-for-Windows' `bash.exe` can WRITE to `\\?\C:\...`
+/// via redirect operators, but it cannot pass such a path as an argument
+/// to a builtin or external command (`cat '\\?\C:\...\prompt.txt'`
+/// fails "No such file or directory"). `PathBuf::canonicalize` on
+/// Windows loves to return the verbatim form, so stripping here keeps
+/// generated shell scripts portable.
+///
+/// No-op on non-Windows.
+#[allow(clippy::manual_map)]
+pub(crate) fn sanitize_bash_path(path: &str) -> String {
+    #[cfg(windows)]
+    {
+        if let Some(rest) = path.strip_prefix(r"\\?\") {
+            // UNC form: `\\?\UNC\server\share\x` → `\\server\share\x`
+            if let Some(unc) = rest.strip_prefix("UNC\\") {
+                return format!(r"\\{}", unc);
+            }
+            return rest.to_string();
+        }
+    }
+    path.to_string()
 }
 
 /// Result of spawning an agent


### PR DESCRIPTION
## Summary

Sibling of #24 and #25. Same root cause (`PathBuf::canonicalize` yields `\\?\\C:\\…` verbatim paths on Windows that Git-for-Windows `bash` can't handle), two additional sinks the prefix leaks into — the generated `run.sh` wrapper script.

## Symptoms without this fix

Even with #24 (`bash` can find the wrapper) and #25 (`git worktree add` succeeds), Windows task agents die ~60s after spawn with:

- Empty agent directory (`.workgraph/agents/<id>/` has only `metadata.json`, `prompt.txt`, `run.sh` — no `output.log`)
- Daemon log shows `Task unclaimed: agent ... process exited`
- Nothing in the claude session jsonl for that agent
- Looks like the claude CLI is exiting 1 immediately, but there's no claude call happening — bash fails before it gets that far

The three sinks inside the wrapper:

```bash
# 1. cat argument — can't open verbatim path
cat '\\?\\C:\\src\\...\\prompt.txt' | claude ...

# 2. bash redirect target — same
... >> \"$OUTPUT_FILE\"  # OUTPUT_FILE='\\?\\C:\\...\\output.log'

# 3. tee argument (claude executor only) — same
... > >(tee -a '\\?\\C:\\...\\raw_stream.jsonl' >> \"$OUTPUT_FILE\") 2>> \"$OUTPUT_FILE\"
```

All three fail with \"No such file or directory\" — tested directly in Git-for-Windows bash. `cat` / `tee` open the path by argument; bash opens the redirect target; both fail the same way.

## Fix

New `sanitize_bash_path(&str) -> String` helper in `commands/spawn/mod.rs` that strips the `\\?\\` prefix on Windows (with `\\?\\UNC\\server\\share\\x` → `\\\\server\\share\\x`) and is a no-op elsewhere.

Applied to three call sites:

- `prompt_file_command(prompt_file, command)` — before shell-escaping the prompt file path
- `raw` interpolation in the claude-executor branch of `write_wrapper_script`
- `escaped_output_file` — before interpolating into the `OUTPUT_FILE=` line

After this, the wrapper emits `cat 'C:\\src\\…\\prompt.txt'` and `OUTPUT_FILE='C:\\src\\…\\output.log'` — both of which bash handles fine. Agents actually run end-to-end, `output.log` fills up with real claude stream-json, and agents mark tasks `done` or `failed` through the normal path.

## Test plan

- [ ] Linux/macOS: the helper is a no-op; existing tests pass unchanged
- [ ] Windows: spawn a fresh task agent with a worktree — `run.sh` contains `cat 'C:\\...'` (no `\\?\\` prefix), `output.log` exists and contains claude stream-json, agent completes the task through the verify+done path

## De-duplication

The helper is duplicated with the inline `strip_verbatim_prefix` introduced in #24 (bash script invocation path) and duplicated again in #25 (git worktree paths). Same ~15 lines in all three. Factor out into a shared module once all three land — a maintainer-friendly cleanup separate from any of these fixes.

## Sequencing

Part of the Windows-port arc: #19 / #20 / #21 / #22 / #23 / #24 / #25 / #27 (auth) / **this** (wrapper paths). Without this, #24 and #25 by themselves aren't enough to get agents actually producing output on Windows.