### PR TITLE
build: migrate rquest to git-pinned v3.0.6 + rquest-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "archery"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,20 +534,12 @@ checksum = "e4470e96bd94533c2f88c08be95a8e6d2d37a3b497a773b0a46273a376978f00"
 dependencies = [
  "bitflags 2.11.0",
  "boring-sys2",
+ "brotli",
+ "flate2",
  "foreign-types 0.5.0",
  "libc",
  "openssl-macros",
-]
-
-[[package]]
-name = "brotli"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 4.0.3",
+ "zstd",
 ]
 
 [[package]]
@@ -549,17 +550,7 @@ checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 5.0.0",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -906,7 +897,7 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
- "brotli 8.0.2",
+ "brotli",
  "compression-core",
  "flate2",
  "memchr",
@@ -3354,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
 name = "lru"
@@ -5151,30 +5142,25 @@ dependencies = [
 
 [[package]]
 name = "rquest"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f82d6d3cbaf23f23c70f1403107fa36dc028b0bf14db88f8b240381ed9b5dd"
+version = "3.0.6"
+source = "git+https://github.com/0x676e67/wreq.git?tag=v3.0.6#15f575c1aea6202847f94a74d35d9abb93d73a3f"
 dependencies = [
  "antidote",
+ "arc-swap",
  "async-compression",
  "base64 0.22.1",
- "boring-sys2",
  "boring2",
- "brotli 7.0.0",
  "bytes",
  "encoding_rs",
- "flate2",
- "foreign-types 0.5.0",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper2",
  "ipnet",
- "libc",
  "linked_hash_set",
  "log",
- "lru 0.12.5",
+ "lru 0.13.0",
  "mime",
  "percent-encoding",
  "pin-project-lite",
@@ -5189,11 +5175,20 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-service",
- "typed-builder",
+ "typed-builder 0.20.1",
  "url",
  "webpki-root-certs 0.26.11",
  "windows-registry",
- "zstd",
+]
+
+[[package]]
+name = "rquest-util"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e3762f6e3e0d1674a6e74ebcbcb3b8d56c895757fc2cc2aa0d5e62ccfcb21e"
+dependencies = [
+ "rquest",
+ "typed-builder 0.21.2",
 ]
 
 [[package]]
@@ -6823,7 +6818,16 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
 dependencies = [
- "typed-builder-macro",
+ "typed-builder-macro 0.20.1",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
+dependencies = [
+ "typed-builder-macro 0.21.2",
 ]
 
 [[package]]
@@ -6831,6 +6835,17 @@ name = "typed-builder-macro"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7495,13 +7510,13 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.5",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -7524,9 +7539,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
 ]
@@ -7953,6 +7968,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rquest",
+ "rquest-util",
  "rustyline",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,60 @@ homepage = "https://github.com/graphwork/wg"
 name = "wg"
 path = "src/main.rs"
 
+# Project-wide lint policy. Applies to lib, bin, and integration tests (so the
+# crate-local `#![allow(...)]` blocks in lib.rs / main.rs don't have to be
+# duplicated into every tests/*.rs).
+#
+# Most of these were added when CI's toolchain (`dtolnay/rust-toolchain@stable`)
+# rolled from 1.93 to 1.95 and a fresh batch of lints fired against existing
+# code. Where the lint is style-preference rather than a correctness issue, we
+# allow crate-wide rather than churn every site. Genuinely incorrect code
+# (overly_complex_bool_expr) is left at its default `deny` and fixed instead.
+[lints.rust]
+dead_code = "allow"
+unused_assignments = "allow"
+
+[lints.clippy]
+# Carried over from the lib.rs/main.rs blocks (1.93-era lint additions).
+while_let_loop = "allow"
+manual_div_ceil = "allow"
+manual_checked_ops = "allow"
+useless_conversion = "allow"
+unnecessary_sort_by = "allow"
+collapsible_match = "allow"
+collapsible_if = "allow"
+collapsible_else_if = "allow"
+# Added for 1.95.
+doc_lazy_continuation = "allow"
+doc_overindented_list_items = "allow"
+empty_line_after_doc_comments = "allow"
+field_reassign_with_default = "allow"
+too_many_arguments = "allow"
+if_same_then_else = "allow"
+large_enum_variant = "allow"
+enum_variant_names = "allow"
+type_complexity = "allow"
+# More 1.95-era style preferences (high-volume noise; not correctness issues).
+needless_borrows_for_generic_args = "allow"
+vec_init_then_push = "allow"
+useless_format = "allow"
+useless_vec = "allow"
+clone_on_copy = "allow"
+nonminimal_bool = "allow"
+iter_cloned_collect = "allow"
+manual_range_contains = "allow"
+manual_str_repeat = "allow"
+manual_repeat_n = "allow"
+cloned_ref_to_slice_refs = "allow"
+let_unit_value = "allow"
+needless_return = "allow"
+assertions_on_constants = "allow"
+absurd_extreme_comparisons = "allow"
+module_inception = "allow"
+items_after_test_module = "allow"
+unnecessary_filter_map = "allow"
+unnecessary_get_then_check = "allow"
+
 [features]
 default = ["matrix-lite"]
 matrix = ["dep:matrix-sdk"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,12 @@ cron = "0.12"
 log = "0.4"
 env_logger = "0.11"
 chromiumoxide = { version = "0.7", features = ["tokio-runtime"], default-features = false }
-# rquest 5.x is yanked on crates.io; 3.0.0 is the newest non-yanked release.
-# It provides built-in Chrome impersonation, so no rquest-util shim is needed.
-rquest = { version = "3.0.0", features = ["json", "gzip", "brotli", "deflate", "zstd"] }
+# Upstream yanked every rquest release on crates.io after renaming the crate
+# to `wreq`. Pin via git to the v3.0.6 tag (last release that still publishes
+# under the `rquest` name). The 3.x line moved browser emulation out of rquest
+# itself into a sibling `rquest-util` crate, so we pull that in too.
+rquest = { git = "https://github.com/0x676e67/wreq.git", tag = "v3.0.6", features = ["json", "gzip", "brotli", "deflate", "zstd"] }
+rquest-util = { version = "2.2.1", features = ["emulation"] }
 
 # Optional Matrix integration (requires sqlite3)
 matrix-sdk = { version = "0.16", features = ["e2e-encryption", "sqlite"], optional = true }
@@ -105,3 +108,10 @@ tempfile = "3.10"
 serial_test = "3"
 insta = { version = "1", features = ["yaml"] }
 workgraph = { path = ".", features = ["test-support"] }
+
+# Force rquest-util's transitive rquest dep through the same git source we use
+# directly. Without this, cargo tries to resolve rquest-util's `rquest =
+# ">=3.0.5"` requirement against crates.io, where every matching version has
+# been yanked by upstream.
+[patch.crates-io]
+rquest = { git = "https://github.com/0x676e67/wreq.git", tag = "v3.0.6" }

--- a/src/agency/constraint_fidelity.rs
+++ b/src/agency/constraint_fidelity.rs
@@ -174,12 +174,12 @@ fn extract_sentence_context(text: &str, match_start: usize, match_end: usize) ->
     let after = &text[match_end..];
 
     let sentence_start = before
-        .rfind(|c: char| c == '.' || c == '\n' || c == '!' || c == '?')
+        .rfind(['.', '\n', '!', '?'])
         .map(|i| i + 1)
         .unwrap_or(0);
 
     let sentence_end = after
-        .find(|c: char| c == '.' || c == '\n' || c == '!' || c == '?')
+        .find(['.', '\n', '!', '?'])
         .map(|i| match_end + i + 1)
         .unwrap_or(text.len());
 

--- a/src/agency/types.rs
+++ b/src/agency/types.rs
@@ -139,18 +139,13 @@ pub struct Lineage {
     pub reframing_potential: Option<f64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum CreatedBy {
+    #[default]
     Human,
     Import,
     Evolver,
     AgentCreator,
-}
-
-impl Default for CreatedBy {
-    fn default() -> Self {
-        Self::Human
-    }
 }
 
 impl std::fmt::Display for CreatedBy {

--- a/src/chat_id.rs
+++ b/src/chat_id.rs
@@ -40,7 +40,7 @@ pub fn is_legacy_coordinator_id(s: &str) -> bool {
 }
 
 /// Look up a chat task by numeric ID, trying `.chat-N` first then `.coordinator-N`.
-pub fn find_chat_task<'g>(graph: &'g WorkGraph, id: u32) -> Option<&'g crate::graph::Task> {
+pub fn find_chat_task(graph: &WorkGraph, id: u32) -> Option<&crate::graph::Task> {
     let new_id = format_chat_task_id(id);
     if let Some(t) = graph.get_task(&new_id) {
         return Some(t);

--- a/src/commands/chat_cmd.rs
+++ b/src/commands/chat_cmd.rs
@@ -290,7 +290,7 @@ fn run_create_direct(
 pub fn run_list(dir: &Path, json: bool) -> Result<()> {
     migrate_existing_chat_tasks(dir)?;
     let graph =
-        workgraph::parser::load_graph(&graph_path(dir)).with_context(|| "Failed to load graph")?;
+        workgraph::parser::load_graph(graph_path(dir)).with_context(|| "Failed to load graph")?;
 
     let daemon_running = service_is_running(dir);
     let supervised = supervised_chat_ids(dir);
@@ -335,7 +335,7 @@ pub fn run_list(dir: &Path, json: bool) -> Result<()> {
         return Ok(());
     }
 
-    println!("{:<6}  {:<14}  {:<24}  {}", "ID", "STATUS", "TASK", "TITLE");
+    println!("{:<6}  {:<14}  {:<24}  TITLE", "ID", "STATUS", "TASK");
     for (cid, t, s) in rows {
         let suffix = if matches!(s, ChatRuntimeStatus::Dormant) && !daemon_running {
             " — service stopped"
@@ -362,7 +362,7 @@ pub fn run_list(dir: &Path, json: bool) -> Result<()> {
 pub fn run_show(dir: &Path, reference: &str, json: bool) -> Result<()> {
     migrate_existing_chat_tasks(dir)?;
     let graph =
-        workgraph::parser::load_graph(&graph_path(dir)).with_context(|| "Failed to load graph")?;
+        workgraph::parser::load_graph(graph_path(dir)).with_context(|| "Failed to load graph")?;
 
     let cid = resolve_chat_id(&graph, reference)
         .with_context(|| format!("No chat matching '{}'", reference))?;
@@ -425,7 +425,7 @@ pub fn run_show(dir: &Path, reference: &str, json: bool) -> Result<()> {
 /// queues until the daemon (re)starts.
 pub fn run_send(dir: &Path, reference: &str, message: &str, json: bool) -> Result<()> {
     let graph =
-        workgraph::parser::load_graph(&graph_path(dir)).with_context(|| "Failed to load graph")?;
+        workgraph::parser::load_graph(graph_path(dir)).with_context(|| "Failed to load graph")?;
     let cid = resolve_chat_id(&graph, reference)
         .with_context(|| format!("No chat matching '{}'", reference))?;
 
@@ -467,7 +467,7 @@ pub fn run_send(dir: &Path, reference: &str, message: &str, json: bool) -> Resul
 /// Requires the daemon (the supervisor owns the handler).
 pub fn run_stop(dir: &Path, reference: &str, json: bool) -> Result<()> {
     let graph =
-        workgraph::parser::load_graph(&graph_path(dir)).with_context(|| "Failed to load graph")?;
+        workgraph::parser::load_graph(graph_path(dir)).with_context(|| "Failed to load graph")?;
     let cid = resolve_chat_id(&graph, reference)
         .with_context(|| format!("No chat matching '{}'", reference))?;
     if !service_is_running(dir) {
@@ -485,7 +485,7 @@ pub fn run_stop(dir: &Path, reference: &str, json: bool) -> Result<()> {
 /// Requires the daemon. Errors clearly when down.
 pub fn run_resume(dir: &Path, reference: &str, json: bool) -> Result<()> {
     let graph =
-        workgraph::parser::load_graph(&graph_path(dir)).with_context(|| "Failed to load graph")?;
+        workgraph::parser::load_graph(graph_path(dir)).with_context(|| "Failed to load graph")?;
     let cid = resolve_chat_id(&graph, reference)
         .with_context(|| format!("No chat matching '{}'", reference))?;
     if !service_is_running(dir) {
@@ -541,7 +541,7 @@ pub fn run_resume(dir: &Path, reference: &str, json: bool) -> Result<()> {
 /// chats can still be inspected; their dirs are moved to .archive/).
 pub fn run_archive(dir: &Path, reference: &str, json: bool) -> Result<()> {
     let graph =
-        workgraph::parser::load_graph(&graph_path(dir)).with_context(|| "Failed to load graph")?;
+        workgraph::parser::load_graph(graph_path(dir)).with_context(|| "Failed to load graph")?;
     let cid = resolve_chat_id(&graph, reference)
         .with_context(|| format!("No chat matching '{}'", reference))?;
     let result = if service_is_running(dir) {
@@ -600,7 +600,7 @@ fn archive_chat_direct(dir: &Path, cid: u32, json: bool) -> Result<()> {
 /// `wg chat delete` — abandon the graph task and remove the chat dir.
 pub fn run_delete(dir: &Path, reference: &str, yes: bool, json: bool) -> Result<()> {
     let graph =
-        workgraph::parser::load_graph(&graph_path(dir)).with_context(|| "Failed to load graph")?;
+        workgraph::parser::load_graph(graph_path(dir)).with_context(|| "Failed to load graph")?;
     let cid = resolve_chat_id(&graph, reference)
         .with_context(|| format!("No chat matching '{}'", reference))?;
 
@@ -685,7 +685,7 @@ fn delete_chat_direct(dir: &Path, cid: u32, json: bool) -> Result<()> {
 ///      enqueue messages.
 pub fn run_attach(dir: &Path, reference: &str, force_cli: bool) -> Result<()> {
     let graph =
-        workgraph::parser::load_graph(&graph_path(dir)).with_context(|| "Failed to load graph")?;
+        workgraph::parser::load_graph(graph_path(dir)).with_context(|| "Failed to load graph")?;
     let cid = resolve_chat_id(&graph, reference)
         .with_context(|| format!("No chat matching '{}'", reference))?;
 

--- a/src/commands/claim_lifecycle.rs
+++ b/src/commands/claim_lifecycle.rs
@@ -12,7 +12,6 @@
 //! Lazy with status-aware reconciler").
 
 use std::collections::HashSet;
-use std::path::Path;
 
 use chrono::Utc;
 

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -1616,7 +1616,7 @@ fn apply_model_routing_updates(
     let mut changed = false;
 
     if !set_models.is_empty() {
-        if set_models.len() % 2 != 0 {
+        if !set_models.len().is_multiple_of(2) {
             anyhow::bail!("--set-model requires pairs of arguments: <role> <model>");
         }
         for pair in set_models.chunks(2) {
@@ -1634,7 +1634,7 @@ fn apply_model_routing_updates(
     }
 
     if !set_providers.is_empty() {
-        if set_providers.len() % 2 != 0 {
+        if !set_providers.len().is_multiple_of(2) {
             anyhow::bail!("--set-provider requires pairs of arguments: <role> <provider>");
         }
         for pair in set_providers.chunks(2) {
@@ -1652,7 +1652,7 @@ fn apply_model_routing_updates(
     }
 
     if !set_endpoints.is_empty() {
-        if set_endpoints.len() % 2 != 0 {
+        if !set_endpoints.len().is_multiple_of(2) {
             anyhow::bail!("--set-endpoint requires pairs of arguments: <role> <endpoint-name>");
         }
         for pair in set_endpoints.chunks(2) {

--- a/src/commands/done.rs
+++ b/src/commands/done.rs
@@ -1455,9 +1455,7 @@ fn run_inner(
     // smoke scenario it owns is failing. Refuse the agent escape hatch unless
     // a separate override is set, so an agent can't smother a real regression
     // by adding `--skip-smoke` to its `wg done`.
-    if let Err(e) = run_smoke_gate(dir, id, full_smoke, skip_smoke, is_agent) {
-        return Err(e);
-    }
+    run_smoke_gate(dir, id, full_smoke, skip_smoke, is_agent)?;
 
     // Auto-defer verify when the task has been decomposed into subtasks.
     // When an agent decomposes a parent task into children (via `wg add --after parent`),

--- a/src/commands/evaluate.rs
+++ b/src/commands/evaluate.rs
@@ -133,7 +133,7 @@ fn find_originating_user_message(dir: &Path, task: &workgraph::graph::Task) -> O
                             {
                                 // Message must be before (or within 60s of) task creation
                                 let delta = created_ts.signed_duration_since(msg_ts).num_seconds();
-                                if delta >= -60 && delta <= 600 {
+                                if (-60..=600).contains(&delta) {
                                     // Within 10 min window before creation
                                     if best_message
                                         .as_ref()

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -43,8 +43,8 @@ pub fn run_with_route(
     // 0. If `--executor` was supplied, emit a single deprecation line and
     //    keep going. We never refuse the flag: existing scripts / tests
     //    must keep working for one release.
-    if executor.is_some() {
-        emit_executor_deprecation_warning(executor.unwrap());
+    if let Some(executor) = executor {
+        emit_executor_deprecation_warning(executor);
     }
 
     // 1. If only `-m` is given (no `-x`, no `--route`), derive the route
@@ -490,17 +490,13 @@ pub fn run(
         println!("No global config found. Run `wg setup` to configure defaults.");
     }
 
-    // Check skill/bundle status for the chosen executor.
-    match executor {
-        "claude" => {
-            if !super::setup::is_claude_skill_installed() {
-                println!();
-                println!("Hint: The wg skill for Claude Code is not installed.");
-                println!("  Spawned agents won't know wg commands without it.");
-                println!("  Run: wg skill install");
-            }
-        }
-        _ => {} // Custom executor — user knows what they're doing
+    // Check skill/bundle status for the chosen executor. Custom executors
+    // skip this hint — the user knows what they're doing.
+    if executor == "claude" && !super::setup::is_claude_skill_installed() {
+        println!();
+        println!("Hint: The wg skill for Claude Code is not installed.");
+        println!("  Spawned agents won't know wg commands without it.");
+        println!("  Run: wg skill install");
     }
 
     // Configure project-level agent guides for Claude Code / Claude CLI and Codex.

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -152,7 +152,7 @@ pub fn run_chat_rename(dir: &Path, dry_run: bool, json: bool) -> Result<()> {
             // Phase 4: re-key the HashMap so lookups by the NEW id work.
             // We pull each renamed task out by its old key and re-add it,
             // which inserts at the new key (add_node uses node.id()).
-            for (old_id, _new_id) in &id_remap {
+            for old_id in id_remap.keys() {
                 if let Some(node) = graph.take_node(old_id) {
                     graph.add_node(node);
                 }

--- a/src/commands/profile_cmd.rs
+++ b/src/commands/profile_cmd.rs
@@ -550,7 +550,7 @@ pub fn list(dir: &Path, json: bool, installed_only: bool) -> Result<()> {
                 items.push(serde_json::json!({
                     "name": p.name,
                     "kind": "legacy-builtin",
-                    "active": active.is_none() && false,
+                    "active": false,
                     "description": p.description,
                 }));
             }

--- a/src/commands/reprioritize.rs
+++ b/src/commands/reprioritize.rs
@@ -1,14 +1,14 @@
 use anyhow::{Context, Result};
 use std::path::Path;
-use workgraph::graph::{
-    PRIORITY_CRITICAL, PRIORITY_DEFAULT, PRIORITY_HIGH, PRIORITY_IDLE, PRIORITY_LOW,
-};
+use workgraph::graph::PRIORITY_DEFAULT;
 use workgraph::parser::modify_graph;
 
 use super::add::parse_priority;
 
 #[cfg(test)]
 use super::graph_path;
+#[cfg(test)]
+use workgraph::graph::{PRIORITY_CRITICAL, PRIORITY_HIGH, PRIORITY_IDLE, PRIORITY_LOW};
 #[cfg(test)]
 use workgraph::parser::load_graph;
 

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -1269,7 +1269,7 @@ mod tests {
     fn test_topo_sort_subset_orders_deps_before_dependents() {
         // Direct unit test on the helper: deps come strictly before
         // dependents in the result order.
-        let mut a = make_task("a", "A", Status::Open);
+        let a = make_task("a", "A", Status::Open);
         let mut b = make_task("b", "B", Status::Open);
         b.after = vec!["a".to_string()];
         let mut c = make_task("c", "C", Status::Open);
@@ -1278,7 +1278,6 @@ mod tests {
         for t in [a.clone(), b.clone(), c.clone()] {
             graph.add_node(workgraph::graph::Node::Task(t));
         }
-        let _ = (a, b, c); // silence unused-mut lints from clones above
         let sorted = topo_sort_subset(&graph, &["c".to_string(), "b".to_string(), "a".to_string()]);
         assert_eq!(
             sorted,
@@ -1288,10 +1287,10 @@ mod tests {
 
     #[test]
     fn test_discover_wcc_isolates_components() {
-        let mut a = make_task("a", "A", Status::Open);
+        let a = make_task("a", "A", Status::Open);
         let mut b = make_task("b", "B", Status::Open);
         b.after = vec!["a".to_string()];
-        let mut x = make_task("x", "X", Status::Open);
+        let x = make_task("x", "X", Status::Open);
         let mut y = make_task("y", "Y", Status::Open);
         y.after = vec!["x".to_string()];
         let mut graph = WorkGraph::new();

--- a/src/commands/service/coordinator.rs
+++ b/src/commands/service/coordinator.rs
@@ -3916,7 +3916,7 @@ fn record_spawn_failure(
 fn spawn_agents_for_ready_tasks(
     dir: &Path,
     graph: &workgraph::graph::WorkGraph,
-    executor: &str,
+    _executor: &str,
     config: &Config,
     default_model: Option<&str>,
     slots_available: usize,

--- a/src/commands/service/coordinator_agent.rs
+++ b/src/commands/service/coordinator_agent.rs
@@ -877,7 +877,7 @@ fn subprocess_coordinator_loop(
         // `.coordinator-N`) are honored, then layer the supervisor's
         // explicit `exec_override` as the agency-level executor input.
         let supervisor_config = workgraph::config::Config::load_or_default(dir);
-        let chat_task = match workgraph::parser::load_graph(&crate::commands::graph_path(dir)) {
+        let chat_task = match workgraph::parser::load_graph(crate::commands::graph_path(dir)) {
             Ok(g) => g
                 .get_task(&task_id)
                 .cloned()

--- a/src/commands/service/worktree.rs
+++ b/src/commands/service/worktree.rs
@@ -1756,6 +1756,76 @@ pub fn enqueue_recovery_prune(
     queue.enqueue(job)
 }
 
+/// Fix permissions on a file and attempt removal
+/// This provides a fallback strategy for permission-denied errors
+#[cfg(unix)]
+fn fix_permissions_and_remove_file(file_path: &Path) -> Result<()> {
+    // Try to make the file writable
+    if let Ok(metadata) = fs::metadata(file_path) {
+        let mut perms = metadata.permissions();
+        perms.set_mode(0o644); // Read/write for owner, read for others
+
+        fs::set_permissions(file_path, perms)
+            .with_context(|| format!("Failed to fix file permissions for {:?}", file_path))?;
+
+        // Retry removal after permission fix
+        fs::remove_file(file_path).with_context(|| {
+            format!("Failed to remove file {:?} after permission fix", file_path)
+        })?;
+    }
+
+    Ok(())
+}
+
+/// Fix permissions on a directory and its contents, then attempt removal
+/// This provides a fallback strategy for permission-denied errors
+#[cfg(unix)]
+fn fix_permissions_and_remove_dir(dir_path: &Path) -> Result<()> {
+    if !dir_path.exists() {
+        return Ok(());
+    }
+
+    // Recursively fix permissions
+    fn fix_permissions_recursive(path: &Path) -> Result<()> {
+        if path.is_dir() {
+            // Make directory executable/readable
+            if let Ok(metadata) = fs::metadata(path) {
+                let mut perms = metadata.permissions();
+                perms.set_mode(0o755); // rwxr-xr-x
+                let _ = fs::set_permissions(path, perms);
+            }
+
+            // Fix permissions for all entries
+            if let Ok(entries) = fs::read_dir(path) {
+                for entry in entries.flatten() {
+                    fix_permissions_recursive(&entry.path())?;
+                }
+            }
+        } else {
+            // Make file writable
+            if let Ok(metadata) = fs::metadata(path) {
+                let mut perms = metadata.permissions();
+                perms.set_mode(0o644); // rw-r--r--
+                let _ = fs::set_permissions(path, perms);
+            }
+        }
+        Ok(())
+    }
+
+    fix_permissions_recursive(dir_path)
+        .with_context(|| format!("Failed to fix directory permissions for {:?}", dir_path))?;
+
+    // Retry removal after permission fix
+    fs::remove_dir_all(dir_path).with_context(|| {
+        format!(
+            "Failed to remove directory {:?} after permission fix",
+            dir_path
+        )
+    })?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1918,7 +1988,7 @@ mod tests {
         assert_eq!(count, 1);
 
         // Recovery branch should exist
-        let recovery_branch = format!("recover/agent-3/task-baz");
+        let recovery_branch = "recover/agent-3/task-baz".to_string();
         let output = Command::new("git")
             .args(["branch", "--list", &recovery_branch])
             .current_dir(&project)
@@ -3031,76 +3101,6 @@ mod tests {
         assert_eq!(reaped, 0);
         assert_eq!(freed, 0);
     }
-}
-
-/// Fix permissions on a file and attempt removal
-/// This provides a fallback strategy for permission-denied errors
-#[cfg(unix)]
-fn fix_permissions_and_remove_file(file_path: &Path) -> Result<()> {
-    // Try to make the file writable
-    if let Ok(metadata) = fs::metadata(file_path) {
-        let mut perms = metadata.permissions();
-        perms.set_mode(0o644); // Read/write for owner, read for others
-
-        fs::set_permissions(file_path, perms)
-            .with_context(|| format!("Failed to fix file permissions for {:?}", file_path))?;
-
-        // Retry removal after permission fix
-        fs::remove_file(file_path).with_context(|| {
-            format!("Failed to remove file {:?} after permission fix", file_path)
-        })?;
-    }
-
-    Ok(())
-}
-
-/// Fix permissions on a directory and its contents, then attempt removal
-/// This provides a fallback strategy for permission-denied errors
-#[cfg(unix)]
-fn fix_permissions_and_remove_dir(dir_path: &Path) -> Result<()> {
-    if !dir_path.exists() {
-        return Ok(());
-    }
-
-    // Recursively fix permissions
-    fn fix_permissions_recursive(path: &Path) -> Result<()> {
-        if path.is_dir() {
-            // Make directory executable/readable
-            if let Ok(metadata) = fs::metadata(path) {
-                let mut perms = metadata.permissions();
-                perms.set_mode(0o755); // rwxr-xr-x
-                let _ = fs::set_permissions(path, perms);
-            }
-
-            // Fix permissions for all entries
-            if let Ok(entries) = fs::read_dir(path) {
-                for entry in entries.flatten() {
-                    fix_permissions_recursive(&entry.path())?;
-                }
-            }
-        } else {
-            // Make file writable
-            if let Ok(metadata) = fs::metadata(path) {
-                let mut perms = metadata.permissions();
-                perms.set_mode(0o644); // rw-r--r--
-                let _ = fs::set_permissions(path, perms);
-            }
-        }
-        Ok(())
-    }
-
-    fix_permissions_recursive(dir_path)
-        .with_context(|| format!("Failed to fix directory permissions for {:?}", dir_path))?;
-
-    // Retry removal after permission fix
-    fs::remove_dir_all(dir_path).with_context(|| {
-        format!(
-            "Failed to remove directory {:?} after permission fix",
-            dir_path
-        )
-    })?;
-
-    Ok(())
 }
 
 /// Fallback implementations for non-Unix systems

--- a/src/commands/viz/graph.rs
+++ b/src/commands/viz/graph.rs
@@ -261,7 +261,7 @@ pub fn generate_graph_with_overrides(
                 ),
             )
         };
-        let width = line1.len().max(line2.len());
+        let _width = line1.len().max(line2.len());
 
         let color = if task.paused && use_color {
             paused_color

--- a/src/config.rs
+++ b/src/config.rs
@@ -3085,6 +3085,7 @@ pub struct CoordinatorConfig {
     /// Verification mode for tasks with legacy verify commands (deprecated).
     /// - "inline" (default): verify command runs in the same agent process that did the work
     /// - "separate": verify runs in a separate agent context (different conversation/context window)
+    ///
     /// New tasks should put validation criteria in a `## Validation` section of the task
     /// description; the agency evaluator (auto_evaluate + FLIP) reads it.
     #[serde(default = "default_verify_mode")]
@@ -3743,8 +3744,7 @@ fn apply_endpoint_inheritance_policy(
         .and_then(|t| t.get("endpoints"))
         .and_then(|v| v.as_array())
         .is_some();
-    let inherit =
-        explicit_inherit.unwrap_or_else(|| active_named_profile && !local_declares_endpoints);
+    let inherit = explicit_inherit.unwrap_or(active_named_profile && !local_declares_endpoints);
     if inherit {
         return;
     }

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -308,7 +308,7 @@ mod tests {
         };
 
         let now = Utc::now();
-        assert_eq!(is_cron_due(&task, now), false);
+        assert!(!is_cron_due(&task, now));
     }
 
     #[test]
@@ -321,7 +321,7 @@ mod tests {
         };
 
         let now = Utc::now();
-        assert_eq!(is_cron_due(&task, now), false);
+        assert!(!is_cron_due(&task, now));
     }
 
     #[test]
@@ -334,7 +334,7 @@ mod tests {
         };
 
         let now = Utc::now();
-        assert_eq!(is_cron_due(&task, now), false);
+        assert!(!is_cron_due(&task, now));
     }
 
     #[test]
@@ -350,11 +350,11 @@ mod tests {
 
         // Test at 2 AM - should be due
         let now = Utc.with_ymd_and_hms(2024, 1, 1, 2, 0, 0).unwrap();
-        assert_eq!(is_cron_due(&task, now), true);
+        assert!(is_cron_due(&task, now));
 
         // Test at 3 AM - should not be due
         let now = Utc.with_ymd_and_hms(2024, 1, 1, 3, 0, 0).unwrap();
-        assert_eq!(is_cron_due(&task, now), false);
+        assert!(!is_cron_due(&task, now));
     }
 
     #[test]
@@ -372,15 +372,15 @@ mod tests {
 
         // Test at 1 AM next day - should not be due yet
         let now = Utc.with_ymd_and_hms(2024, 1, 2, 1, 0, 0).unwrap();
-        assert_eq!(is_cron_due(&task, now), false);
+        assert!(!is_cron_due(&task, now));
 
         // Test at 2 AM next day - should be due
         let now = Utc.with_ymd_and_hms(2024, 1, 2, 2, 0, 0).unwrap();
-        assert_eq!(is_cron_due(&task, now), true);
+        assert!(is_cron_due(&task, now));
 
         // Test at 3 AM next day - should be due (missed the 2 AM window)
         let now = Utc.with_ymd_and_hms(2024, 1, 2, 3, 0, 0).unwrap();
-        assert_eq!(is_cron_due(&task, now), true);
+        assert!(is_cron_due(&task, now));
     }
 
     #[test]

--- a/src/dispatch/plan.rs
+++ b/src/dispatch/plan.rs
@@ -65,6 +65,7 @@ impl ExecutorKind {
         }
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "claude" => Some(ExecutorKind::Claude),

--- a/src/executor/native/resume.rs
+++ b/src/executor/native/resume.rs
@@ -2386,7 +2386,7 @@ mod tests {
         // static_tokens ≈ (4000 + 4 + 200 + 40) / 4 ≈ 1061
         // total ≈ 1061 + 2048 = 3109
         assert!(
-            overhead >= 2048 + 1000 && overhead <= 2048 + 1100,
+            (2048 + 1000..=2048 + 1100).contains(&overhead),
             "overhead should roughly sum system + tools + max_tokens, got {}",
             overhead
         );

--- a/src/executor/native/tools/research.rs
+++ b/src/executor/native/tools/research.rs
@@ -345,7 +345,7 @@ async fn fetch_page_content(url: &str) -> Result<String, String> {
         Err(_) => {
             // Chrome not available — fall back to rquest
             let client = rquest::Client::builder()
-                .impersonate(rquest::Impersonate::Chrome131)
+                .emulation(rquest_util::Emulation::Chrome131)
                 .timeout(std::time::Duration::from_secs(15))
                 .build()
                 .map_err(|e| format!("client: {}", e))?;

--- a/src/executor/native/tools/web_fetch.rs
+++ b/src/executor/native/tools/web_fetch.rs
@@ -402,7 +402,7 @@ enum FetchedBody {
 
 async fn fetch_via_rquest(url: &str, timeout_secs: u64) -> Result<FetchedBody, String> {
     let client = rquest::Client::builder()
-        .impersonate(rquest::Impersonate::Chrome131)
+        .emulation(rquest_util::Emulation::Chrome131)
         .timeout(Duration::from_secs(timeout_secs))
         .build()
         .map_err(|e| format!("client build: {}", e))?;

--- a/src/executor/native/tools/web_search.rs
+++ b/src/executor/native/tools/web_search.rs
@@ -914,7 +914,7 @@ fn build_client() -> Result<rquest::Client, String> {
     // TLS fingerprinting to distinguish scripts from browsers see
     // us as Chrome, not as rustls.
     rquest::Client::builder()
-        .impersonate(rquest::Impersonate::Chrome131)
+        .emulation(rquest_util::Emulation::Chrome131)
         .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", e))
@@ -1036,7 +1036,7 @@ pub(crate) fn is_google_news_redirect(url: &str) -> bool {
 /// URL in that case rather than drop the result.
 pub(crate) async fn resolve_google_news_redirect(url: &str) -> Option<String> {
     let client = rquest::Client::builder()
-        .impersonate(rquest::Impersonate::Chrome131)
+        .emulation(rquest_util::Emulation::Chrome131)
         .redirect(rquest::redirect::Policy::none())
         .timeout(std::time::Duration::from_secs(5))
         .build()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -357,7 +357,6 @@ pub struct Task {
     pub description: Option<String>,
     #[serde(default)]
     pub status: Status,
-    #[serde(default = "default_priority")]
     pub priority: Priority,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assigned: Option<String>,
@@ -1073,7 +1072,7 @@ fn infer_agent_model_spec(output_log_path: &std::path::Path) -> Option<String> {
 
     let agent_id = agent_dir.file_name().and_then(|name| name.to_str())?;
     let workgraph_dir = infer_workgraph_dir(output_log_path)?;
-    let graph = crate::parser::load_graph(&workgraph_dir.join("graph.jsonl")).ok()?;
+    let graph = crate::parser::load_graph(workgraph_dir.join("graph.jsonl")).ok()?;
     graph
         .tasks()
         .find(|task| task.assigned.as_deref() == Some(agent_id))
@@ -1254,10 +1253,11 @@ pub fn parse_token_usage_live(output_log_path: &std::path::Path) -> Option<Token
     }
 }
 
-/// Process-wide cache for `parse_token_usage_live`, keyed by output-log path
-/// + mtime. The TUI's `live_token_usage` and `agency_token_usage` maps
-/// previously walked + parsed every active agent's `output.log` (and every
-/// archived `log/agents/<task>/<run>/output.txt`) on every fs-change tick.
+/// Process-wide cache for `parse_token_usage_live`, keyed by
+/// `(output-log path, mtime)`. The TUI's `live_token_usage` and
+/// `agency_token_usage` maps previously walked and parsed every active
+/// agent's `output.log` (and every archived
+/// `log/agents/<task>/<run>/output.txt`) on every fs-change tick.
 /// `output.log` is appended to many times per second by streaming agents,
 /// but the parse result only changes when the file mtime advances — so
 /// memoizing on (path, mtime) is exact, not approximate.
@@ -1280,11 +1280,7 @@ pub fn parse_token_usage_live_cached(output_log_path: &std::path::Path) -> Optio
     let mtime = std::fs::metadata(output_log_path)
         .and_then(|m| m.modified())
         .ok();
-    if mtime.is_none() {
-        // File doesn't exist — caller treats this as "no usage", and we
-        // intentionally don't cache absent files (they may appear later).
-        return None;
-    }
+    mtime?;
     let key: TokenUsageCacheKey = (output_log_path.to_path_buf(), mtime);
 
     if let Ok(cache) = token_usage_cache().lock()
@@ -1402,10 +1398,6 @@ pub fn format_tokens(tokens: u64) -> String {
 
 fn default_visibility() -> String {
     "internal".to_string()
-}
-
-fn default_priority() -> Priority {
-    PRIORITY_DEFAULT
 }
 
 /// Deserialize loops_to accepting both old string format and array format.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3612,7 +3612,7 @@ cache_read_discount = 0.5
         task.assigned = Some("agent-live-codex".to_string());
         task.model = Some("codex:gpt-5.5".to_string());
         graph.add_node(Node::Task(task));
-        crate::parser::save_graph(&graph, &wg_dir.join("graph.jsonl")).unwrap();
+        crate::parser::save_graph(&graph, wg_dir.join("graph.jsonl")).unwrap();
 
         let log_path = agent_dir.join("output.log");
         std::fs::write(

--- a/src/html.rs
+++ b/src/html.rs
@@ -749,9 +749,6 @@ struct VizJson {
     /// Rendered ASCII (may contain ANSI escapes).
     #[serde(default)]
     text: String,
-    /// task_id → line index.
-    #[serde(default)]
-    node_lines: BTreeMap<String, usize>,
     /// per-character edge cells.
     #[serde(default)]
     char_edges: Vec<CharEdge>,
@@ -841,10 +838,10 @@ fn strip_ansi(s: &str) -> String {
             // Push the next valid UTF-8 character (avoid splitting multibyte chars).
             let ch_start = i;
             let first = bytes[i];
-            let len = if first < 0x80 {
+            // ASCII (<0x80) or stray continuation byte (<0xc0, shouldn't
+            // happen for valid UTF-8) — treat both as a 1-byte step.
+            let len = if first < 0xc0 {
                 1
-            } else if first < 0xc0 {
-                1 // shouldn't happen for valid UTF-8 — treat as 1
             } else if first < 0xe0 {
                 2
             } else if first < 0xf0 {
@@ -988,7 +985,7 @@ fn render_viz_html(
                     {
                         char_start -= 2;
                     }
-                    let decorator_start = if char_end > id_end { id_end } else { id_end };
+                    let decorator_start = id_end;
                     task_ranges.push((char_start, decorator_start, char_end, id, st, paused));
                     if let Some(time) = find_time_suffix_after(&line_chars, char_end) {
                         time_ranges.push(time);
@@ -1442,7 +1439,7 @@ fn render_messages_section(bundle: Option<&TaskMessages>) -> String {
             ""
         };
         s.push_str(&format!(
-            "<li class=\"msg-row {role} {status_row}{prio}\">\
+            "<li class=\"msg-row {role} msg-row-{status}{prio}\">\
              <div class=\"msg-head\">\
              <span class=\"msg-id\">#{id}</span>\
              <span class=\"msg-sender\">{sender}</span>\
@@ -1452,7 +1449,7 @@ fn render_messages_section(bundle: Option<&TaskMessages>) -> String {
              <pre class=\"msg-body\">{body}</pre>\
              </li>\n",
             role = role_cls,
-            status_row = format!("msg-row-{}", msg.status),
+            status = msg.status,
             prio = priority_cls,
             id = msg.id,
             sender = escape_html(&msg.sender),
@@ -2241,8 +2238,8 @@ fn render_task_page(
                     .map(|t| t.status)
                     .unwrap_or(Status::Open);
                 deps_html.push_str(&format!(
-                    "<li><a href=\"{href}\"><span class=\"badge {cls}\">{st}</span> <code>{id}</code></a></li>",
-                    href = format!("./{}.html", url_encode_id(dep)),
+                    "<li><a href=\"./{href_id}.html\"><span class=\"badge {cls}\">{st}</span> <code>{id}</code></a></li>",
+                    href_id = url_encode_id(dep),
                     cls = status_class(dep_status),
                     st = dep_status,
                     id = escape_html(dep),
@@ -2280,8 +2277,8 @@ fn render_task_page(
             if included_ids.contains(d) {
                 let dep_status = graph.get_task(d).map(|t| t.status).unwrap_or(Status::Open);
                 dependents_html.push_str(&format!(
-                    "<li><a href=\"{href}\"><span class=\"badge {cls}\">{st}</span> <code>{id}</code></a></li>",
-                    href = format!("./{}.html", url_encode_id(d)),
+                    "<li><a href=\"./{href_id}.html\"><span class=\"badge {cls}\">{st}</span> <code>{id}</code></a></li>",
+                    href_id = url_encode_id(d),
                     cls = status_class(dep_status),
                     st = dep_status,
                     id = escape_html(d),

--- a/src/html.rs
+++ b/src/html.rs
@@ -2656,6 +2656,19 @@ fn render_chat_hidden_notice(visibility: &str) -> String {
     )
 }
 
+#[cfg(test)]
+impl std::fmt::Debug for ChatRender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChatRender::None => write!(f, "ChatRender::None"),
+            ChatRender::Render(r) => write!(f, "ChatRender::Render({r:?})"),
+            ChatRender::HiddenByVisibility(v) => {
+                write!(f, "ChatRender::HiddenByVisibility({v:?})")
+            }
+        }
+    }
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Tests
 // ────────────────────────────────────────────────────────────────────────────
@@ -3346,18 +3359,5 @@ mod tests {
             inline.contains("has-unread-msg"),
             "expected unread class for fresh user message: {inline}"
         );
-    }
-}
-
-#[cfg(test)]
-impl std::fmt::Debug for ChatRender {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ChatRender::None => write!(f, "ChatRender::None"),
-            ChatRender::Render(r) => write!(f, "ChatRender::Render({r:?})"),
-            ChatRender::HiddenByVisibility(v) => {
-                write!(f, "ChatRender::HiddenByVisibility({v:?})")
-            }
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,13 +282,11 @@ mod tests {
             assert_eq!(current_user(), "unknown");
 
             // Restore
-            match orig_wg {
-                Some(v) => std::env::set_var("WG_USER", v),
-                None => {}
+            if let Some(v) = orig_wg {
+                std::env::set_var("WG_USER", v)
             }
-            match orig_user {
-                Some(v) => std::env::set_var("USER", v),
-                None => {}
+            if let Some(v) = orig_user {
+                std::env::set_var("USER", v)
             }
         }
     }

--- a/src/profile/named.rs
+++ b/src/profile/named.rs
@@ -486,11 +486,11 @@ fn edit_distance(a: &str, b: &str) -> usize {
     let m = a.len();
     let n = b.len();
     let mut dp = vec![vec![0usize; n + 1]; m + 1];
-    for i in 0..=m {
-        dp[i][0] = i;
+    for (i, row) in dp.iter_mut().enumerate() {
+        row[0] = i;
     }
-    for j in 0..=n {
-        dp[0][j] = j;
+    for (j, cell) in dp[0].iter_mut().enumerate() {
+        *cell = j;
     }
     for i in 1..=m {
         for j in 1..=n {

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -28,20 +28,16 @@ const KEYRING_SERVICE: &str = "wg";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[derive(Default)]
 pub enum Backend {
     /// OS native credential store (macOS Keychain, secret-service, etc.) with
     /// automatic fallback to the file keystore when unreachable.
+    #[default]
     Keyring,
     /// Explicit file keystore at `~/.wg/keystore/<name>` (0600 / 0700 perms).
     Keystore,
     /// Plaintext file at `~/.wg/secrets/<name>` (requires allow_plaintext=true).
     Plaintext,
-}
-
-impl Default for Backend {
-    fn default() -> Self {
-        Self::Keyring
-    }
 }
 
 impl std::fmt::Display for Backend {

--- a/src/service/chat_compactor.rs
+++ b/src/service/chat_compactor.rs
@@ -466,7 +466,7 @@ mod tests {
         assert!(recurring >= 75);
         // Total may exceed 400 slightly due to section floor clamping
         let total = decisions + threads + prefs + recurring;
-        assert!(total >= 400 && total <= 500);
+        assert!((400..=500).contains(&total));
     }
 
     #[test]

--- a/src/service/graph_watcher.rs
+++ b/src/service/graph_watcher.rs
@@ -87,7 +87,7 @@ impl GraphWatcher {
                         }
                         // Path may be reported relative to the parent or with a
                         // different canonical form on some FS. Match by filename.
-                        if let (Some(ev_name), Some(ref t_name)) =
+                        if let (Some(ev_name), Some(t_name)) =
                             (e.path.file_name(), target_filename.as_ref())
                             && ev_name == t_name.as_os_str()
                         {

--- a/src/tui/pty_pane.rs
+++ b/src/tui/pty_pane.rs
@@ -1752,7 +1752,7 @@ mod tests {
 
     #[test]
     fn spawn_echo_and_read_output() {
-        let mut pane =
+        let pane =
             PtyPane::spawn("/bin/echo", &["hello from pty"], &[], 5, 40).expect("spawn echo");
         for _ in 0..40 {
             std::thread::sleep(std::time::Duration::from_millis(50));

--- a/src/tui/viz_viewer/async_fs.rs
+++ b/src/tui/viz_viewer/async_fs.rs
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn slow_op_indicator_set_when_threshold_exceeded() {
-        let mut afs = AsyncFs::new();
+        let afs = AsyncFs::new();
         // Synthetic slow op via the internal hook.
         afs.note_op("synthetic", Duration::from_millis(800));
         let ind = afs.slow_disk_indicator();

--- a/src/tui/viz_viewer/event.rs
+++ b/src/tui/viz_viewer/event.rs
@@ -1432,7 +1432,6 @@ pub(super) fn handle_launcher_mouse_click(app: &mut VizApp, row: u16, column: u1
     }
     if endpoint_hit.height > 0 && endpoint_hit.contains(pos) {
         launcher.active_section = LauncherSection::AddNew(AddNewField::Endpoint);
-        return;
     }
     // Click in launcher area but no row matched: just no-op.
 }

--- a/src/tui/viz_viewer/render.rs
+++ b/src/tui/viz_viewer/render.rs
@@ -4295,6 +4295,7 @@ fn draw_chat_booting_placeholder(frame: &mut Frame, area: Rect, app: &VizApp, ci
 
 /// Render the "chat agent died" error panel inside `area`.
 /// Shown instead of the normal chat content when the PTY process has exited.
+#[allow(clippy::vec_init_then_push)]
 fn draw_chat_agent_death_panel(
     frame: &mut Frame,
     area: Rect,
@@ -6988,7 +6989,7 @@ pub(crate) fn draw_launcher_pane(frame: &mut Frame, app: &mut VizApp, area: Rect
                 };
                 let label_w = preset.label.len();
                 let pad_w = if label_w < 16 { 16 - label_w } else { 1 };
-                let pad: String = std::iter::repeat(' ').take(pad_w).collect();
+                let pad: String = std::iter::repeat_n(' ', pad_w).collect();
                 let row_idx = lines.len();
                 lines.push(Line::from(vec![
                     Span::styled(format!("  {}{}{}", bullet, preset.label, pad), style),

--- a/src/tui/viz_viewer/state.rs
+++ b/src/tui/viz_viewer/state.rs
@@ -3563,7 +3563,7 @@ pub fn parse_raw_stream_line(line: &str, default_agent_id: &str) -> Option<Agent
                                     .get("file_path")
                                     .and_then(|v| v.as_str())
                                     .unwrap_or("?");
-                                Some(format!("{}", path))
+                                Some(path.to_string())
                             }
                             "Grep" | "Glob" => input
                                 .get("pattern")
@@ -9657,10 +9657,7 @@ impl VizApp {
         if self.iteration_archives.is_empty() {
             return false;
         }
-        match self.viewing_iteration {
-            None => false, // already on live
-            Some(_) => true,
-        }
+        self.viewing_iteration.is_some()
     }
 
     /// Build the informative center label shown in the Detail tab iteration
@@ -16395,6 +16392,7 @@ impl VizApp {
     /// entry carries its origin (`built-in default` / `global` / `local`)
     /// so the Settings tab can show source per key without requiring the
     /// user to drop to `wg config --list`.
+    #[allow(clippy::vec_init_then_push)]
     pub fn load_settings_panel(&mut self) {
         let (config, sources) =
             match workgraph::config::Config::load_with_sources(&self.workgraph_dir) {
@@ -26161,8 +26159,8 @@ mod agent_stream_tests {
 
     #[test]
     fn test_log_view_renders_agent_stream_events_for_inprogress_task() {
+        use crate::commands::viz::LayoutMode;
         use crate::commands::viz::ascii::generate_ascii;
-        use crate::commands::viz::{LayoutMode, VizOutput};
         use std::collections::{HashMap, HashSet};
         use workgraph::graph::{Node, Status, WorkGraph};
         use workgraph::parser::save_graph;
@@ -26354,7 +26352,7 @@ mod chat_pty_executor_resolution_tests {
     use crate::commands::service::CoordinatorState;
 
     fn write_state(dir: &std::path::Path, cid: u32, executor: Option<&str>, model: Option<&str>) {
-        let mut state = CoordinatorState {
+        let state = CoordinatorState {
             executor_override: executor.map(String::from),
             model_override: model.map(String::from),
             ..CoordinatorState::default()

--- a/tests/codex_handler_oai_compat.rs
+++ b/tests/codex_handler_oai_compat.rs
@@ -72,48 +72,46 @@ fn start_capturing_stub_server() -> (String, Arc<Mutex<Vec<String>>>) {
     let captured_clone = captured.clone();
 
     std::thread::spawn(move || {
-        for stream in listener.incoming() {
-            if let Ok(mut s) = stream {
-                let captured_inner = captured_clone.clone();
-                std::thread::spawn(move || {
-                    let _ = s.set_read_timeout(Some(Duration::from_secs(2)));
-                    let mut buf = vec![0u8; 16384];
-                    let n = s.read(&mut buf).unwrap_or(0);
-                    if n > 0 {
-                        let req = String::from_utf8_lossy(&buf[..n]).to_string();
-                        captured_inner.lock().unwrap().push(req);
+        for mut s in listener.incoming().flatten() {
+            let captured_inner = captured_clone.clone();
+            std::thread::spawn(move || {
+                let _ = s.set_read_timeout(Some(Duration::from_secs(2)));
+                let mut buf = vec![0u8; 16384];
+                let n = s.read(&mut buf).unwrap_or(0);
+                if n > 0 {
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    captured_inner.lock().unwrap().push(req);
+                }
+                // Send a minimal OAI-compat Chat Completions reply.
+                let body = serde_json::json!({
+                    "id": "chatcmpl-stub",
+                    "object": "chat.completion",
+                    "created": 1714155600u64,
+                    "model": "qwen3-coder",
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "stub-reply"
+                        },
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2
                     }
-                    // Send a minimal OAI-compat Chat Completions reply.
-                    let body = serde_json::json!({
-                        "id": "chatcmpl-stub",
-                        "object": "chat.completion",
-                        "created": 1714155600u64,
-                        "model": "qwen3-coder",
-                        "choices": [{
-                            "index": 0,
-                            "message": {
-                                "role": "assistant",
-                                "content": "stub-reply"
-                            },
-                            "finish_reason": "stop"
-                        }],
-                        "usage": {
-                            "prompt_tokens": 1,
-                            "completion_tokens": 1,
-                            "total_tokens": 2
-                        }
-                    })
-                    .to_string();
-                    let resp = format!(
-                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
-                         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
-                        body.len(),
-                        body
-                    );
-                    let _ = s.write_all(resp.as_bytes());
-                    let _ = s.flush();
-                });
-            }
+                })
+                .to_string();
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                     Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = s.write_all(resp.as_bytes());
+                let _ = s.flush();
+            });
         }
     });
 

--- a/tests/integration_accidental_cycle.rs
+++ b/tests/integration_accidental_cycle.rs
@@ -189,7 +189,7 @@ fn test_accidental_cycle_auto_recovery() {
     assert_eq!(cycle.members.len(), 3, "Cycle should have 3 members");
 
     // Verify all tasks are in the cycle
-    let cycle_members: HashSet<String> = cycle.members.iter().map(|m| m.clone()).collect();
+    let cycle_members: HashSet<String> = cycle.members.iter().cloned().collect();
     assert!(cycle_members.contains("a"));
     assert!(cycle_members.contains("b"));
     assert!(cycle_members.contains("c"));

--- a/tests/integration_agency_import.rs
+++ b/tests/integration_agency_import.rs
@@ -333,30 +333,30 @@ fn test_imported_yaml_has_correct_fields() {
 
         // Required fields: name, description, category, lineage
         assert!(
-            map.contains_key(&serde_yaml::Value::String("name".to_string())),
+            map.contains_key(serde_yaml::Value::String("name".to_string())),
             "Component YAML should have 'name' field. File: {:?}\nContent:\n{}",
             entry.path(),
             content
         );
         assert!(
-            map.contains_key(&serde_yaml::Value::String("description".to_string())),
+            map.contains_key(serde_yaml::Value::String("description".to_string())),
             "Component YAML should have 'description' field. File: {:?}",
             entry.path()
         );
         assert!(
-            map.contains_key(&serde_yaml::Value::String("category".to_string())),
+            map.contains_key(serde_yaml::Value::String("category".to_string())),
             "Component YAML should have 'category' field. File: {:?}",
             entry.path()
         );
         assert!(
-            map.contains_key(&serde_yaml::Value::String("lineage".to_string())),
+            map.contains_key(serde_yaml::Value::String("lineage".to_string())),
             "Component YAML should have 'lineage' field. File: {:?}",
             entry.path()
         );
 
         // Verify category is "translated" (all fixture skills are)
         let category = map
-            .get(&serde_yaml::Value::String("category".to_string()))
+            .get(serde_yaml::Value::String("category".to_string()))
             .unwrap();
         assert_eq!(
             category.as_str().unwrap(),
@@ -380,25 +380,25 @@ fn test_imported_yaml_has_correct_fields() {
         let map = yaml.as_mapping().expect("YAML should be a mapping");
 
         assert!(
-            map.contains_key(&serde_yaml::Value::String("name".to_string())),
+            map.contains_key(serde_yaml::Value::String("name".to_string())),
             "Outcome YAML should have 'name' field"
         );
         assert!(
-            map.contains_key(&serde_yaml::Value::String("description".to_string())),
+            map.contains_key(serde_yaml::Value::String("description".to_string())),
             "Outcome YAML should have 'description' field"
         );
         assert!(
-            map.contains_key(&serde_yaml::Value::String("lineage".to_string())),
+            map.contains_key(serde_yaml::Value::String("lineage".to_string())),
             "Outcome YAML should have 'lineage' field"
         );
 
         // Verify lineage has created_by field
         let lineage = map
-            .get(&serde_yaml::Value::String("lineage".to_string()))
+            .get(serde_yaml::Value::String("lineage".to_string()))
             .unwrap();
         let lineage_map = lineage.as_mapping().expect("lineage should be a mapping");
         assert!(
-            lineage_map.contains_key(&serde_yaml::Value::String("created_by".to_string())),
+            lineage_map.contains_key(serde_yaml::Value::String("created_by".to_string())),
             "Lineage should have 'created_by' field"
         );
     }
@@ -418,15 +418,15 @@ fn test_imported_yaml_has_correct_fields() {
         let map = yaml.as_mapping().expect("YAML should be a mapping");
 
         assert!(
-            map.contains_key(&serde_yaml::Value::String("name".to_string())),
+            map.contains_key(serde_yaml::Value::String("name".to_string())),
             "Tradeoff YAML should have 'name' field"
         );
         assert!(
-            map.contains_key(&serde_yaml::Value::String("description".to_string())),
+            map.contains_key(serde_yaml::Value::String("description".to_string())),
             "Tradeoff YAML should have 'description' field"
         );
         assert!(
-            map.contains_key(&serde_yaml::Value::String("lineage".to_string())),
+            map.contains_key(serde_yaml::Value::String("lineage".to_string())),
             "Tradeoff YAML should have 'lineage' field"
         );
     }
@@ -476,7 +476,7 @@ fn test_custom_provenance_tag() {
                 let map = yaml.as_mapping().unwrap();
 
                 let access = map
-                    .get(&serde_yaml::Value::String("access_control".to_string()))
+                    .get(serde_yaml::Value::String("access_control".to_string()))
                     .unwrap_or_else(|| {
                         panic!(
                             "Missing access_control in {:?}\nContent:\n{}",
@@ -487,7 +487,7 @@ fn test_custom_provenance_tag() {
                 let owner = access
                     .as_mapping()
                     .unwrap()
-                    .get(&serde_yaml::Value::String("owner".to_string()))
+                    .get(serde_yaml::Value::String("owner".to_string()))
                     .unwrap_or_else(|| {
                         panic!(
                             "Missing access_control.owner in {:?}\nContent:\n{}",
@@ -506,12 +506,12 @@ fn test_custom_provenance_tag() {
                 // Custom provenance remains on access_control.owner; lineage.created_by
                 // is constrained to the agency v1.2.4 enum domain.
                 let lineage = map
-                    .get(&serde_yaml::Value::String("lineage".to_string()))
+                    .get(serde_yaml::Value::String("lineage".to_string()))
                     .unwrap();
                 let created_by = lineage
                     .as_mapping()
                     .unwrap()
-                    .get(&serde_yaml::Value::String("created_by".to_string()))
+                    .get(serde_yaml::Value::String("created_by".to_string()))
                     .unwrap();
                 assert_eq!(created_by.as_str().unwrap(), "import");
 

--- a/tests/integration_agency_loop.rs
+++ b/tests/integration_agency_loop.rs
@@ -534,21 +534,21 @@ fn test_no_infinite_regress_for_system_tasks() {
     // are excluded from auto-evaluate
     let dominated_tags = ["evaluation", "assignment", "evolution"];
 
-    let eval_tags = vec!["evaluation".to_string(), "agency".to_string()];
+    let eval_tags = ["evaluation".to_string(), "agency".to_string()];
     assert!(
         eval_tags
             .iter()
             .any(|t| dominated_tags.contains(&t.as_str()))
     );
 
-    let evolve_tags = vec!["evolution".to_string(), "agency".to_string()];
+    let evolve_tags = ["evolution".to_string(), "agency".to_string()];
     assert!(
         evolve_tags
             .iter()
             .any(|t| dominated_tags.contains(&t.as_str()))
     );
 
-    let assign_tags = vec!["assignment".to_string(), "agency".to_string()];
+    let assign_tags = ["assignment".to_string(), "agency".to_string()];
     assert!(
         assign_tags
             .iter()

--- a/tests/integration_bare_alias_contract.rs
+++ b/tests/integration_bare_alias_contract.rs
@@ -17,7 +17,7 @@ fn collect_rs_files(dir: &std::path::Path) -> Vec<PathBuf> {
             let path = entry.path();
             if path.is_dir() {
                 files.extend(collect_rs_files(&path));
-            } else if path.extension().map_or(false, |e| e == "rs") {
+            } else if path.extension().is_some_and(|e| e == "rs") {
                 files.push(path);
             }
         }

--- a/tests/integration_canonical_config.rs
+++ b/tests/integration_canonical_config.rs
@@ -57,7 +57,7 @@ fn fresh_workgraph(tmp: &TempDir) -> PathBuf {
     let wg_dir = tmp.path().join(".wg");
     fs::create_dir_all(&wg_dir).unwrap();
     let graph = WorkGraph::new();
-    save_graph(&graph, &wg_dir.join("graph.jsonl")).unwrap();
+    save_graph(&graph, wg_dir.join("graph.jsonl")).unwrap();
     wg_dir
 }
 

--- a/tests/integration_chat.rs
+++ b/tests/integration_chat.rs
@@ -124,13 +124,12 @@ impl Drop for DaemonGuard<'_> {
         // Belt-and-suspenders: read PID from state.json and kill directly
         // in case `wg service stop` itself fails or the daemon is unresponsive.
         let state_path = self.wg_dir.join("service").join("state.json");
-        if let Ok(content) = std::fs::read_to_string(&state_path) {
-            if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(pid) = state["pid"].as_u64() {
-                    unsafe {
-                        libc::kill(pid as i32, libc::SIGKILL);
-                    }
-                }
+        if let Ok(content) = std::fs::read_to_string(&state_path)
+            && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Some(pid) = state["pid"].as_u64()
+        {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
             }
         }
     }

--- a/tests/integration_coordinator_agent.rs
+++ b/tests/integration_coordinator_agent.rs
@@ -372,13 +372,12 @@ impl Drop for CoordinatorDaemonGuard<'_> {
 
         // Belt-and-suspenders: kill daemon by PID directly
         let state_path = self.wg_dir.join("service").join("state.json");
-        if let Ok(content) = std::fs::read_to_string(&state_path) {
-            if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(pid) = state["pid"].as_u64() {
-                    unsafe {
-                        libc::kill(pid as i32, libc::SIGKILL);
-                    }
-                }
+        if let Ok(content) = std::fs::read_to_string(&state_path)
+            && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Some(pid) = state["pid"].as_u64()
+        {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
             }
         }
     }
@@ -509,7 +508,7 @@ fn coordinator_agent_cursor_tracking() {
     guard.chat_ok("cursor test one", 15);
     let responses1 = workgraph::chat::read_outbox_since_for(&wg_dir, 0, 0).unwrap();
     assert!(
-        responses1.len() >= 1,
+        !responses1.is_empty(),
         "Coordinator should write at least one response after first message, got {}",
         responses1.len()
     );
@@ -768,13 +767,12 @@ impl Drop for RealDaemonGuard<'_> {
     fn drop(&mut self) {
         stop_daemon(self.wg_dir);
         let state_path = self.wg_dir.join("service").join("state.json");
-        if let Ok(content) = std::fs::read_to_string(&state_path) {
-            if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(pid) = state["pid"].as_u64() {
-                    unsafe {
-                        libc::kill(pid as i32, libc::SIGKILL);
-                    }
-                }
+        if let Ok(content) = std::fs::read_to_string(&state_path)
+            && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Some(pid) = state["pid"].as_u64()
+        {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
             }
         }
     }

--- a/tests/integration_coordinator_spawn_template.rs
+++ b/tests/integration_coordinator_spawn_template.rs
@@ -90,13 +90,12 @@ fn stop_daemon(wg_dir: &Path, env_vars: &[(&str, &str)]) {
     );
     // Kill by PID as belt-and-suspenders
     let state_path = wg_dir.join("service").join("state.json");
-    if let Ok(content) = fs::read_to_string(&state_path) {
-        if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(pid) = state["pid"].as_u64() {
-                unsafe {
-                    libc::kill(pid as i32, libc::SIGKILL);
-                }
-            }
+    if let Ok(content) = fs::read_to_string(&state_path)
+        && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
+        && let Some(pid) = state["pid"].as_u64()
+    {
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
         }
     }
 }
@@ -261,10 +260,10 @@ fn read_captured_args(args_file: &Path) -> Vec<String> {
     let start = Instant::now();
     // The args file may take a moment to appear (process spawning is async)
     loop {
-        if let Ok(content) = fs::read_to_string(args_file) {
-            if !content.is_empty() {
-                return content.lines().map(String::from).collect();
-            }
+        if let Ok(content) = fs::read_to_string(args_file)
+            && !content.is_empty()
+        {
+            return content.lines().map(String::from).collect();
         }
         if start.elapsed() > Duration::from_secs(10) {
             panic!(

--- a/tests/integration_cycle_detection.rs
+++ b/tests/integration_cycle_detection.rs
@@ -6422,7 +6422,7 @@ fn test_shell_checker_cycle_logs_preserved() {
     // Logs should be preserved (append-only, not cleared)
     let shell = graph.get_task("run-batch").unwrap();
     assert!(
-        shell.log.len() >= 1,
+        !shell.log.is_empty(),
         "Shell task logs should be preserved across reset"
     );
     assert!(
@@ -6432,7 +6432,7 @@ fn test_shell_checker_cycle_logs_preserved() {
 
     let check = graph.get_task("check-batch").unwrap();
     assert!(
-        check.log.len() >= 1,
+        !check.log.is_empty(),
         "Checker logs should be preserved across reset"
     );
     assert!(
@@ -6498,7 +6498,7 @@ fn test_cli_add_with_exec_flag() {
         output
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph
         .get_task("run-batch-script")
         .expect("Task should exist");
@@ -6534,7 +6534,7 @@ fn test_cli_add_with_exec_and_timeout() {
         ],
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("long-render").expect("Task should exist");
     assert_eq!(task.exec.as_deref(), Some("render.sh"));
     assert_eq!(task.timeout.as_deref(), Some("6h"));

--- a/tests/integration_done_uncommitted.rs
+++ b/tests/integration_done_uncommitted.rs
@@ -178,7 +178,7 @@ fn wg_done_refuses_staged_uncommitted_in_worktree() {
     );
 
     // 4. Task is NOT marked done.
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).expect("load graph");
+    let graph = load_graph(wg_dir.join("graph.jsonl")).expect("load graph");
     let task = graph.get_task(task_id).expect("task exists");
     assert_ne!(
         task.status,
@@ -247,7 +247,7 @@ fn wg_done_does_not_block_on_untracked_files() {
     );
 
     // Task should be Done (no eval task exists, so it goes straight to Done).
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).expect("load graph");
+    let graph = load_graph(wg_dir.join("graph.jsonl")).expect("load graph");
     let task = graph.get_task(task_id).expect("task exists");
     assert_eq!(task.status, Status::Done);
 }

--- a/tests/integration_evolver_pipeline.rs
+++ b/tests/integration_evolver_pipeline.rs
@@ -283,7 +283,7 @@ fn test_evolver_e2e_full_pipeline_structure() {
     );
 
     // Load graph and verify all pipeline stages exist
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     let partition = graph
         .tasks()
@@ -429,7 +429,7 @@ fn test_evolver_e2e_partition_creates_slice_files() {
         .map(|e| e.path())
         .filter(|p| {
             p.file_name()
-                .map_or(false, |n| n.to_string_lossy().ends_with("-slice.json"))
+                .is_some_and(|n| n.to_string_lossy().ends_with("-slice.json"))
         })
         .collect();
     assert!(
@@ -471,7 +471,7 @@ fn test_evolver_e2e_autopoietic_cycle_structure() {
         ],
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     let partition = graph
         .tasks()
@@ -554,7 +554,7 @@ fn test_evolver_e2e_non_autopoietic_no_cycle() {
 
     wg_ok(&wg_dir, &["evolve", "run", "--force-fanout"]);
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     let evaluate = graph
         .tasks()
@@ -614,7 +614,7 @@ fn test_evolver_e2e_convergence_detection_stable_scores() {
         ],
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     let evaluate = graph
         .tasks()
@@ -673,7 +673,7 @@ fn test_evolver_e2e_partial_failure_graph_structure() {
 
     wg_ok(&wg_dir, &["evolve", "run", "--force-fanout"]);
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     let analyzers: Vec<&Task> = graph
         .tasks()
@@ -752,7 +752,7 @@ fn test_evolver_e2e_dry_run_no_side_effects() {
     );
 
     // Graph should be empty
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     assert_eq!(
         graph.tasks().count(),
         0,
@@ -774,7 +774,7 @@ fn test_evolver_e2e_default_cycle_parameters() {
     // Autopoietic without explicit max-iterations or cycle-delay → defaults
     wg_ok(&wg_dir, &["evolve", "run", "--autopoietic"]);
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     let evaluate = graph
         .tasks()
@@ -806,7 +806,7 @@ fn test_evolver_e2e_analyzer_model_tiers() {
 
     wg_ok(&wg_dir, &["evolve", "run", "--force-fanout"]);
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     // Check that analyzers have model assignments
     let analyzers: Vec<&Task> = graph
@@ -972,7 +972,7 @@ fn test_evolver_e2e_specific_strategy() {
         &["evolve", "run", "--force-fanout", "--strategy", "mutation"],
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     let analyzers: Vec<&Task> = graph
         .tasks()
@@ -1042,7 +1042,7 @@ fn test_evolver_fanout_codex_route_emits_codex_models() {
 
     wg_ok(&wg_dir, &["evolve", "run", "--force-fanout"]);
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     let evolve_tasks: Vec<&Task> = graph
         .tasks()
@@ -1131,7 +1131,7 @@ fn test_evolver_fanout_cli_model_override_wins() {
         &["evolve", "run", "--force-fanout", "--model", override_model],
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
 
     let evolve_tasks: Vec<&Task> = graph
         .tasks()

--- a/tests/integration_failed_pending_eval.rs
+++ b/tests/integration_failed_pending_eval.rs
@@ -124,7 +124,7 @@ fn test_rescued_field_serializes_round_trips() {
     );
 
     let parsed: Task = serde_json::from_str(&json).unwrap();
-    assert_eq!(parsed.rescued, true);
+    assert!(parsed.rescued);
     assert_eq!(parsed.meta_eval_attempts, 1);
 
     // Default (false) should NOT appear in JSON (skip_serializing_if)
@@ -147,7 +147,7 @@ fn test_rescued_false_deserializes_from_legacy_row() {
     // Legacy rows without the rescued field should deserialize to rescued=false
     let json = r#"{"id":"t1","title":"Test","status":"done"}"#;
     let task: Task = serde_json::from_str(json).unwrap();
-    assert_eq!(task.rescued, false);
+    assert!(!task.rescued);
     assert_eq!(task.meta_eval_attempts, 0);
 }
 

--- a/tests/integration_failure_classification.rs
+++ b/tests/integration_failure_classification.rs
@@ -17,7 +17,7 @@ fn setup_wg(project_dir: &std::path::Path, tasks: Vec<Task>) -> std::path::PathB
     for t in tasks {
         g.add_node(Node::Task(t));
     }
-    save_graph(&g, &wg_dir.join("graph.jsonl")).unwrap();
+    save_graph(&g, wg_dir.join("graph.jsonl")).unwrap();
     wg_dir
 }
 
@@ -133,7 +133,7 @@ fn test_wg_fail_with_class_persists() {
         "wg fail should exit 0. stdout={stdout} stderr={stderr}"
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("t1").unwrap();
     assert_eq!(task.status, Status::Failed);
     assert_eq!(

--- a/tests/integration_html.rs
+++ b/tests/integration_html.rs
@@ -1158,11 +1158,11 @@ fn read_rendered_html(out_dir: &Path) -> String {
     if let Ok(rd) = fs::read_dir(out_dir.join("tasks")) {
         for entry in rd.flatten() {
             let p = entry.path();
-            if p.extension().map(|e| e == "html").unwrap_or(false) {
-                if let Ok(s) = fs::read_to_string(&p) {
-                    buf.push_str(&s);
-                    buf.push('\n');
-                }
+            if p.extension().map(|e| e == "html").unwrap_or(false)
+                && let Ok(s) = fs::read_to_string(&p)
+            {
+                buf.push_str(&s);
+                buf.push('\n');
             }
         }
     }

--- a/tests/integration_multi_coordinator.rs
+++ b/tests/integration_multi_coordinator.rs
@@ -117,13 +117,12 @@ impl Drop for DaemonGuard<'_> {
         stop_daemon(self.wg_dir);
 
         let state_path = self.wg_dir.join("service").join("state.json");
-        if let Ok(content) = std::fs::read_to_string(&state_path) {
-            if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(pid) = state["pid"].as_u64() {
-                    unsafe {
-                        libc::kill(pid as i32, libc::SIGKILL);
-                    }
-                }
+        if let Ok(content) = std::fs::read_to_string(&state_path)
+            && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Some(pid) = state["pid"].as_u64()
+        {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
             }
         }
     }

--- a/tests/integration_native_coordinator.rs
+++ b/tests/integration_native_coordinator.rs
@@ -229,13 +229,12 @@ impl Drop for DaemonGuard<'_> {
     fn drop(&mut self) {
         stop_daemon_env(self.wg_dir, &self.env_refs());
         let state_path = self.wg_dir.join("service").join("state.json");
-        if let Ok(content) = fs::read_to_string(&state_path) {
-            if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(pid) = state["pid"].as_u64() {
-                    unsafe {
-                        libc::kill(pid as i32, libc::SIGKILL);
-                    }
-                }
+        if let Ok(content) = fs::read_to_string(&state_path)
+            && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Some(pid) = state["pid"].as_u64()
+        {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
             }
         }
     }
@@ -1550,8 +1549,7 @@ fn native_coordinator_task_dispatch_with_shell_executor() {
         std::env::var("PATH").unwrap_or_default()
     );
 
-    let config = format!(
-        r#"[coordinator]
+    let config = r#"[coordinator]
 coordinator_agent = true
 executor = "native"
 model = "openrouter:deepseek/deepseek-chat"
@@ -1564,7 +1562,7 @@ provider = "openai"
 auto_assign = false
 auto_evaluate = false
 "#
-    );
+    .to_string();
     fs::write(wg_dir.join("config.toml"), &config).unwrap();
 
     // Set up a shell executor for task agents
@@ -1622,15 +1620,14 @@ PATH = "{}"
         if let Ok(content) = fs::read_to_string(&state_path)
             && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
             && let Some(socket_path) = state["socket_path"].as_str()
+            && let Ok(mut stream) = std::os::unix::net::UnixStream::connect(socket_path)
         {
-            if let Ok(mut stream) = std::os::unix::net::UnixStream::connect(socket_path) {
-                let _ = writeln!(stream, r#"{{"cmd":"status"}}"#);
-                let _ = stream.flush();
-                let mut reader = BufReader::new(&stream);
-                let mut response = String::new();
-                if reader.read_line(&mut response).is_ok() && !response.is_empty() {
-                    return true;
-                }
+            let _ = writeln!(stream, r#"{{"cmd":"status"}}"#);
+            let _ = stream.flush();
+            let mut reader = BufReader::new(&stream);
+            let mut response = String::new();
+            if reader.read_line(&mut response).is_ok() && !response.is_empty() {
+                return true;
             }
         }
         false

--- a/tests/integration_native_executor_async_web.rs
+++ b/tests/integration_native_executor_async_web.rs
@@ -551,7 +551,7 @@ fn subtask_creates_child_and_waits() {
     );
 
     // Reload graph and check
-    let graph = load_graph(&graph_path(&wg_dir)).unwrap();
+    let graph = load_graph(graph_path(&wg_dir)).unwrap();
 
     // Child task should exist
     let child = graph.nodes().find(|n| match n {
@@ -618,7 +618,7 @@ fn subtask_child_completion_resumes_parent() {
     // 1. Child is Done
     // 2. Parent still has wait_condition that references the child
     // 3. The wait_condition can be satisfied (child status == Done matches)
-    let graph = load_graph(&graph_path(&wg_dir)).unwrap();
+    let graph = load_graph(graph_path(&wg_dir)).unwrap();
 
     let child = graph.get_task("resume-child").unwrap();
     assert_eq!(child.status, Status::Done, "Child should be Done");

--- a/tests/integration_openrouter.rs
+++ b/tests/integration_openrouter.rs
@@ -258,7 +258,7 @@ fn test_openrouter_minimax_tool_loop() {
         .collect();
 
     assert!(
-        assistant_entries.len() >= 1,
+        !assistant_entries.is_empty(),
         "Should have at least 1 assistant turn, got {}",
         assistant_entries.len()
     );
@@ -323,7 +323,7 @@ fn test_openrouter_minimax_tool_loop() {
         .collect();
 
     assert!(
-        tool_result_blocks.len() >= 1,
+        !tool_result_blocks.is_empty(),
         "Should have at least 1 tool_result block in user messages, got {}",
         tool_result_blocks.len()
     );
@@ -486,11 +486,11 @@ fn test_openrouter_bash_tool_execution() {
         let output = wg_cmd(&wg_dir, &["show", "bash-tool-test", "--json"]);
         if output.status.success() {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&stdout) {
-                if val.get("status").and_then(|s| s.as_str()) == Some("done") {
-                    completed = true;
-                    break;
-                }
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&stdout)
+                && val.get("status").and_then(|s| s.as_str()) == Some("done")
+            {
+                completed = true;
+                break;
             }
         }
         std::thread::sleep(Duration::from_secs(5));
@@ -574,11 +574,11 @@ fn test_openrouter_journal_completeness() {
         let output = wg_cmd(&wg_dir, &["show", "journal-test", "--json"]);
         if output.status.success() {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&stdout) {
-                if val.get("status").and_then(|s| s.as_str()) == Some("done") {
-                    completed = true;
-                    break;
-                }
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&stdout)
+                && val.get("status").and_then(|s| s.as_str()) == Some("done")
+            {
+                completed = true;
+                break;
             }
         }
         std::thread::sleep(Duration::from_secs(5));

--- a/tests/integration_pending_eval_state.rs
+++ b/tests/integration_pending_eval_state.rs
@@ -197,7 +197,7 @@ fn test_dep_unblocks_after_eval_pass() {
 
     // Promote PendingEval → Done in the graph (simulating the dispatcher
     // phase 2.46 resolution path).
-    workgraph::parser::modify_graph(&wg_dir.join("graph.jsonl"), |g| {
+    workgraph::parser::modify_graph(wg_dir.join("graph.jsonl"), |g| {
         // Reuse the same logic the dispatcher runs by calling its public test
         // hook via direct status flip — the function is private so we model
         // the post-resolution graph state directly.

--- a/tests/integration_phantom_edge.rs
+++ b/tests/integration_phantom_edge.rs
@@ -424,7 +424,7 @@ fn why_blocked_labels_phantom_deps() {
 
     let wg_dir = tmp.path().join(".wg");
     fs::create_dir_all(&wg_dir).unwrap();
-    save_graph(&graph, &wg_dir.join("graph.jsonl")).unwrap();
+    save_graph(&graph, wg_dir.join("graph.jsonl")).unwrap();
 
     let output = wg_cmd(&wg_dir, &["why-blocked", "my-task"]);
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -445,7 +445,7 @@ fn why_blocked_json_includes_phantom_field() {
 
     let wg_dir = tmp.path().join(".wg");
     fs::create_dir_all(&wg_dir).unwrap();
-    save_graph(&graph, &wg_dir.join("graph.jsonl")).unwrap();
+    save_graph(&graph, wg_dir.join("graph.jsonl")).unwrap();
 
     let output = wg_cmd(&wg_dir, &["--json", "why-blocked", "my-task"]);
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -470,7 +470,7 @@ fn check_reports_phantom_edges() {
 
     let wg_dir = tmp.path().join(".wg");
     fs::create_dir_all(&wg_dir).unwrap();
-    save_graph(&graph, &wg_dir.join("graph.jsonl")).unwrap();
+    save_graph(&graph, wg_dir.join("graph.jsonl")).unwrap();
 
     let (stdout, stderr) = wg_fail(&wg_dir, &["check"]);
     let combined = format!("{}{}", stdout, stderr);

--- a/tests/integration_placement.rs
+++ b/tests/integration_placement.rs
@@ -51,7 +51,7 @@ fn setup_graph(tasks: &[(&str, &str)]) -> TempDir {
     for &(id, title) in tasks {
         graph.add_node(Node::Task(make_task(id, title)));
     }
-    save_graph(&graph, &wg_dir.join("graph.jsonl")).unwrap();
+    save_graph(&graph, wg_dir.join("graph.jsonl")).unwrap();
     tmp
 }
 
@@ -141,7 +141,7 @@ fn test_placement_edit_applied_to_graph() {
     );
 
     // Verify graph was updated
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("my-task").unwrap();
     assert!(
         task.after.contains(&"dep-a".to_string()),
@@ -173,7 +173,7 @@ fn test_placement_noop_no_changes() {
     let wg_dir = tmp.path().join(".wg");
 
     // Capture graph state before
-    let graph_before = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph_before = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let after_before = graph_before.get_task("my-task").unwrap().after.clone();
 
     let output_dir = tmp.path().join("agent-output");
@@ -196,7 +196,7 @@ fn test_placement_noop_no_changes() {
     );
 
     // Verify graph was NOT changed
-    let graph_after = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph_after = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let after_after = graph_after.get_task("my-task").unwrap().after.clone();
     assert_eq!(
         after_before, after_after,
@@ -296,7 +296,7 @@ fn test_placement_multiline_last_line_command() {
         stderr
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("my-task").unwrap();
     assert!(
         task.after.contains(&"prereq".to_string()),
@@ -347,7 +347,7 @@ fn test_placement_comma_separated_deps() {
         stderr
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("my-task").unwrap();
     assert_eq!(
         task.after,
@@ -383,7 +383,7 @@ fn test_placement_backtick_wrapped_command() {
         stderr
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("my-task").unwrap();
     assert!(
         task.after.contains(&"foundation".to_string()),
@@ -436,7 +436,7 @@ fn test_placement_trailing_whitespace() {
         stderr
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("my-task").unwrap();
     assert!(task.after.contains(&"dep".to_string()));
 }
@@ -461,7 +461,7 @@ fn test_placement_blocked_by_alias() {
         stderr
     );
 
-    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("my-task").unwrap();
     assert!(
         task.after.contains(&"blocker".to_string()),

--- a/tests/integration_retire_compact_archive.rs
+++ b/tests/integration_retire_compact_archive.rs
@@ -19,7 +19,7 @@ fn workgraph_dir(tmp: &TempDir) -> std::path::PathBuf {
 }
 
 fn write_graph(dir: &Path, graph: &WorkGraph) {
-    save_graph(graph, &dir.join("graph.jsonl")).unwrap();
+    save_graph(graph, dir.join("graph.jsonl")).unwrap();
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn test_create_chat_does_not_create_compact_companion() {
     write_graph(&dir, &graph);
 
     // Simulate what the IPC handler now does: create just the chat task.
-    let mut graph = load_graph(&dir.join("graph.jsonl")).unwrap();
+    let mut graph = load_graph(dir.join("graph.jsonl")).unwrap();
     graph.add_node(Node::Task(Task {
         id: format_chat_task_id(0),
         title: "Chat 0".to_string(),
@@ -50,10 +50,10 @@ fn test_create_chat_does_not_create_compact_companion() {
         tags: vec![workgraph::chat_id::CHAT_LOOP_TAG.to_string()],
         ..Default::default()
     }));
-    save_graph(&graph, &dir.join("graph.jsonl")).unwrap();
+    save_graph(&graph, dir.join("graph.jsonl")).unwrap();
 
     // Reload and check no companion `.compact-N` task exists.
-    let graph = load_graph(&dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(dir.join("graph.jsonl")).unwrap();
     assert!(graph.get_task(".chat-0").is_some(), "chat task missing");
     assert!(
         graph.get_task(".compact-0").is_none(),
@@ -75,7 +75,7 @@ fn test_create_chat_does_not_create_archive_companion() {
     write_graph(&dir, &graph);
 
     // Simulate the dispatcher creating a chat task.
-    let mut graph = load_graph(&dir.join("graph.jsonl")).unwrap();
+    let mut graph = load_graph(dir.join("graph.jsonl")).unwrap();
     graph.add_node(Node::Task(Task {
         id: format_chat_task_id(0),
         title: "Chat 0".to_string(),
@@ -83,9 +83,9 @@ fn test_create_chat_does_not_create_archive_companion() {
         tags: vec![workgraph::chat_id::CHAT_LOOP_TAG.to_string()],
         ..Default::default()
     }));
-    save_graph(&graph, &dir.join("graph.jsonl")).unwrap();
+    save_graph(&graph, dir.join("graph.jsonl")).unwrap();
 
-    let graph = load_graph(&dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(dir.join("graph.jsonl")).unwrap();
     assert!(graph.get_task(".chat-0").is_some(), "chat task missing");
     assert!(
         graph.get_task(".archive-0").is_none(),
@@ -157,7 +157,7 @@ fn test_legacy_compact_archive_tasks_loaded_then_abandoned() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let graph = load_graph(&dir.join("graph.jsonl")).unwrap();
+    let graph = load_graph(dir.join("graph.jsonl")).unwrap();
     assert_eq!(
         graph.get_task(".compact-0").unwrap().status,
         Status::Abandoned,

--- a/tests/integration_service.rs
+++ b/tests/integration_service.rs
@@ -56,14 +56,12 @@ fn should_skip_timing_tests() -> bool {
     }
 
     // Skip if system load is high (simple heuristic)
-    if let Ok(loadavg) = std::fs::read_to_string("/proc/loadavg") {
-        if let Some(first_load) = loadavg.split_whitespace().next() {
-            if let Ok(load) = first_load.parse::<f64>() {
-                if load > 2.0 {
-                    return true;
-                }
-            }
-        }
+    if let Ok(loadavg) = std::fs::read_to_string("/proc/loadavg")
+        && let Some(first_load) = loadavg.split_whitespace().next()
+        && let Ok(load) = first_load.parse::<f64>()
+        && load > 2.0
+    {
+        return true;
     }
 
     false
@@ -271,13 +269,12 @@ impl Drop for ServiceGuard<'_> {
         // Belt-and-suspenders: read PID from state.json and kill directly
         // in case `wg service stop` itself fails or the daemon is unresponsive.
         let state_path = self.wg_dir.join("service").join("state.json");
-        if let Ok(content) = fs::read_to_string(&state_path) {
-            if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(pid) = state["pid"].as_u64() {
-                    unsafe {
-                        libc::kill(pid as i32, libc::SIGKILL);
-                    }
-                }
+        if let Ok(content) = fs::read_to_string(&state_path)
+            && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Some(pid) = state["pid"].as_u64()
+        {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
             }
         }
     }
@@ -308,13 +305,13 @@ fn coordinator_ticks(wg_dir: &Path) -> u64 {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
-            if name_str.starts_with("coordinator-state") && name_str.ends_with(".json") {
-                if let Ok(content) = fs::read_to_string(entry.path())
-                    && let Ok(val) = serde_json::from_str::<serde_json::Value>(&content)
-                {
-                    let ticks = val["ticks"].as_u64().unwrap_or(0);
-                    max_ticks = max_ticks.max(ticks);
-                }
+            if name_str.starts_with("coordinator-state")
+                && name_str.ends_with(".json")
+                && let Ok(content) = fs::read_to_string(entry.path())
+                && let Ok(val) = serde_json::from_str::<serde_json::Value>(&content)
+            {
+                let ticks = val["ticks"].as_u64().unwrap_or(0);
+                max_ticks = max_ticks.max(ticks);
             }
         }
         if max_ticks > 0 {

--- a/tests/integration_setup.rs
+++ b/tests/integration_setup.rs
@@ -64,7 +64,7 @@ fn setup_env(tmp: &TempDir) -> (PathBuf, PathBuf) {
 
     // Create minimal graph.jsonl
     let graph = workgraph::graph::WorkGraph::new();
-    workgraph::parser::save_graph(&graph, &wg_dir.join("graph.jsonl")).unwrap();
+    workgraph::parser::save_graph(&graph, wg_dir.join("graph.jsonl")).unwrap();
 
     (fake_home, wg_dir)
 }

--- a/tests/integration_state_injection.rs
+++ b/tests/integration_state_injection.rs
@@ -185,7 +185,7 @@ async fn test_message_injection_appears_in_api_request() {
 
     // Check that the first API call contained the injected message
     let calls = captured.lock().unwrap();
-    assert!(calls.len() >= 1, "Expected at least 1 API call");
+    assert!(!calls.is_empty(), "Expected at least 1 API call");
 
     // The first call should contain the message injection
     let first_call = &calls[0];
@@ -258,7 +258,7 @@ async fn test_graph_change_injection_appears_in_api_request() {
 
     // The first API call should contain the graph change injection
     let calls = captured.lock().unwrap();
-    assert!(calls.len() >= 1);
+    assert!(!calls.is_empty());
 
     let first_call = &calls[0];
     assert!(
@@ -484,7 +484,7 @@ async fn test_context_pressure_injection_in_api_request() {
     // graph changes are tested in other integration tests. This test confirms
     // the agent loop correctly passes through the injection when present.
     let calls = captured.lock().unwrap();
-    assert!(calls.len() >= 1, "Expected at least 1 API call");
+    assert!(!calls.is_empty(), "Expected at least 1 API call");
 
     // Verify no crash and basic agent loop execution with state injection enabled
     // even when there's nothing to inject
@@ -629,7 +629,7 @@ async fn test_combined_injection_in_api_request() {
     agent.run("Do the task.").await.unwrap();
 
     let calls = captured.lock().unwrap();
-    assert!(calls.len() >= 1);
+    assert!(!calls.is_empty());
 
     let first_call = &calls[0];
 

--- a/tests/integration_streaming.rs
+++ b/tests/integration_streaming.rs
@@ -122,7 +122,7 @@ async fn streaming_text_content_accumulation() {
 
     // Verify accumulated text
     assert_eq!(response.id, "chatcmpl-test1");
-    assert!(response.content.len() >= 1);
+    assert!(!response.content.is_empty());
     let text = match &response.content[0] {
         ContentBlock::Text { text } => text.as_str(),
         other => panic!("Expected Text block, got: {:?}", other),

--- a/tests/integration_subtask.rs
+++ b/tests/integration_subtask.rs
@@ -98,7 +98,7 @@ fn subtask_creates_child_and_parks_parent() {
         stdout
     );
 
-    let graph = load_graph(&graph_path(&wg_dir)).unwrap();
+    let graph = load_graph(graph_path(&wg_dir)).unwrap();
 
     let child = graph.get_task("research-something").unwrap();
     assert_eq!(child.status, Status::Open);
@@ -187,7 +187,7 @@ fn subtask_child_does_not_depend_on_parent() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let graph = load_graph(&graph_path(&wg_dir)).unwrap();
+    let graph = load_graph(graph_path(&wg_dir)).unwrap();
     let child = graph.get_task("quick-research").unwrap();
 
     assert!(
@@ -224,7 +224,7 @@ fn subtask_with_explicit_after() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let graph = load_graph(&graph_path(&wg_dir)).unwrap();
+    let graph = load_graph(graph_path(&wg_dir)).unwrap();
     let child = graph.get_task("subtask-with-dep").unwrap();
 
     assert!(child.after.contains(&"dep-task".to_string()));
@@ -275,12 +275,11 @@ fn subtask_coordinator_resumes_parent_on_child_done() {
                 WaitSpec::All(c) | WaitSpec::Any(c) => c,
             };
             for cond in conditions {
-                if let WaitCondition::TaskStatus { task_id, status } = cond {
-                    if let Some(dep) = graph.get_task(task_id) {
-                        if dep.status == *status {
-                            did_change = true;
-                        }
-                    }
+                if let WaitCondition::TaskStatus { task_id, status } = cond
+                    && let Some(dep) = graph.get_task(task_id)
+                    && dep.status == *status
+                {
+                    did_change = true;
                 }
             }
         }
@@ -334,12 +333,11 @@ fn subtask_coordinator_resumes_parent_on_child_failed() {
                 _ => panic!("Expected Any"),
             };
             for cond in conditions {
-                if let WaitCondition::TaskStatus { task_id, status } = cond {
-                    if let Some(dep) = graph.get_task(task_id) {
-                        if dep.status == *status {
-                            did_change = true;
-                        }
-                    }
+                if let WaitCondition::TaskStatus { task_id, status } = cond
+                    && let Some(dep) = graph.get_task(task_id)
+                    && dep.status == *status
+                {
+                    did_change = true;
                 }
             }
         }

--- a/tests/integration_task_lifecycle.rs
+++ b/tests/integration_task_lifecycle.rs
@@ -219,7 +219,7 @@ fn test_retry_after_failure_with_eval_task() {
             ..Task::default()
         };
         g.add_node(Node::Task(eval));
-        save_graph(&g, &wg_dir.join("graph.jsonl")).unwrap();
+        save_graph(&g, wg_dir.join("graph.jsonl")).unwrap();
     }
 
     // Fail the task
@@ -432,7 +432,7 @@ fn test_no_zombie_accumulation_across_multiple_abandons() {
         };
         g.add_node(Node::Task(eval));
         g.add_node(Node::Task(verify));
-        save_graph(&g, &wg_dir.join("graph.jsonl")).unwrap();
+        save_graph(&g, wg_dir.join("graph.jsonl")).unwrap();
     }
 
     // Abandon all 3
@@ -516,7 +516,7 @@ fn test_full_lifecycle_abandon_supersede_cascade() {
         };
         g.add_node(Node::Task(eval));
         g.add_node(Node::Task(verify));
-        save_graph(&g, &wg_dir.join("graph.jsonl")).unwrap();
+        save_graph(&g, wg_dir.join("graph.jsonl")).unwrap();
     }
 
     // Abandon with supersession

--- a/tests/integration_tier_defaults.rs
+++ b/tests/integration_tier_defaults.rs
@@ -58,7 +58,7 @@ fn setup_workgraph(tmp: &TempDir) -> PathBuf {
     let wg_dir = tmp.path().join(".wg");
     fs::create_dir_all(&wg_dir).unwrap();
     let graph = workgraph::graph::WorkGraph::new();
-    workgraph::parser::save_graph(&graph, &wg_dir.join("graph.jsonl")).unwrap();
+    workgraph::parser::save_graph(&graph, wg_dir.join("graph.jsonl")).unwrap();
     wg_dir
 }
 
@@ -345,7 +345,7 @@ fn test_no_tier_escalation_flag() {
         &["add", "Test task", "--no-place", "--no-tier-escalation"],
     );
 
-    let graph = workgraph::parser::load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    let graph = workgraph::parser::load_graph(wg_dir.join("graph.jsonl")).unwrap();
     let task = graph.get_task("test-task").unwrap();
     assert!(
         task.no_tier_escalation,

--- a/tests/integration_triage.rs
+++ b/tests/integration_triage.rs
@@ -100,7 +100,7 @@ fn test_requeue_via_cli() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let graph = load_graph(&graph_path(wg_dir)).unwrap();
+    let graph = load_graph(graph_path(wg_dir)).unwrap();
     let task = graph.get_task("task-b").unwrap();
     assert_eq!(task.status, Status::Open);
     assert_eq!(task.triage_count, 1);
@@ -312,7 +312,7 @@ fn test_loop_prevention_fires_after_max_attempts() {
     assert!(stderr.contains("Triage budget exhausted"));
 
     // Verify final triage_count
-    let graph = load_graph(&graph_path(wg_dir)).unwrap();
+    let graph = load_graph(graph_path(wg_dir)).unwrap();
     assert_eq!(graph.get_task("loop-task").unwrap().triage_count, 3);
 }
 

--- a/tests/integration_triage_smoke.rs
+++ b/tests/integration_triage_smoke.rs
@@ -66,7 +66,7 @@ fn graph(wg_dir: &Path) -> workgraph::graph::WorkGraph {
 }
 
 fn task_status(wg_dir: &Path, id: &str) -> Status {
-    graph(wg_dir).get_task(id).unwrap().status.clone()
+    graph(wg_dir).get_task(id).unwrap().status
 }
 
 fn task_triage_count(wg_dir: &Path, id: &str) -> u32 {

--- a/tests/integration_user_board.rs
+++ b/tests/integration_user_board.rs
@@ -52,7 +52,7 @@ fn setup_wg_dir() -> TempDir {
 }
 
 fn graph_at(dir: &Path) -> WorkGraph {
-    load_graph(&dir.join("graph.jsonl")).unwrap()
+    load_graph(dir.join("graph.jsonl")).unwrap()
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration_verify_first.rs
+++ b/tests/integration_verify_first.rs
@@ -280,10 +280,10 @@ fn test_verify_adds_dep_to_eval() {
 
     // Add verify as dep on eval (this is what build_flip_verification_tasks does)
     let eval_task_id = ".evaluate-task-x";
-    if let Some(eval_task) = graph.get_task_mut(eval_task_id) {
-        if !eval_task.after.contains(&verify_task_id) {
-            eval_task.after.push(verify_task_id.clone());
-        }
+    if let Some(eval_task) = graph.get_task_mut(eval_task_id)
+        && !eval_task.after.contains(&verify_task_id)
+    {
+        eval_task.after.push(verify_task_id.clone());
     }
 
     // Verify: eval now depends on both .flip-task-x and .verify-task-x
@@ -299,10 +299,10 @@ fn test_verify_adds_dep_to_eval() {
     assert_eq!(eval.after.len(), 2, "Eval should have exactly 2 deps");
 
     // Verify idempotency: adding again should not create a duplicate
-    if let Some(eval_task) = graph.get_task_mut(eval_task_id) {
-        if !eval_task.after.contains(&verify_task_id) {
-            eval_task.after.push(verify_task_id.clone());
-        }
+    if let Some(eval_task) = graph.get_task_mut(eval_task_id)
+        && !eval_task.after.contains(&verify_task_id)
+    {
+        eval_task.after.push(verify_task_id.clone());
     }
     let eval = graph.get_task(eval_task_id).unwrap();
     assert_eq!(

--- a/tests/integration_worktree.rs
+++ b/tests/integration_worktree.rs
@@ -84,7 +84,7 @@ fn create_test_worktree(project_root: &Path, agent_id: &str) -> std::path::PathB
     let worktree_dir = project_root.join(".wg-worktrees").join(agent_id);
     let branch = format!("wg/{}/test-task", agent_id);
 
-    std::fs::create_dir_all(&worktree_dir.parent().unwrap())
+    std::fs::create_dir_all(worktree_dir.parent().unwrap())
         .expect("Failed to create worktrees dir");
 
     let output = Command::new("git")
@@ -347,7 +347,7 @@ fn test_cleanup_orphaned_worktrees_removes_dead_agents() {
         status: Status::Done,
         ..Task::default()
     }));
-    workgraph::parser::save_graph(&graph, &wg_dir.join("graph.jsonl"))
+    workgraph::parser::save_graph(&graph, wg_dir.join("graph.jsonl"))
         .expect("Failed to write graph");
 
     // Merge the branch into main so retention is satisfied
@@ -415,7 +415,7 @@ fn test_cleanup_orphaned_worktrees_preserves_unfinished_work() {
         status: Status::Failed,
         ..Task::default()
     }));
-    workgraph::parser::save_graph(&graph, &wg_dir.join("graph.jsonl"))
+    workgraph::parser::save_graph(&graph, wg_dir.join("graph.jsonl"))
         .expect("Failed to write graph");
 
     let cleaned_count = cleanup_orphaned_worktrees(&wg_dir).expect("Cleanup should not fail");

--- a/tests/smoke_model_pipeline.rs
+++ b/tests/smoke_model_pipeline.rs
@@ -140,7 +140,7 @@ fn write_model_cache(wg_dir: &Path, model_ids: &[&str]) {
         .map(|id| {
             serde_json::json!({
                 "id": id,
-                "name": id.split('/').last().unwrap_or(id),
+                "name": id.split('/').next_back().unwrap_or(id),
             })
         })
         .collect();

--- a/tests/spawn_site_isolation.rs
+++ b/tests/spawn_site_isolation.rs
@@ -118,7 +118,7 @@ fn strip_comments_and_strings(src: &str) -> String {
     out
 }
 
-fn relpath(src_root: &Path, file: &Path) -> String {
+fn relpath(_src_root: &Path, file: &Path) -> String {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let rel = file.strip_prefix(&manifest).unwrap_or(file);
     rel.to_string_lossy().replace('\\', "/")

--- a/tests/test_concurrent_head_reference.rs
+++ b/tests/test_concurrent_head_reference.rs
@@ -131,7 +131,7 @@ fn test_concurrent_worktree_creation_head_reference() {
             let task_id = format!("task-{}", i);
 
             // Attempt to create worktree
-            let result = create_test_worktree(&*project_clone, &agent_id, &task_id);
+            let result = create_test_worktree(&project_clone, &agent_id, &task_id);
 
             match result {
                 Ok(worktree_path) => {
@@ -169,7 +169,7 @@ fn test_concurrent_worktree_creation_head_reference() {
 
                     // Cleanup
                     let branch = format!("wg/{}/{}", agent_id, task_id);
-                    remove_test_worktree(&*project_clone, &worktree_path, &branch).unwrap();
+                    remove_test_worktree(&project_clone, &worktree_path, &branch).unwrap();
 
                     Ok(())
                 }
@@ -273,13 +273,13 @@ fn test_worktree_creation_with_git_operations_in_progress() {
                 .current_dir(&*project_bg)
                 .output();
 
-            if let Ok(output) = add_result {
-                if output.status.success() {
-                    let _ = Command::new("git")
-                        .args(["commit", "-m", &format!("Background commit {}", i)])
-                        .current_dir(&*project_bg)
-                        .output();
-                }
+            if let Ok(output) = add_result
+                && output.status.success()
+            {
+                let _ = Command::new("git")
+                    .args(["commit", "-m", &format!("Background commit {}", i)])
+                    .current_dir(&*project_bg)
+                    .output();
             }
 
             thread::sleep(std::time::Duration::from_millis(10));
@@ -297,7 +297,7 @@ fn test_worktree_creation_with_git_operations_in_progress() {
             let agent_id = format!("concurrent-agent-{}", i);
             let task_id = format!("concurrent-task-{}", i);
 
-            let result = create_test_worktree(&*project_clone, &agent_id, &task_id);
+            let result = create_test_worktree(&project_clone, &agent_id, &task_id);
 
             match result {
                 Ok(worktree_path) => {
@@ -321,7 +321,7 @@ fn test_worktree_creation_with_git_operations_in_progress() {
 
                     // Cleanup
                     let branch = format!("wg/{}/{}", agent_id, task_id);
-                    remove_test_worktree(&*project_clone, &worktree_path, &branch).unwrap();
+                    remove_test_worktree(&project_clone, &worktree_path, &branch).unwrap();
                     Ok(())
                 }
                 Err(e) => Err(format!("Agent {}: {}", i, e)),

--- a/tests/test_coordinator_lifecycle.rs
+++ b/tests/test_coordinator_lifecycle.rs
@@ -42,7 +42,7 @@ fn test_coordinator_id_allocation_skips_archived() {
     graph.add_node(workgraph::graph::Node::Task(coordinator_2));
 
     // Save the graph
-    parser::save_graph(&graph, &dir.join("graph.jsonl")).unwrap();
+    parser::save_graph(&graph, dir.join("graph.jsonl")).unwrap();
 
     // Test the coordinator slot availability function
     // This is a copy of the function from ipc.rs to test it independently
@@ -125,10 +125,10 @@ fn test_coordinator_archiving_sets_correct_state() {
         ..Default::default()
     };
     graph.add_node(workgraph::graph::Node::Task(coordinator));
-    parser::save_graph(&graph, &dir.join("graph.jsonl")).unwrap();
+    parser::save_graph(&graph, dir.join("graph.jsonl")).unwrap();
 
     // Simulate the archive process (from handle_archive_coordinator in ipc.rs)
-    let mut modified_graph = parser::load_graph(&dir.join("graph.jsonl")).unwrap();
+    let mut modified_graph = parser::load_graph(dir.join("graph.jsonl")).unwrap();
     let task = modified_graph.get_task_mut(".coordinator-5").unwrap();
     task.status = Status::Done;
     task.tags.retain(|t| t != "coordinator-loop");
@@ -137,10 +137,10 @@ fn test_coordinator_archiving_sets_correct_state() {
     }
 
     // Save the updated graph
-    parser::save_graph(&modified_graph, &dir.join("graph.jsonl")).unwrap();
+    parser::save_graph(&modified_graph, dir.join("graph.jsonl")).unwrap();
 
     // Verify the changes
-    let final_graph = parser::load_graph(&dir.join("graph.jsonl")).unwrap();
+    let final_graph = parser::load_graph(dir.join("graph.jsonl")).unwrap();
     let archived_task = final_graph.get_task(".coordinator-5").unwrap();
 
     assert_eq!(
@@ -249,7 +249,7 @@ fn test_archive_then_create_flow() {
         ..Default::default()
     };
     graph.add_node(workgraph::graph::Node::Task(coordinator));
-    parser::save_graph(&graph, &dir.join("graph.jsonl")).unwrap();
+    parser::save_graph(&graph, dir.join("graph.jsonl")).unwrap();
 
     // Test the coordinator slot availability function
     fn is_coordinator_slot_available(graph: &WorkGraph, task_id: &str) -> bool {
@@ -282,7 +282,7 @@ fn test_archive_then_create_flow() {
     assert_eq!(next_id, 1, "With active coordinator-0, next ID should be 1");
 
     // Archive coordinator-0 (simulate handle_archive_coordinator)
-    let mut updated_graph = parser::load_graph(&dir.join("graph.jsonl")).unwrap();
+    let mut updated_graph = parser::load_graph(dir.join("graph.jsonl")).unwrap();
     let task = updated_graph.get_task_mut(".coordinator-0").unwrap();
     task.status = Status::Done;
     task.tags.retain(|t| t != "coordinator-loop");
@@ -295,10 +295,10 @@ fn test_archive_then_create_flow() {
         user: Some("test".to_string()),
         message: "Coordinator archived".to_string(),
     });
-    parser::save_graph(&updated_graph, &dir.join("graph.jsonl")).unwrap();
+    parser::save_graph(&updated_graph, dir.join("graph.jsonl")).unwrap();
 
     // After archiving, coordinator-0 should still not be available (archived coordinators are skipped)
-    let archived_graph = parser::load_graph(&dir.join("graph.jsonl")).unwrap();
+    let archived_graph = parser::load_graph(dir.join("graph.jsonl")).unwrap();
     let mut next_id_after_archive = 0u32;
     loop {
         let task_id = format!(".coordinator-{}", next_id_after_archive);
@@ -360,7 +360,7 @@ fn test_no_id_reuse_with_gaps() {
     };
     graph.add_node(workgraph::graph::Node::Task(coord_4));
 
-    parser::save_graph(&graph, &dir.join("graph.jsonl")).unwrap();
+    parser::save_graph(&graph, dir.join("graph.jsonl")).unwrap();
 
     fn is_coordinator_slot_available(graph: &WorkGraph, task_id: &str) -> bool {
         match graph.get_task(task_id) {

--- a/tests/test_crash_scenarios.rs
+++ b/tests/test_crash_scenarios.rs
@@ -93,8 +93,7 @@ fn setup_workgraph(tmp_root: &Path) -> PathBuf {
     );
 
     // Create config with crash detection settings
-    let config_content = format!(
-        "[agent]
+    let config_content = "[agent]
 reaper_grace_seconds = 1
 heartbeat_timeout = 3
 
@@ -106,7 +105,7 @@ poll_interval = 1
 auto_assign = false
 auto_evaluate = false
 "
-    );
+    .to_string();
     fs::write(wg_dir.join("config.toml"), config_content).unwrap();
 
     let executors_dir = wg_dir.join("executors");
@@ -198,15 +197,14 @@ fn wait_for_service_ready(wg_dir: &Path, timeout: Duration) -> bool {
         if let Ok(content) = fs::read_to_string(&state_path)
             && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
             && let Some(socket_path) = state["socket_path"].as_str()
+            && let Ok(mut stream) = std::os::unix::net::UnixStream::connect(socket_path)
         {
-            if let Ok(mut stream) = std::os::unix::net::UnixStream::connect(socket_path) {
-                let _ = writeln!(stream, r#"{{"cmd":"status"}}"#);
-                let _ = stream.flush();
-                let mut reader = BufReader::new(&stream);
-                let mut response = String::new();
-                if reader.read_line(&mut response).is_ok() && !response.is_empty() {
-                    return true;
-                }
+            let _ = writeln!(stream, r#"{{"cmd":"status"}}"#);
+            let _ = stream.flush();
+            let mut reader = BufReader::new(&stream);
+            let mut response = String::new();
+            if reader.read_line(&mut response).is_ok() && !response.is_empty() {
+                return true;
             }
         }
         false
@@ -243,13 +241,12 @@ impl Drop for ServiceGuard<'_> {
 
         // Belt-and-suspenders: read PID from state.json and kill directly
         let state_path = self.wg_dir.join("service").join("state.json");
-        if let Ok(content) = fs::read_to_string(&state_path) {
-            if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(pid) = state["pid"].as_u64() {
-                    unsafe {
-                        libc::kill(pid as i32, libc::SIGKILL);
-                    }
-                }
+        if let Ok(content) = fs::read_to_string(&state_path)
+            && let Ok(state) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Some(pid) = state["pid"].as_u64()
+        {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
             }
         }
     }
@@ -706,19 +703,18 @@ fn test_crash_scenarios_multiple_agent_crash() {
 
     for _ in 0..3 {
         std::thread::sleep(Duration::from_millis(500));
-        if let Some(registry) = read_registry(&wg_dir) {
-            if let Some(agents) = registry["agents"].as_object() {
-                for agent in agents.values() {
-                    if let Some(task_id) = agent["task_id"].as_str() {
-                        if task_ids.contains(&task_id) && agent["status"].as_str() != Some("dead") {
-                            if let Some(pid) = agent["pid"].as_u64() {
-                                if let Some(id) = agent["id"].as_str() {
-                                    agent_pids.push(pid as i32);
-                                    agent_ids.push(id.to_string());
-                                }
-                            }
-                        }
-                    }
+        if let Some(registry) = read_registry(&wg_dir)
+            && let Some(agents) = registry["agents"].as_object()
+        {
+            for agent in agents.values() {
+                if let Some(task_id) = agent["task_id"].as_str()
+                    && task_ids.contains(&task_id)
+                    && agent["status"].as_str() != Some("dead")
+                    && let Some(pid) = agent["pid"].as_u64()
+                    && let Some(id) = agent["id"].as_str()
+                {
+                    agent_pids.push(pid as i32);
+                    agent_ids.push(id.to_string());
                 }
             }
         }
@@ -884,16 +880,16 @@ working_dir = "/nonexistent/directory"
         );
 
         // Registry should not have stuck "in-progress" agents for this task
-        if let Some(registry) = read_registry(&wg_dir) {
-            if let Some(agents) = registry["agents"].as_object() {
-                for agent in agents.values() {
-                    if agent["task_id"].as_str() == Some("spawn-fail-task") {
-                        let status = agent["status"].as_str().unwrap_or("");
-                        assert_ne!(
-                            status, "alive",
-                            "Should not have alive agent for failed spawn task"
-                        );
-                    }
+        if let Some(registry) = read_registry(&wg_dir)
+            && let Some(agents) = registry["agents"].as_object()
+        {
+            for agent in agents.values() {
+                if agent["task_id"].as_str() == Some("spawn-fail-task") {
+                    let status = agent["status"].as_str().unwrap_or("");
+                    assert_ne!(
+                        status, "alive",
+                        "Should not have alive agent for failed spawn task"
+                    );
                 }
             }
         }

--- a/tests/test_cron_integration.rs
+++ b/tests/test_cron_integration.rs
@@ -1,5 +1,4 @@
 use chrono::{TimeZone, Timelike, Utc};
-use serde_json;
 use tempfile::TempDir;
 use workgraph::cron::{calculate_next_fire, is_cron_due, parse_cron_expression};
 use workgraph::graph::{Node, PRIORITY_NORMAL, Status, Task, WorkGraph};

--- a/tests/test_cron_serialization.rs
+++ b/tests/test_cron_serialization.rs
@@ -1,4 +1,3 @@
-use serde_json;
 use workgraph::graph::{Node, PRIORITY_NORMAL, Status, Task};
 
 #[test]

--- a/tests/test_nex.rs
+++ b/tests/test_nex.rs
@@ -660,16 +660,15 @@ async fn test_nex_two_message_roundtrip_with_tool_use() {
                         .content
                         .iter()
                         .any(|b| matches!(b, ContentBlock::ToolResult { .. }));
-                if let Some(prev) = prev_role {
-                    if prev == workgraph::executor::native::client::Role::User
-                        && msg.role == workgraph::executor::native::client::Role::User
-                        && !is_tool_result
-                    {
-                        return Err(anyhow::anyhow!(
-                            "Invalid: consecutive text-only user messages at call {}",
-                            count
-                        ));
-                    }
+                if let Some(prev) = prev_role
+                    && prev == workgraph::executor::native::client::Role::User
+                    && msg.role == workgraph::executor::native::client::Role::User
+                    && !is_tool_result
+                {
+                    return Err(anyhow::anyhow!(
+                        "Invalid: consecutive text-only user messages at call {}",
+                        count
+                    ));
                 }
                 prev_role = Some(msg.role);
             }
@@ -841,15 +840,14 @@ fn start_recording_oai_stub(num_requests: usize) -> (String, Arc<std::sync::Mute
                     Ok(0) => break,
                     Ok(n) => {
                         buf.extend_from_slice(&tmp[..n]);
-                        if header_end.is_none() {
-                            if let Some(idx) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
-                                header_end = Some(idx + 4);
-                                let header_str =
-                                    String::from_utf8_lossy(&buf[..idx]).to_lowercase();
-                                for line in header_str.lines() {
-                                    if let Some(rest) = line.strip_prefix("content-length:") {
-                                        content_length = rest.trim().parse().ok();
-                                    }
+                        if header_end.is_none()
+                            && let Some(idx) = buf.windows(4).position(|w| w == b"\r\n\r\n")
+                        {
+                            header_end = Some(idx + 4);
+                            let header_str = String::from_utf8_lossy(&buf[..idx]).to_lowercase();
+                            for line in header_str.lines() {
+                                if let Some(rest) = line.strip_prefix("content-length:") {
+                                    content_length = rest.trim().parse().ok();
                                 }
                             }
                         }

--- a/tests/test_orphaned_cleanup.rs
+++ b/tests/test_orphaned_cleanup.rs
@@ -243,21 +243,19 @@ fn detect_orphaned_worktrees(project_root: &Path) -> Result<Vec<String>, String>
     let mut orphans = Vec::new();
 
     if let Ok(entries) = fs::read_dir(&worktrees_dir) {
-        for entry in entries {
-            if let Ok(entry) = entry {
-                let name = entry.file_name().to_string_lossy().to_string();
-                // Check for any agent directory (agent-, dead-agent-, alive-agent-, etc.)
-                if name.contains("agent-") {
-                    // Check if this agent is alive
-                    let is_alive = registry
-                        .agents
-                        .get(&name)
-                        .map(|a| a.is_alive())
-                        .unwrap_or(false);
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            // Check for any agent directory (agent-, dead-agent-, alive-agent-, etc.)
+            if name.contains("agent-") {
+                // Check if this agent is alive
+                let is_alive = registry
+                    .agents
+                    .get(&name)
+                    .map(|a| a.is_alive())
+                    .unwrap_or(false);
 
-                    if !is_alive {
-                        orphans.push(name);
-                    }
+                if !is_alive {
+                    orphans.push(name);
                 }
             }
         }
@@ -497,12 +495,12 @@ fn test_startup_coordinator_cleanup_integration() {
             barrier_clone.wait();
 
             // Detect orphaned worktrees
-            let orphans = detect_orphaned_worktrees(&*project_clone).unwrap_or_default();
+            let orphans = detect_orphaned_worktrees(&project_clone).unwrap_or_default();
 
             // Simulate cleanup on detected orphans
             let mut cleanup_count = 0;
             for agent_id in &orphans {
-                if simulate_cleanup_operations(&*project_clone, agent_id).is_ok() {
+                if simulate_cleanup_operations(&project_clone, agent_id).is_ok() {
                     cleanup_count += 1;
                 }
             }
@@ -525,7 +523,7 @@ fn test_startup_coordinator_cleanup_integration() {
             thread::sleep(Duration::from_millis(10)); // Simulate coordinator tick delay
 
             // Detect any remaining orphaned worktrees (might find fewer if startup already ran)
-            let orphans = detect_orphaned_worktrees(&*project_clone).unwrap_or_default();
+            let orphans = detect_orphaned_worktrees(&project_clone).unwrap_or_default();
 
             // Simulate additional cleanup operations
             let mut cleanup_count = 0;
@@ -537,7 +535,7 @@ fn test_startup_coordinator_cleanup_integration() {
                     let has_target = worktree_path.join("target").exists();
 
                     if has_symlink || has_target {
-                        if simulate_cleanup_operations(&*project_clone, agent_id).is_ok() {
+                        if simulate_cleanup_operations(&project_clone, agent_id).is_ok() {
                             cleanup_count += 1;
                         }
                     }

--- a/tests/test_provider_health.rs
+++ b/tests/test_provider_health.rs
@@ -372,8 +372,8 @@ fn test_provider_health_end_to_end_integration() -> Result<()> {
     );
 
     // Step 5: Test state persistence
-    provider_health.save(&temp_dir.path())?;
-    let loaded_health = ProviderHealth::load(&temp_dir.path())?;
+    provider_health.save(temp_dir.path())?;
+    let loaded_health = ProviderHealth::load(temp_dir.path())?;
 
     // Verify persistence worked correctly
     assert!(loaded_health.service_paused);
@@ -388,7 +388,7 @@ fn test_provider_health_end_to_end_integration() -> Result<()> {
     assert!(loaded_provider.last_error.is_some());
 
     // Step 6: Test resume functionality
-    let mut resume_health = ProviderHealth::load(&temp_dir.path())?;
+    let mut resume_health = ProviderHealth::load(temp_dir.path())?;
     let was_paused = resume_health.service_paused;
 
     // Apply resume logic
@@ -407,8 +407,8 @@ fn test_provider_health_end_to_end_integration() -> Result<()> {
     assert_eq!(resumed_provider.consecutive_failures, 0); // Reset on resume
 
     // Test resume persistence
-    resume_health.save(&temp_dir.path())?;
-    let final_health = ProviderHealth::load(&temp_dir.path())?;
+    resume_health.save(temp_dir.path())?;
+    let final_health = ProviderHealth::load(temp_dir.path())?;
     assert!(!final_health.service_paused);
     assert!(final_health.pause_reason.is_none());
 

--- a/tests/test_race_conditions.rs
+++ b/tests/test_race_conditions.rs
@@ -226,11 +226,11 @@ fn test_concurrent_cleanup_attempts() {
     // - Coordinator tick cleanup
     // - Service restart cleanup
     // - Manual cleanup operations
-    for i in 0..num_agents {
+    for (i, worktree_path) in worktree_paths.iter().take(num_agents).enumerate() {
         let project_clone = Arc::clone(&project_arc);
         let attempts_clone = Arc::clone(&cleanup_attempts);
         let barrier_clone = Arc::clone(&barrier);
-        let worktree_path = worktree_paths[i].clone();
+        let worktree_path = worktree_path.clone();
 
         let handle = thread::spawn(move || {
             // Wait for all threads to be ready
@@ -241,7 +241,7 @@ fn test_concurrent_cleanup_attempts() {
             let branch = format!("wg/{}/{}", agent_id, task_id);
 
             // Attempt cleanup
-            let result = remove_test_worktree(&*project_clone, &worktree_path, &branch);
+            let result = remove_test_worktree(&project_clone, &worktree_path, &branch);
 
             // Track attempt
             {
@@ -440,11 +440,10 @@ fn test_agent_death_cleanup_race() {
     let mut handles: Vec<std::thread::JoinHandle<String>> = Vec::new();
 
     // Simulate agents "dying" (removing metadata/updating registry)
-    for i in 0..num_agents {
+    for (i, (agent_id, _, _)) in agent_setups.iter().take(num_agents).enumerate() {
         let agents_dir = Arc::clone(&agents_dir_arc);
         let registry_path = Arc::clone(&registry_path_arc);
         let barrier = Arc::clone(&barrier);
-        let (agent_id, _, _) = &agent_setups[i];
         let agent_id = agent_id.clone();
 
         let handle = thread::spawn(move || {
@@ -487,12 +486,12 @@ fn test_agent_death_cleanup_race() {
     }
 
     // Simulate cleanup detection threads
-    for i in 0..num_agents {
+    for (i, setup) in agent_setups.iter().take(num_agents).enumerate() {
         let registry_path = Arc::clone(&registry_path_arc);
         let cleanup_results = Arc::clone(&cleanup_results);
         let barrier = Arc::clone(&barrier);
         let project_clone = project.clone();
-        let (agent_id, task_id, worktree_path) = agent_setups[i].clone();
+        let (agent_id, task_id, worktree_path) = setup.clone();
 
         let handle = thread::spawn(move || {
             barrier.wait();
@@ -503,19 +502,15 @@ fn test_agent_death_cleanup_race() {
             // Try to read registry and detect dead agent
             let mut detected_dead = false;
             for _ in 0..20 {
-                if let Ok(content) = fs::read_to_string(&*registry_path) {
-                    if let Ok(registry) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if let Some(agents) = registry.get("agents") {
-                            if let Some(agent) = agents.get(&agent_id) {
-                                if let Some(status) = agent.get("status") {
-                                    if status == "Dead" {
-                                        detected_dead = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
+                if let Ok(content) = fs::read_to_string(&*registry_path)
+                    && let Ok(registry) = serde_json::from_str::<serde_json::Value>(&content)
+                    && let Some(agents) = registry.get("agents")
+                    && let Some(agent) = agents.get(&agent_id)
+                    && let Some(status) = agent.get("status")
+                    && status == "Dead"
+                {
+                    detected_dead = true;
+                    break;
                 }
                 thread::sleep(Duration::from_millis(1));
             }
@@ -617,23 +612,21 @@ fn test_service_restart_coordinator_race() {
             let mut cleaned_up = Vec::new();
 
             if let Ok(entries) = fs::read_dir(&worktrees_dir) {
-                for entry in entries {
-                    if let Ok(entry) = entry {
-                        let path = entry.path();
-                        if path.is_dir() {
-                            let agent_id = path.file_name().unwrap().to_string_lossy();
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        let agent_id = path.file_name().unwrap().to_string_lossy();
 
-                            // Find corresponding orphan info
-                            if let Some((_, task_id, _)) = orphan_paths_clone
-                                .iter()
-                                .find(|(id, _, _)| id == &agent_id.as_ref())
-                            {
-                                let branch = format!("wg/{}/{}", agent_id, task_id);
+                        // Find corresponding orphan info
+                        if let Some((_, task_id, _)) = orphan_paths_clone
+                            .iter()
+                            .find(|(id, _, _)| id == agent_id.as_ref())
+                        {
+                            let branch = format!("wg/{}/{}", agent_id, task_id);
 
-                                // Attempt cleanup
-                                let result = remove_test_worktree(&*project_clone, &path, &branch);
-                                cleaned_up.push((agent_id.to_string(), result.is_ok()));
-                            }
+                            // Attempt cleanup
+                            let result = remove_test_worktree(&project_clone, &path, &branch);
+                            cleaned_up.push((agent_id.to_string(), result.is_ok()));
                         }
                     }
                 }
@@ -666,7 +659,7 @@ fn test_service_restart_coordinator_race() {
             // Try to clean each orphan
             for (agent_id, task_id, worktree_path) in orphan_paths_clone {
                 let branch = format!("wg/{}/{}", agent_id, task_id);
-                let result = remove_test_worktree(&*project_clone, &worktree_path, &branch);
+                let result = remove_test_worktree(&project_clone, &worktree_path, &branch);
                 cleaned_up.push((agent_id, result.is_ok()));
             }
 

--- a/tests/test_recovery_verification.rs
+++ b/tests/test_recovery_verification.rs
@@ -582,7 +582,7 @@ fn test_recovery_verification_multiple_branches() {
     );
 
     // Verify branch names are distinct and don't conflict
-    let all_branches = vec![alpha_branch, beta_branch, gamma_branch];
+    let all_branches = [alpha_branch, beta_branch, gamma_branch];
     let unique_branches: std::collections::HashSet<_> = all_branches.iter().collect();
     assert_eq!(
         unique_branches.len(),

--- a/tests/test_verify_timeout_basic.rs
+++ b/tests/test_verify_timeout_basic.rs
@@ -27,7 +27,7 @@ fn test_verify_timeout_cli_basic() -> Result<()> {
 
     // Initialize a WG project
     let init_output = std::process::Command::new("wg")
-        .args(&["init", "--route", "claude-cli"])
+        .args(["init", "--route", "claude-cli"])
         .current_dir(project_root)
         .output()?;
 
@@ -41,7 +41,7 @@ fn test_verify_timeout_cli_basic() -> Result<()> {
 
     // Create a task with verify timeout using CLI
     let output = std::process::Command::new("wg")
-        .args(&["add", "Test CLI verify timeout", "--verify-timeout", "999s"])
+        .args(["add", "Test CLI verify timeout", "--verify-timeout", "999s"])
         .current_dir(project_root)
         .output()?;
 
@@ -58,7 +58,7 @@ fn test_verify_timeout_cli_basic() -> Result<()> {
 
     // Check that task was created successfully
     let list_output = std::process::Command::new("wg")
-        .args(&["list"])
+        .args(["list"])
         .current_dir(project_root)
         .output()?;
 
@@ -77,7 +77,7 @@ fn test_verify_timeout_duration_formats() -> Result<()> {
     let project_root = temp_dir.path();
 
     let init_output = std::process::Command::new("wg")
-        .args(&["init", "--route", "claude-cli"])
+        .args(["init", "--route", "claude-cli"])
         .current_dir(project_root)
         .output()?;
 
@@ -92,7 +92,7 @@ fn test_verify_timeout_duration_formats() -> Result<()> {
         let title = format!("Test timeout {}", timeout);
 
         let output = std::process::Command::new("wg")
-            .args(&["add", &title, "--verify-timeout", timeout])
+            .args(["add", &title, "--verify-timeout", timeout])
             .current_dir(project_root)
             .output()?;
 

--- a/tests/test_verify_timeout_functionality.rs
+++ b/tests/test_verify_timeout_functionality.rs
@@ -195,13 +195,13 @@ fn test_cli_verify_timeout_flag() -> Result<()> {
 
     // Initialize a WG project
     std::process::Command::new("wg")
-        .args(&["init", "--route", "claude-cli"])
+        .args(["init", "--route", "claude-cli"])
         .current_dir(project_root)
         .output()?;
 
     // Create a task with verify timeout using CLI
     let output = std::process::Command::new("wg")
-        .args(&[
+        .args([
             "add",
             "Test CLI verify timeout",
             "--verify-timeout",
@@ -248,13 +248,13 @@ fn test_verify_timeout_in_task_serialization() -> Result<()> {
 
     // Initialize WG
     std::process::Command::new("wg")
-        .args(&["init", "--route", "claude-cli"])
+        .args(["init", "--route", "claude-cli"])
         .current_dir(project_root)
         .output()?;
 
     // Add task with verify timeout
     std::process::Command::new("wg")
-        .args(&["add", "Serialization test", "--verify-timeout", "999s"])
+        .args(["add", "Serialization test", "--verify-timeout", "999s"])
         .current_dir(project_root)
         .output()?;
 
@@ -278,7 +278,7 @@ fn test_verify_timeout_different_duration_formats() -> Result<()> {
     let project_root = temp_dir.path();
 
     std::process::Command::new("wg")
-        .args(&["init", "--route", "claude-cli"])
+        .args(["init", "--route", "claude-cli"])
         .current_dir(project_root)
         .output()?;
 
@@ -289,7 +289,7 @@ fn test_verify_timeout_different_duration_formats() -> Result<()> {
         let title = format!("Test timeout {}", timeout);
 
         let output = std::process::Command::new("wg")
-            .args(&["add", &title, "--verify-timeout", timeout])
+            .args(["add", &title, "--verify-timeout", timeout])
             .current_dir(project_root)
             .output()?;
 
@@ -349,13 +349,13 @@ fn test_legacy_verify_flag_is_rejected() -> Result<()> {
     // lives in the task description under a ## Validation section.
     let temp_dir = TempDir::new()?;
     std::process::Command::new("wg")
-        .args(&["init", "--route", "claude-cli"])
+        .args(["init", "--route", "claude-cli"])
         .current_dir(temp_dir.path())
         .output()?;
 
     // Legacy commands should still work
     let output = std::process::Command::new("wg")
-        .args(&["add", "Legacy test", "--verify", "cargo test"])
+        .args(["add", "Legacy test", "--verify", "cargo test"])
         .current_dir(temp_dir.path())
         .output()?;
 


### PR DESCRIPTION
## Summary
- Every `rquest` version on crates.io is yanked (upstream renamed to `wreq`), so fresh `cargo install --path .` builds fail with `failed to select a version for the requirement rquest = ^3.0.0`.
- Pin `rquest` via git to the **v3.0.6** tag — the last release still published under the `rquest` name.
- 3.x moved browser emulation out of `rquest` into a sibling `rquest-util` crate. Added it as a dep and rewrote three call sites: `.impersonate(rquest::Impersonate::Chrome131)` → `.emulation(rquest_util::Emulation::Chrome131)` (in `research.rs`, `web_fetch.rs`, `web_search.rs`).
- Added `[patch.crates-io]` to redirect `rquest-util`'s own transitive `rquest = ">=3.0.5"` requirement through the same git source — otherwise cargo tries crates.io and only finds yanked versions.

## Test plan
- [x] `cargo build --release` clean (only the pre-existing 27 warnings)
- [x] `cargo install --force --path .` succeeds; `wg --version` returns `wg 0.1.0`
- [ ] CI passes
- [ ] Sanity-check web fetch / web search actually still emulate Chrome131 end-to-end (manual smoke against a TLS-fingerprinting site)