### PR TITLE
fix(spawn): CREATE_NEW_PROCESS_GROUP on Windows task-agent spawn

### DIFF
--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -611,6 +611,18 @@ pub(crate) fn spawn_agent_inner(
             });
         }
     }
+    // Windows equivalent: put the child at the root of its own process
+    // group so console control events (Ctrl+Break, Ctrl+C, window-close)
+    // that reach — or cascade through — the daemon's group don't also
+    // terminate the task agent. The coordinator spawn in
+    // `coordinator_agent::spawn_claude_process` already sets this flag
+    // for the same reason; task agents need the same protection.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NEW_PROCESS_GROUP = 0x00000200
+        cmd.creation_flags(0x0000_0200);
+    }
 
     // Claim the task BEFORE spawning the process to prevent race conditions
     // where two concurrent spawns both pass the status check.


### PR DESCRIPTION
## Summary

The Unix branch of `spawn_agent_inner` already calls `setsid()` on the child to detach from the daemon's session. Windows got nothing — task agents stayed in the daemon's process group and were vulnerable to console control events propagating through it.

Symptoms on some Windows setups (confirmed on Windows 11 ARM64 with the daemon launched from a cmd.exe shell):
- Task agents die at roughly each tick boundary
- `output.log` empty, nothing in daemon log beyond `Task unclaimed: agent ... process exited`
- Manual `bash run.sh` invocation completes normally — only the daemon-spawned case fails

## Fix

Mirror what `coordinator_agent::spawn_claude_process` already does: put the Windows child at the root of its own process group via `CREATE_NEW_PROCESS_GROUP` (0x0200).

```rust
#[cfg(windows)]
{
    use std::os::windows::process::CommandExt;
    cmd.creation_flags(0x0000_0200);
}
```

Conceptually the same as the adjacent Unix `setsid()` pre_exec. No behavior change on Unix.

## Test plan

- [x] Windows: task agents survive past the tick boundary and produce real output.log content (verified end-to-end via `wg add … ; wg publish ; wg service start`)
- [ ] Linux/macOS: no change — `cfg(windows)` only

Part of the Windows-port arc: companion to #19 / #20 / #21 / #22 / #23 / #24 / #25 / #27 / #28. On its own this fix isn't sufficient — #24 and #28 must also land so bash can actually find + write to the generated paths. This closes the last gap I hit that wasn't path-related.