### PR TITLE
fix(spawn): strip CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST etc. from spawned claude

### DIFF
--- a/src/commands/service/coordinator_agent.rs
+++ b/src/commands/service/coordinator_agent.rs
@@ -2418,8 +2418,16 @@ fn spawn_claude_process(
         .context("Failed to write coordinator system prompt file")?;
 
     let mut cmd = Command::new(command);
+    // Strip Claude-Code-specific env vars that leak through when the
+    // daemon was launched from inside a Claude Code session. See the
+    // matching comment in `service/llm.rs::call_claude_cli` for detail;
+    // without these removals the coordinator claude would prefer an
+    // inaccessible host bridge over the configured OAuth token and 401
+    // on every turn.
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    cmd.env_remove("CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST");
+    cmd.env_remove("CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH");
     cmd.args([
         "--print",
         "--input-format",

--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -1221,9 +1221,15 @@ fn write_wrapper_script(
 TASK_ID={escaped_task_id}
 OUTPUT_FILE={escaped_output_file}
 
-# Allow nested Claude Code sessions (spawned agents are independent)
+# Allow nested Claude Code sessions (spawned agents are independent).
+# The MANAGED_BY_HOST / SDK_HAS_OAUTH_REFRESH vars in particular leak
+# through when the daemon was launched from inside a Claude Code
+# session and make the spawned claude CLI prefer an inaccessible host
+# bridge over the configured token.
 unset CLAUDECODE
 unset CLAUDE_CODE_ENTRYPOINT
+unset CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
+unset CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH
 {timeout_note}
 {debug_env_vars}
 {stream_init}

--- a/src/service/llm.rs
+++ b/src/service/llm.rs
@@ -120,11 +120,26 @@ fn call_claude_cli(model: &str, prompt: &str, timeout_secs: u64) -> Result<LlmCa
         .arg("--output-format")
         .arg("json")
         .arg("--dangerously-skip-permissions")
-        // Strip CLAUDECODE env var so the CLI doesn't refuse to run
-        // when invoked from within a Claude Code session (e.g. daemon
-        // spawned by a coordinator agent). This is a headless --print
-        // call, not an interactive nested session.
+        // Strip Claude-Code-specific env vars that leak through when the
+        // daemon itself was spawned from a Claude Code session (common on
+        // Windows where people launch the daemon from a cmd.exe spawned
+        // by Claude Code):
+        //   - CLAUDECODE / CLAUDE_CODE_ENTRYPOINT: make the CLI refuse
+        //     to run or behave as a nested session
+        //   - CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: tells the CLI to
+        //     prefer the host bridge (Claude Code's auth IPC) over the
+        //     configured API key / OAuth token. In a detached daemon
+        //     there's no host bridge to resolve to, so the CLI 401s on
+        //     every call and surfaces its synthetic "Invalid API key"
+        //     placeholder.
+        //   - CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH: hints the CLI that an
+        //     SDK-level refresh loop is running and it shouldn't refresh
+        //     its own token. True inside Claude Code, false in a headless
+        //     daemon; leaving it set disables the CLI's own refresh.
         .env_remove("CLAUDECODE")
+        .env_remove("CLAUDE_CODE_ENTRYPOINT")
+        .env_remove("CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST")
+        .env_remove("CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH")
         .stdin(process::Stdio::piped())
         .stdout(process::Stdio::piped())
         .stderr(process::Stdio::piped())


### PR DESCRIPTION
## Summary

When `wg service start` runs from inside a Claude Code session — the common flow on Windows where users launch the daemon from a cmd.exe spawned by Claude Code — the daemon inherits a handful of Claude-Code-internal env vars:

```
CLAUDECODE=1
CLAUDE_CODE_ENTRYPOINT=claude-desktop
CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1
CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH=1
```

The first two are already stripped when the daemon spawns `claude` subprocesses. The latter two weren't, and they quietly misroute auth.

## Why it matters

- `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1` tells the CLI to prefer the **host bridge** (Claude Code's auth IPC) over whatever token is configured. Outside a live Claude Code session there's no host bridge to reach, so the CLI 401s on every request and surfaces its synthetic \"Invalid API key · Fix external API key\" placeholder as if it were a model response — no matter what valid token you set in `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` / `[auth]` config. The leaked env **silently overrides** all the auth paths the user expects to work.
- `CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH=1` tells the CLI an SDK-level refresh loop is running and it shouldn't run its own. True inside Claude Code, false in a detached daemon; leaving it set disables the CLI's built-in refresh.

Diagnosed by inspecting the env dump of a daemon-spawned wrapper via `BASH_ENV` hook — both vars were present.

## Fix

Strip both in all three spawn paths, next to the existing `CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT` removals:

- `service/llm.rs::call_claude_cli` — lightweight LLM calls (compaction, triage, evaluation)
- `commands/service/coordinator_agent.rs::spawn_claude_process` — long-running coordinator
- `commands/spawn/execution.rs` wrapper template — `unset` lines in generated run.sh (matches the existing pattern)

## Test plan

- [x] Windows: daemon launched from inside a Claude Code session — spawned agents now authenticate with the configured OAuth token instead of silently 401-ing
- [ ] No-op when the daemon runs in a clean shell (the vars just aren't set)

Part of the Windows-port arc. Follow-up to #27 (`[auth]` config + README). Without this strip, #27's token-config is effectively a no-op when run under Claude Code launch.