### PR TITLE
fix(spawn): CREATE_NEW_PROCESS_GROUP on inline eval + assign spawns

### DIFF
--- a/src/commands/service/coordinator.rs
+++ b/src/commands/service/coordinator.rs
@@ -2767,6 +2767,20 @@ exit $EXIT_CODE"#,
             });
         }
     }
+    // On Windows, the direct equivalent is `CREATE_NEW_PROCESS_GROUP`: it
+    // puts the child at the root of its own process group so console
+    // control events (Ctrl+Break, Ctrl+C, window-close) sent to — or
+    // cascading through — the daemon's group don't also terminate it.
+    // Without this, inline-spawn bash children die at roughly each 60s
+    // tick because a stray console event in the daemon's group takes them
+    // with it. The regular task-agent spawn path in `spawn/execution`
+    // already uses the same flag for this reason.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NEW_PROCESS_GROUP = 0x00000200
+        cmd.creation_flags(0x0000_0200);
+    }
 
     let child = match cmd.spawn() {
         Ok(child) => child,
@@ -2934,6 +2948,20 @@ exit $EXIT_CODE"#,
                 Ok(())
             });
         }
+    }
+    // On Windows, the direct equivalent is `CREATE_NEW_PROCESS_GROUP`: it
+    // puts the child at the root of its own process group so console
+    // control events (Ctrl+Break, Ctrl+C, window-close) sent to — or
+    // cascading through — the daemon's group don't also terminate it.
+    // Without this, inline-spawn bash children die at roughly each 60s
+    // tick because a stray console event in the daemon's group takes them
+    // with it. The regular task-agent spawn path in `spawn/execution`
+    // already uses the same flag for this reason.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NEW_PROCESS_GROUP = 0x00000200
+        cmd.creation_flags(0x0000_0200);
     }
 
     let child = match cmd.spawn() {


### PR DESCRIPTION
Mirror #29's fix to the two remaining child-spawn paths in the coordinator: \`spawn_eval_inline\` and \`spawn_assign_inline\`. Without \`CREATE_NEW_PROCESS_GROUP\` on Windows, these bash children inherit the daemon's console process group and receive console control events (Ctrl+Break, Ctrl+C, window-close) that cascade through the group, killing them at roughly each 60s tick. The regular task-agent spawn path in \`spawn/execution\` already uses this flag (#29).

Fixes the observed symptom where \`.evaluate-*\` and \`.assign-*\` tasks die at exactly 60s on Windows, putting their downstream graph in a permanent respawn backoff.

Verified locally against a running ontempo graph: four eval-inline agents spawned and ran past 60s, producing \`Turn N evaluated: <score>\` lines in daemon.log. No process-group kills.