### PR TITLE
fix: probe for gtimeout/timeout at wrapper runtime

### DIFF
--- a/src/commands/spawn/execution.rs
+++ b/src/commands/spawn/execution.rs
@@ -537,10 +537,16 @@ pub(crate) fn spawn_agent_inner(
         }
     };
 
-    // Build the actual command line, optionally wrapped with `timeout`
+    // Build the actual command line, optionally wrapped with `timeout`.
+    //
+    // The timeout binary is resolved at runtime via $WG_TIMEOUT_BIN (set by
+    // the wrapper header). macOS ships no GNU timeout — coreutils provides
+    // it as `gtimeout`. When neither is available the wrapper warns and the
+    // ${VAR:+...} expansion collapses to nothing, so the inner command runs
+    // unwrapped instead of failing silently with empty stdin to the executor.
     let timed_command = if let Some(secs) = effective_timeout_secs {
         format!(
-            "timeout --signal=TERM --kill-after=30 {} {}",
+            r#"${{WG_TIMEOUT_BIN:+"$WG_TIMEOUT_BIN" --signal=TERM --kill-after=30 {} }}{}"#,
             secs, inner_command
         )
     } else {
@@ -548,7 +554,10 @@ pub(crate) fn spawn_agent_inner(
     };
     let timed_fallback = fallback_command.map(|fb| {
         if let Some(secs) = effective_timeout_secs {
-            format!("timeout --signal=TERM --kill-after=30 {} {}", secs, fb)
+            format!(
+                r#"${{WG_TIMEOUT_BIN:+"$WG_TIMEOUT_BIN" --signal=TERM --kill-after=30 {} }}{}"#,
+                secs, fb
+            )
         } else {
             fb
         }
@@ -1247,8 +1256,20 @@ fn write_wrapper_script(
 
     let timeout_note = if let Some(secs) = effective_timeout_secs {
         format!(
-            "\n# Hard timeout: {}s (SIGTERM, then SIGKILL after 30s)\n",
-            secs
+            r#"
+# Hard timeout: {secs}s (SIGTERM, then SIGKILL after 30s).
+# Resolve a GNU `timeout` binary. macOS ships no GNU timeout — coreutils
+# provides it as `gtimeout`. Linux distros usually have `timeout` directly.
+# When neither is available we warn and the ${{WG_TIMEOUT_BIN:+...}} expansion
+# in the run command collapses to nothing, so the executor still runs (just
+# without a hard timeout). Without this probe a missing `timeout` would
+# silently break the pipeline and pipe empty stdin into the executor.
+WG_TIMEOUT_BIN="$(command -v gtimeout 2>/dev/null || command -v timeout 2>/dev/null || true)"
+if [ -z "$WG_TIMEOUT_BIN" ]; then
+    echo "[wrapper] WARNING: GNU timeout not found (install coreutils on macOS: 'brew install coreutils'); running without hard timeout" >> "$OUTPUT_FILE"
+fi
+"#,
+            secs = secs
         )
     } else {
         String::new()

--- a/src/commands/spawn/mod.rs
+++ b/src/commands/spawn/mod.rs
@@ -689,10 +689,16 @@ mod tests {
         let wrapper_path = agent_output_dir(&workgraph_dir, "agent-1").join("run.sh");
         let script = fs::read_to_string(&wrapper_path).unwrap();
 
-        // Verify the timeout command wraps the inner command
+        // Verify the timeout command wraps the inner command. The literal
+        // `timeout` prefix is replaced at runtime by $WG_TIMEOUT_BIN (resolved
+        // to gtimeout on macOS / timeout on Linux), so the assertion checks
+        // the parts that survive: the runtime-resolved binary substitution
+        // and the duration.
         assert!(
-            script.contains("timeout --signal=TERM --kill-after=30 300"),
-            "Wrapper should contain timeout command with 300s (5m). Script:\n{}",
+            script.contains(
+                r#"${WG_TIMEOUT_BIN:+"$WG_TIMEOUT_BIN" --signal=TERM --kill-after=30 300 }"#
+            ),
+            "Wrapper should contain WG_TIMEOUT_BIN-substituted timeout prefix with 300s (5m). Script:\n{}",
             script
         );
         // Verify timeout exit code handling
@@ -724,10 +730,69 @@ mod tests {
         let wrapper_path = agent_output_dir(&workgraph_dir, "agent-1").join("run.sh");
         let script = fs::read_to_string(&wrapper_path).unwrap();
 
-        // Default timeout is 30m = 1800s
+        // Default timeout is 30m = 1800s; the literal `timeout` prefix is
+        // resolved at runtime via $WG_TIMEOUT_BIN, so we check the substituted
+        // form rather than a hard-coded binary name.
         assert!(
-            script.contains("timeout --signal=TERM --kill-after=30 1800"),
-            "Wrapper should contain default timeout of 1800s (30m). Script:\n{}",
+            script.contains(
+                r#"${WG_TIMEOUT_BIN:+"$WG_TIMEOUT_BIN" --signal=TERM --kill-after=30 1800 }"#
+            ),
+            "Wrapper should contain WG_TIMEOUT_BIN-substituted default timeout of 1800s (30m). Script:\n{}",
+            script
+        );
+    }
+
+    #[test]
+    fn test_wrapper_script_probes_gtimeout_then_timeout() {
+        // Regression: macOS ships no GNU `timeout` binary; coreutils provides
+        // `gtimeout`. Before this probe was added, the wrapper hard-coded
+        // `timeout` and the missing binary caused the pipeline `cat prompt |
+        // claude --print` to silently hand empty stdin to claude, which then
+        // bailed with "Input must be provided either through stdin or as a
+        // prompt argument when using --print." Tasks died in ~2s with a
+        // confusing error and the real cause (no GNU timeout) was invisible.
+        let temp_dir = TempDir::new().unwrap();
+        let unique_id = get_unique_id();
+        let task_id = format!("t{}", unique_id);
+        let mut task = make_task(&task_id, "Test Task");
+        task.exec = Some("echo hello".to_string());
+        setup_graph(temp_dir.path(), vec![task]);
+
+        let workgraph_dir = temp_dir.path().join(".workgraph");
+        run(&workgraph_dir, &task_id, "shell", Some("5m"), None, false).unwrap();
+
+        let wrapper_path = agent_output_dir(&workgraph_dir, "agent-1").join("run.sh");
+        let script = fs::read_to_string(&wrapper_path).unwrap();
+
+        // Probe must check gtimeout first (macOS via coreutils), then timeout (Linux).
+        assert!(
+            script.contains("command -v gtimeout"),
+            "Wrapper should probe for gtimeout (macOS coreutils). Script:\n{}",
+            script
+        );
+        assert!(
+            script.contains("command -v timeout"),
+            "Wrapper should probe for timeout (Linux). Script:\n{}",
+            script
+        );
+        // The probe must set WG_TIMEOUT_BIN, which the timed command interpolates.
+        assert!(
+            script.contains("WG_TIMEOUT_BIN="),
+            "Wrapper should set WG_TIMEOUT_BIN env var. Script:\n{}",
+            script
+        );
+        // Substitution must use ${VAR:+...} so the prefix collapses to nothing
+        // when neither timeout binary is present (instead of breaking the pipeline).
+        assert!(
+            script.contains("${WG_TIMEOUT_BIN:+"),
+            "Wrapper should use ${{WG_TIMEOUT_BIN:+...}} substitution so the timeout prefix collapses cleanly when no binary is found. Script:\n{}",
+            script
+        );
+        // Warning when neither binary is found — visible in output.log so the
+        // operator can see why their hard timeout isn't being enforced.
+        assert!(
+            script.contains("GNU timeout not found"),
+            "Wrapper should warn when timeout binaries are missing. Script:\n{}",
             script
         );
     }


### PR DESCRIPTION
## Summary

The agent wrapper hard-coded `timeout --signal=TERM --kill-after=30 N`
in front of the executor pipeline (`cat prompt.txt | claude --print …`).
On macOS, BSD ships **no GNU `timeout` binary** — Homebrew's coreutils
provides it as `gtimeout`, but it isn't installed on a default macOS
host. With `timeout` missing on `\$PATH`, the shell silently failed the
left side of the pipe and handed empty stdin to the executor:

```
Error: Input must be provided either through stdin or as a prompt
       argument when using --print
```

Tasks died in ~2 seconds with the real cause invisible — the failure
class was `wrapper-internal` and the executor's error message pointed
at "missing input," which sent investigators down the wrong trail
(checking the prompt builder, the model, etc.).

This PR makes the wrapper probe `gtimeout` first (macOS coreutils),
then `timeout` (Linux), and resolve both into `\$WG_TIMEOUT_BIN` at
script start. The timed command uses `\${VAR:+ALT}` expansion so the
timeout prefix collapses cleanly to nothing when neither binary is
available — the executor still runs (just without a hard timeout) and
the wrapper logs an actionable warning to `output.log` pointing the
operator at `brew install coreutils`.

## Changes

- `src/commands/spawn/execution.rs` — replace hard-coded `timeout` prefix
  with `\${WG_TIMEOUT_BIN:+"\$WG_TIMEOUT_BIN" --signal=TERM --kill-after=30 N }`
  in `timed_command` and the resume-fallback path.
- `src/commands/spawn/execution.rs` — extend `timeout_note` to emit the
  probe block (`command -v gtimeout || command -v timeout || true`)
  followed by a `WARNING` log line when neither resolves.
- `src/commands/spawn/mod.rs` — update two existing tests that asserted
  the literal `timeout` prefix to the new substituted form.
- `src/commands/spawn/mod.rs` — add `test_wrapper_script_probes_gtimeout_then_timeout`
  locking in: probe order, `WG_TIMEOUT_BIN` env var, `:+` collapse,
  and the missing-binary warning.

## Test plan

- [x] `cargo build` — clean (19 pre-existing warnings, no new ones)
- [x] `cargo test --bin wg commands::spawn::tests::test_wrapper` —
      16/16 pass (including the new regression test and the two updated tests)
- [x] `cargo install --path .` + `wg retry <task>` on the failing task
      from a real session — task that died in 2 s with the misleading
      error now runs successfully on opus, with the expected warning
      visible in `output.log`:
      `[wrapper] WARNING: GNU timeout not found (install coreutils on macOS: 'brew install coreutils'); running without hard timeout`

## Notes

The fix is intentionally minimal — it does **not** change wrapper
semantics on Linux (where `timeout` is found and the prefix expands as
before), and it does **not** add a new install dependency. The
operator-visible behaviour delta is: macOS hosts without coreutils
move from "tasks fail with confusing executor error in 2 seconds" to
"tasks run normally with a clear warning that the hard timeout isn't
enforced and an actionable fix in the warning text."

🤖 Generated with [Claude Code](https://claude.com/claude-code)