### PR TITLE
feat: nex CLI polish — timer token-refresh, fuzzy editing, streaming-interrupt fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-nightly-
 
+      # `+nightly` overrides the channel pinned in rust-toolchain.toml so this
+      # job actually exercises nightly (the toml would otherwise force stable).
       - name: cargo build
-        run: cargo build
+        run: cargo +nightly build
 
       - name: cargo test
-        run: cargo test --lib
+        run: cargo +nightly test --lib

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,33 @@ install target, with `--locked` so Cargo uses the checked-in lockfile during
 install. Forgetting this step is a common source of "why isn't this working"
 issues when testing changes.
 
+### Formatting & lint MUST match CI (run `cargo fmt` before pushing)
+
+CI's "Check & Lint" job (`.github/workflows/ci.yml`) fails fast on
+`cargo fmt --check`, then runs `cargo clippy`, both on the **stable** toolchain.
+rustfmt's output differs between stable and nightly (nightly collapses some
+`assert!(...)` / method-chain forms that stable re-expands) and can drift across
+stable releases — this caused two separate fmt-drift CI failures on the polish
+branch.
+
+The repo pins the toolchain in **`rust-toolchain.toml`** (`channel = "1.96.0"`,
+with `rustfmt` + `clippy` components) so local and CI use the *same* rustfmt.
+Because of that pin, the plain commands already do the right thing — **always run
+these before committing/pushing**:
+
+```
+cargo fmt              # formats with the pinned stable rustfmt (matches CI)
+cargo fmt --check      # must be clean — CI fast-fails here
+cargo clippy           # same invocation CI runs
+```
+
+Do **not** format with `cargo +nightly fmt` or an editor configured to run a
+nightly/standalone rustfmt — that reintroduces the drift. If `rustfmt`/`clippy`
+aren't installed for the pinned toolchain, rustup auto-installs them on first
+use; otherwise `rustup component add rustfmt clippy`. To bump Rust, edit
+`channel` in `rust-toolchain.toml` (keep it `>=` the version CI's `@stable`
+resolves to); the CI `nightly` job opts out via `cargo +nightly`.
+
 ## Service Configuration
 
 Pick a **(model, endpoint)** pair — the `wg` command derives the handler from the model spec's provider prefix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,33 @@ install target, with `--locked` so Cargo uses the checked-in lockfile during
 install. Forgetting this step is a common source of "why isn't this working"
 issues when testing changes.
 
+### Formatting & lint MUST match CI (run `cargo fmt` before pushing)
+
+CI's "Check & Lint" job (`.github/workflows/ci.yml`) fails fast on
+`cargo fmt --check`, then runs `cargo clippy`, both on the **stable** toolchain.
+rustfmt's output differs between stable and nightly (nightly collapses some
+`assert!(...)` / method-chain forms that stable re-expands) and can drift across
+stable releases — this caused two separate fmt-drift CI failures on the polish
+branch.
+
+The repo pins the toolchain in **`rust-toolchain.toml`** (`channel = "1.96.0"`,
+with `rustfmt` + `clippy` components) so local and CI use the *same* rustfmt.
+Because of that pin, the plain commands already do the right thing — **always run
+these before committing/pushing**:
+
+```
+cargo fmt              # formats with the pinned stable rustfmt (matches CI)
+cargo fmt --check      # must be clean — CI fast-fails here
+cargo clippy           # same invocation CI runs
+```
+
+Do **not** format with `cargo +nightly fmt` or an editor configured to run a
+nightly/standalone rustfmt — that reintroduces the drift. If `rustfmt`/`clippy`
+aren't installed for the pinned toolchain, rustup auto-installs them on first
+use; otherwise `rustup component add rustfmt clippy`. To bump Rust, edit
+`channel` in `rust-toolchain.toml` (keep it `>=` the version CI's `@stable`
+resolves to); the CI `nightly` job opts out via `cargo +nightly`.
+
 ## Service Configuration
 
 Pick a **(model, endpoint)** pair — the `wg` command derives the handler from the model spec's provider prefix:

--- a/docs/nex-reasoning-display.md
+++ b/docs/nex-reasoning-display.md
@@ -17,7 +17,15 @@ one of two ways while streaming:
 default — there is no flag you must pass to get it.
 
 - While reasoning streams, the existing live prompt hint advances
-  (`thinking… N tokens`).
+  (`thinking… N tokens`). This indicator repaints on a fixed ~100ms timer
+  (the `↯` glyph pulses and the count refreshes ≈10× per second), so it
+  animates smoothly and never freezes during prefill or a long quiet
+  think — even when no new tokens have arrived since the last paint. The
+  cadence is overridable: `WG_NEX_SPINNER_MS=150 wg nex` slows it down,
+  and `WG_NEX_SPINNER_MS=off` (or `0`) disables the timer entirely,
+  falling back to repaint-on-token-flush only. The default is 100ms
+  (values below 16ms are clamped). The timer adds no input latency: it
+  goes quiet at idle prompts and while you are composing a queued line.
 - When reasoning ends, it collapses to a single dim line:
 
   ```

--- a/docs/nex-streaming-resilience.md
+++ b/docs/nex-streaming-resilience.md
@@ -1,0 +1,133 @@
+# nex streaming resilience (the "error decoding response body" interruption)
+
+This documents the diagnosis and fix for a streaming interruption the nex
+(OpenAI-compatible) client hit against a local llama.cpp endpoint, and the
+guarantees the client now provides.
+
+## Symptom
+
+During a long streaming turn against a local endpoint (e.g. puppost
+`http://127.0.0.1:8091/v1`, `qwen3.6-35b-a3b-mtp`), the client logged:
+
+```
+[openai-client] Stream interrupted after ~6260–6317 chunks: error decoding response body
+[openai-client] Streaming error (attempt 1/3): … Retrying in ~800–1150ms
+```
+
+It then retried (up to 3×) and usually recovered. The interruption landed at
+a **consistent ~6300 chunk count**, on **localhost** (no network jitter), and
+the user noticed it seemed to correlate with **hitting Enter repeatedly**
+during the turn.
+
+## Root cause
+
+Two independent facts combine:
+
+1. **reqwest 0.12 hides the real cause.** `Response::bytes_stream()`
+   (reqwest `src/async_impl/response.rs`) wraps the response body in
+   `.map_err(crate::error::decode)`, so **every** body error — a total
+   timeout firing, a per-read timeout, a dropped connection, a chunked
+   framing error — is mapped to `Kind::Decode`, whose `Display` is the
+   single generic string **"error decoding response body"**. The message
+   alone cannot tell these apart; you must inspect `is_timeout()` /
+   `is_connect()` and walk the source chain.
+
+2. **The client put a *total* request timeout on the streaming body.** The
+   shared HTTP client was built with `.timeout(Duration::from_secs(300))`.
+   reqwest applies a total `.timeout()` to the *entire* request including
+   reading the streaming body. A long-but-healthy generation kept producing
+   tokens past the 300s mark; reqwest then fired the total timeout
+   mid-stream, which surfaced — per fact (1) — as the cryptic
+   "error decoding response body".
+
+At a steady local generation rate of roughly ~21 tok/s, 300s ≈ **~6300
+tokens**, which is exactly the consistent chunk count observed. "Usually
+recovers" follows too: when the answer length sits right at the 300s
+boundary, a retry sometimes finishes just under the cap and sometimes does
+not.
+
+### The "hitting Enter" clue: correlation, not causation
+
+The input-race hypothesis was **ruled out**. nex reads the keyboard on a
+**dedicated OS thread** running rustyline (`LiveTerminalInput::start` in
+`src/executor/native/agent.rs`); lines are handed to the agent loop over an
+mpsc channel and *queued* for the next turn. Only a **double Ctrl-C** flips
+the cooperative/hard `CancelToken`; the interactive streaming `tokio::select!`
+aborts the in-flight request **only** on `cancel.cancelled()`. Plain Enter
+never cancels or touches the HTTP body read — at worst it causes some
+terminal repaint churn. The correlation is incidental: long generations are
+the ones that (a) make a user impatient enough to mash Enter and (b) exceed
+the 300s total timeout. The common driver is "this generation is taking a
+long time", not the keystroke.
+
+### Secondary bug: per-chunk lossy UTF-8 decode
+
+The SSE read loop accumulated text with
+`buffer.push_str(&String::from_utf8_lossy(&chunk))` **per network chunk**. A
+multi-byte UTF-8 sequence split across two chunks was decoded before
+reassembly, turning the split bytes into a U+FFFD replacement char and
+silently corrupting any non-ASCII output that straddled a chunk boundary.
+This did not cause the interruption, but it is a real robustness bug in the
+same loop.
+
+## Fix
+
+In `src/executor/native/openai_client.rs`:
+
+1. **Streaming timeout semantics.** The shared client is now built with
+   `connect_timeout(30s)` + `read_timeout(600s)` and **no total timeout**
+   (`build_oai_http_client`). reqwest's `read_timeout` is a per-read /
+   idle timeout that **resets on every received frame**, so a healthy stream
+   that keeps emitting tokens never trips it no matter how long the
+   generation runs — only a genuinely stalled / silently-dropped connection
+   does. The non-streaming path keeps a per-request total
+   `.timeout(300s)` in `send_with_retry` (a single body, so an overall cap is
+   correct there). The idle timeout is overridable via
+   `WG_STREAM_READ_TIMEOUT_SECS`.
+
+2. **Raw-byte SSE buffer.** The streaming loops accumulate `Vec<u8>` and
+   parse complete SSE lines with `parse_next_oai_sse_data_bytes`. Splitting
+   on `\n` (0x0A) is multi-byte-safe — a UTF-8 lead/continuation byte is
+   never 0x0A — so only *whole* lines are ever decoded, and a sequence split
+   across chunks is reassembled intact.
+
+3. **Honest diagnostics.** A mid-stream error is logged via
+   `describe_reqwest_stream_error`, which classifies the error
+   (timeout/connect/request/body/decode) and walks its source chain, so logs
+   reveal the *actual* cause instead of the generic decode string. The
+   returned `anyhow::Error` now **preserves** the underlying
+   `reqwest::Error` (via `anyhow::Error::new(e).context(...)`) so upstream
+   timeout/retry classification keeps working.
+
+## Tests / evidence
+
+- `tests/integration_nex_streaming_resilience.rs` drives the **real**
+  `OpenAiClient::send_streaming` path over a real TCP socket against an
+  in-process mock llama.cpp (chunked SSE):
+  - `total_timeout_reproduces_the_symptom` — a total timeout firing
+    mid-stream yields `is_timeout() == true` **and** Display
+    "error decoding response body" (reproduces the symptom; proves the
+    message hides the cause).
+  - `fixed_client_completes_a_long_slow_stream` — the shipped client rides
+    out a slow ~3s stream that a total timeout would cut, returning the full
+    content.
+  - `read_timeout_aborts_only_a_stalled_stream` — the idle timeout still
+    aborts a genuinely stalled stream while sparing a slow-but-alive one.
+  - `connection_drop_then_retry_recovers` — a mid-stream connection drop is
+    recovered by the retry path.
+  - `split_multibyte_utf8_is_reassembled` — multi-byte UTF-8 split across
+    chunks decodes intact (no U+FFFD).
+- Unit tests in `openai_client.rs` cover `parse_next_oai_sse_data_bytes`
+  including the split-multibyte regression.
+- Smoke scenario `tests/smoke/scenarios/nex_streaming_resilience.sh`
+  (owners: `diagnose-fix-nex`) pins all of the above so a regression — e.g.
+  reintroducing a total timeout on the streaming path — blocks `wg done`.
+
+## Operational note
+
+If a *genuinely* stalled upstream needs to be abandoned sooner or later,
+tune `WG_STREAM_READ_TIMEOUT_SECS` (per-read idle timeout, default 600s). The
+interactive loop additionally has its own application-level idle watchdog
+(`WG_STREAM_IDLE_TIMEOUT_SECS`, default 600s) as a second line of defense.
+Do **not** reintroduce a total request timeout on the streaming client — it
+caps healthy long generations and resurfaces as the cryptic decode error.

--- a/docs/research/nex-fuzzy-edit-design.md
+++ b/docs/research/nex-fuzzy-edit-design.md
@@ -1,0 +1,183 @@
+# nex fuzzy / robust file editing — design & chosen-approach rationale
+
+**Task:** `add-fuzzy-robust` — *Add fuzzy/robust file editing to nex (kill full-file rewrite thrash).*
+**Date:** 2026-06-18
+**Builds on:** `audit-nex-tool` (`docs/research/nex-tool-framework-compat-audit.md`),
+which established that `edit_file` is the canonical, snake_case str-replace
+tool in nex's surface (not a Claude-Code `Edit` clone), and that the tool
+schema is re-sent in prefill every turn (so adding a *second* edit tool is not
+free).
+
+---
+
+## 1. The problem (observed)
+
+Watching nex (qwen3.6-35b-a3b) build a Game-of-Life TUI: after each
+`cargo build` error the model **rewrote the whole file** with `write_file`
+repeatedly — `main.rs` went 2.3KB → 17KB → 19.5KB → about to rewrite again —
+instead of making targeted edits.
+
+Root cause is the classic failure mode of a strict **exact-match** edit tool:
+
+- `edit_file` required `old_string` to appear **byte-for-byte**. Its only
+  leniency was two **opt-in** flags (`normalize_whitespace`,
+  `normalize_line_endings`) that weak/local models essentially never set.
+- When the model's `old_string` was slightly off — indentation it eyeballed
+  wrong, a stray trailing space, a CRLF/LF mismatch, a missing trailing
+  newline — the edit failed with a bare `old_string not found ... Make sure the
+  string matches exactly.`
+- With no path forward, the model fell back to `write_file` and regenerated the
+  entire file. This is wasteful (tokens + latency), error-prone (re-introduces
+  bugs it had already fixed), and disproportionately hurts local/weaker models,
+  which are the least able to reproduce an exact long string.
+
+---
+
+## 2. Approaches considered
+
+| Approach | What it is | Verdict |
+|---|---|---|
+| **A. Fuzzy str-replace** (chosen) | Keep the single `edit_file` tool; make its matching whitespace/indentation/line-ending tolerant with near-miss diagnostics. | **Chosen.** Highest leverage, lowest risk. |
+| **B. OpenAI `apply_patch` (V4A envelope)** | A separate tool taking a `*** Begin Patch / *** Update File / @@ context / -old / +new` envelope. Used by Codex. | Deferred. Adds a second wire format + parser; the V4A context-matching is itself fuzzy, so it solves the *same* problem A does but at the cost of a new tool schema in every prefill and a new failure surface (malformed envelopes). |
+| **C. Aider-style search/replace blocks** | `<<<<<<< SEARCH / ======= / >>>>>>> REPLACE` fenced blocks with fuzzy context matching. | Deferred. Same trade-off as B. Its key insight — *fuzzy context + re-indentation of the replacement* — is exactly what A adopts internally, without a new block grammar the model must emit correctly. |
+| **D. Fast-apply / Morph-style second model** | A small dedicated "apply" model rewrites the file from a loose edit description. | Out of scope as a dependency. Powerful but requires a second model + endpoint; noted here as a *future option*, not a requirement. The task explicitly says "do not require a second model." |
+
+### Why A over B/C
+
+1. **Single tool, no new wire format.** `edit_file` already exists, is audited,
+   and is in the minimal-tools allowlist. Making it tolerant changes behavior
+   the model already knows how to call. B and C each add a tool whose *schema is
+   re-sent every turn* (the audit's prefill-cost finding) and whose envelope
+   grammar is one more thing a weak model can get wrong — trading an
+   exact-`old_string` failure for an exact-envelope failure.
+2. **The hard part is matching, not framing.** Aider/Codex get their robustness
+   from fuzzy *context matching* and *re-indentation*, not from the envelope
+   syntax. A implements those directly (see §3), so we capture the benefit
+   without the grammar.
+3. **Backward compatible.** Existing callers, tests, and the
+   `read_file → edit_file` loop keep working; the two old flags still parse.
+4. **Streaming/latency friendly, no second model.** Pure local string
+   algorithm; no extra round-trip.
+
+B/C remain reasonable *future* additions if a harness needs a multi-file patch
+envelope, but they are not needed to kill the rewrite thrash.
+
+---
+
+## 3. What was implemented
+
+Code: `src/executor/native/tools/fuzzy_match.rs` (matcher + unit tests),
+wired into `EditFileTool` in `src/executor/native/tools/file.rs`.
+
+### 3.1 Strictness cascade (strict → loose; first level with exactly one match wins)
+
+1. **Exact substring** — byte-for-byte. Preserves all historical within-line
+   edit semantics and is the fast path.
+2. **Line-ending tolerant** — `\n` ≡ `\r\n`; a final line with/without a
+   trailing newline matches. (Line-based from here down.)
+3. **+ Trailing-whitespace tolerant** — ignore trailing spaces/tabs per line.
+4. **+ Indentation tolerant** — ignore *leading* whitespace per line. The
+   replacement is **re-indented** to the file's actual indentation (see §3.2),
+   so a block the model supplied at the wrong indent still lands correctly
+   formatted.
+5. **+ Interior-whitespace collapse** — **opt-in only** via the existing
+   `normalize_whitespace` flag. Off by default because collapsing interior
+   whitespace (`a  b` ≡ `a b`) can match semantically different code; kept as a
+   power-user escape hatch.
+
+If a level yields **more than one** match, the tool reports an
+*ambiguous* error (asking for more context) rather than guessing. Uniqueness is
+required at whatever level first matches.
+
+### 3.2 Re-indentation
+
+When a match is found only after ignoring leading whitespace, the replacement
+is re-anchored: the leading-whitespace delta between `old_string`'s first
+non-blank line and the matched file line is applied to every non-blank line of
+`new_string`. This means "model wrote the block at the wrong indent, and wrote
+`new_string` at that same wrong indent" still produces correctly-indented file
+content. Blank lines are left untouched; divergent indent kinds (tabs vs
+spaces) degrade gracefully.
+
+### 3.3 Near-miss diagnostics
+
+On no match at any enabled level, instead of a bare "not found" the tool scans
+the file for the **closest line window** (most trim-equal lines, tie-broken by
+common-prefix length) and returns a side-by-side comparison of the requested
+`old_string` vs the file's actual lines, with the line numbers and a `✗` marker
+on differing lines. The message explicitly steers the model to **fix
+`old_string` and retry a targeted edit rather than rewrite the file with
+`write_file`**. Output is capped (30 lines, 120 cols/line, char-boundary safe).
+
+### 3.4 Steering toward targeted edits
+
+- `edit_file` description now opens with "PREFERRED way to change an existing
+  file: make a small, targeted string replacement instead of rewriting the
+  whole file," documents the tolerant matching, and says "After a failed build,
+  fix each error with a focused edit_file call."
+- `write_file` description now says it is "Best for CREATING a new file or a
+  full rewrite. To CHANGE an existing file, prefer edit_file ... repeatedly
+  rewriting a file to fix small errors is wasteful and reintroduces bugs."
+- The default system prompt (`build_default_system_prompt` in
+  `src/commands/nex.rs`) gained an "Editing files" paragraph telling the model
+  to prefer targeted `edit_file` edits, that matching is tolerant, and to fix
+  each build error with a focused edit instead of regenerating the file.
+
+---
+
+## 4. Tests
+
+- `src/executor/native/tools/fuzzy_match.rs` `#[cfg(test)]`: exact /
+  trailing-ws / line-ending / indentation (+ re-indent) / collapse-opt-in /
+  ambiguity (exact + fuzzy) / near-miss / deletion / unicode. 22 cases.
+- `tests/test_edit_file_edge_cases.rs`: updated from the old strict contract to
+  the tolerant contract (the `*_fails_*` cases that documented the *bug* are now
+  `*_tolerates_*` cases asserting the fix + correct resulting content), plus the
+  deliberate strict boundary (`interior_whitespace_not_collapsed_by_default`)
+  and its opt-in counterpart.
+- `tests/test_edit_file_fix_build_repro.rs`: the headline repro — a "fix build
+  errors" flow where each fix is a targeted `edit_file` with an imperfect
+  `old_string` (wrong indent / trailing space / CRLF), all of which now land
+  without a single `write_file` rewrite; plus a near-miss assertion.
+
+### Live-model repro (executed)
+
+Ran the real flow against **qwen via OpenRouter** (`openrouter:qwen/qwen3-coder`,
+which OpenRouter resolved to `qwen3-coder-480b-a35b`) on a throwaway cargo
+project whose `src/main.rs` had a deliberate build error (missing `;`):
+
+```
+wg nex -m openrouter:qwen/qwen3-coder --autonomous \
+  "Run cargo build. It fails. Fix the build error with a SMALL TARGETED edit_file
+   change to src/main.rs — do NOT rewrite the whole file. Then run cargo build again."
+```
+
+Tool-call tally from the session trace (`.wg/chat/<id>/trace.ndjson`):
+
+| tool | calls |
+|---|---|
+| `bash` (cargo build) | 4 |
+| `read_file` | 2 |
+| **`edit_file`** | **2** |
+| **`write_file`** | **0** |
+
+The model fixed the error with a targeted `edit_file`
+(`old_string: "... sum_all(&nums)\n    println!..."` →
+`new_string: "... sum_all(&nums);\n    println!..."`) — result
+`Successfully edited /tmp/.../src/main.rs` — and `cargo build` then passed.
+**Zero full-file rewrites**, which is the behavior this task set out to produce.
+(The local `http://127.0.0.1:8088` endpoint was down in this environment, so the
+OpenRouter route was used.) The deterministic registry-level repro in
+`tests/test_edit_file_fix_build_repro.rs` additionally exercises the *fuzzy*
+matching paths (imperfect indentation / trailing space / CRLF) that a clean
+small-file live run does not always trigger.
+
+---
+
+## 5. Future options (not dependencies)
+
+- **Fast-apply / Morph** (approach D): a small apply-model for very loose edit
+  intents. Layer *on top of* the fuzzy matcher if ever needed.
+- **apply_patch / search-replace envelope** (B/C): add as a *multi-file* patch
+  tool if a harness needs it; the matcher here is reusable as its context
+  engine.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,19 @@
+# Pin the toolchain so local `cargo fmt`/`cargo clippy` match CI exactly.
+#
+# Why this file exists: CI's "Check & Lint" job runs `cargo fmt --check` and
+# `cargo clippy` on the latest *stable* rustfmt (via dtolnay/rust-toolchain@stable).
+# rustfmt's output differs between stable and nightly (nightly collapses some
+# `assert!`/method-chain forms that stable re-expands), and can drift across
+# stable releases. Twice the polish branch shipped code formatted by a *nightly*
+# rustfmt and failed CI's stable `cargo fmt --check`.
+#
+# Pinning an exact channel here means `cargo fmt` / `cargo clippy` (and every
+# other cargo invocation) in this repo use the SAME rustfmt that CI uses, so
+# `cargo fmt` before pushing produces byte-identical output to CI. rustup
+# auto-installs this toolchain + components on first use.
+#
+# To bump Rust: change `channel` here AND keep it >= the version CI's @stable
+# resolves to. The CI "nightly" job opts out explicitly via `cargo +nightly`.
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]

--- a/src/commands/nex.rs
+++ b/src/commands/nex.rs
@@ -881,6 +881,14 @@ fn build_default_system_prompt(
          Working directory: {}\n\
          Current date: {} ({})\n\
          \n\
+         Editing files: to change an existing file, make targeted edits with \
+         edit_file (old_string → new_string) — do NOT rewrite the whole file with \
+         write_file. edit_file matching tolerates whitespace, indentation, and \
+         line-ending differences, so you don't need a byte-perfect old_string; if an \
+         edit doesn't match, it returns the closest line so you can fix old_string and \
+         retry. Reserve write_file for creating new files. After a failed build, fix \
+         each error with a focused edit_file call rather than regenerating the file.\n\
+         \n\
          Use bash to run `wg` CLI commands when you need WG task management.\n\
          \n\
          When asked to produce content that requires current real-world data \

--- a/src/executor/native/agent.rs
+++ b/src/executor/native/agent.rs
@@ -398,17 +398,37 @@ const NEX_WORKING_FALLBACK: &str = "*";
 /// shifts) and the running token count is rendered as a trailing
 /// rustyline hint. The hint is recomputed inside rustyline's
 /// `refresh_line`, which fires on every keystroke AND every
-/// `ExternalPrinter::print` — so the count advances live as streamed
-/// text flushes, with no extra timer thread and no added render
-/// contention (the original throbber complaint).
+/// `ExternalPrinter::print`.
+///
+/// Token flushes alone are a JITTERY repaint clock: nothing prints
+/// during prefill, and with reasoning hidden the count is incremented
+/// (silently) but never flushed, so the indicator freezes during long
+/// thinks/stalls. The repaint is therefore ALSO driven by a fixed
+/// ~100ms timer (see [`nex_spinner_interval`] /
+/// [`LiveTerminalOutput::repaint`]): every tick reads the latest
+/// cumulative `tokens` and advances `frame` so the count keeps moving
+/// and the `↯` glyph pulses even when no new tokens arrived. The timer
+/// is gated on `!waiting_for_input && !composing`, so it adds no input
+/// latency and never repaints over a half-typed line (the original
+/// throbber complaint that fix-nex-chat-2 guarded against).
 #[derive(Clone, Default)]
 struct LiveProgress {
     tokens: Arc<AtomicU64>,
+    /// Monotonic animation frame, advanced by the repaint timer (NOT by
+    /// keystrokes), so the working-glyph pulse is decoupled from typing
+    /// and never flickers per-keystroke.
+    frame: Arc<AtomicU64>,
+    /// Set true whenever the user has a non-empty input line (observed
+    /// by the rustyline hinter). The repaint timer reads it to suppress
+    /// repaints while the user composes a queued message.
+    composing: Arc<AtomicBool>,
 }
 
 impl LiveProgress {
     /// Clear the count at the start of a model call so the next turn's
-    /// `thinking…` indicator restarts from the prefill phase.
+    /// `thinking…` indicator restarts from the prefill phase. The
+    /// animation `frame` is intentionally left running so the glyph
+    /// pulse stays continuous across turns.
     fn reset(&self) {
         self.tokens.store(0, Ordering::Relaxed);
     }
@@ -421,6 +441,67 @@ impl LiveProgress {
     fn tokens(&self) -> u64 {
         self.tokens.load(Ordering::Relaxed)
     }
+
+    /// Advance the animation frame one step (called on each timer tick).
+    fn tick_frame(&self) {
+        self.frame.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn frame(&self) -> u64 {
+        self.frame.load(Ordering::Relaxed)
+    }
+
+    fn set_composing(&self, composing: bool) {
+        self.composing.store(composing, Ordering::Relaxed);
+    }
+
+    fn composing(&self) -> bool {
+        self.composing.load(Ordering::Relaxed)
+    }
+}
+
+/// Default repaint cadence for the live `thinking… N tokens` working
+/// indicator, in milliseconds (~10 fps). This is the standard band for
+/// agent CLIs (Claude Code ≈120ms; typical 80–250ms) — fast enough to
+/// read as smooth motion, slow enough to add no perceptible cost.
+/// Override at runtime with `WG_NEX_SPINNER_MS` (an integer count of
+/// milliseconds, or `0`/`off` to disable the timer and fall back to
+/// repaint-on-token-flush only).
+const NEX_SPINNER_DEFAULT_MS: u64 = 100;
+
+/// Floor for `WG_NEX_SPINNER_MS` so a pathologically small override
+/// can't peg a core or cause visible flicker.
+const NEX_SPINNER_MIN_MS: u64 = 16;
+
+/// Parse a `WG_NEX_SPINNER_MS` value into a repaint interval. `None`
+/// means the timer is explicitly disabled; `Some(interval)` is the
+/// (clamped) cadence. Empty / unparseable values fall back to the
+/// default rather than disabling, so a stray export never silently
+/// kills the animation. Split out from [`nex_spinner_interval`] so it
+/// is unit-testable without mutating the process environment.
+fn parse_spinner_interval(raw: Option<&str>) -> Option<Duration> {
+    let Some(value) = raw else {
+        return Some(Duration::from_millis(NEX_SPINNER_DEFAULT_MS));
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Some(Duration::from_millis(NEX_SPINNER_DEFAULT_MS));
+    }
+    if matches!(
+        trimmed.to_ascii_lowercase().as_str(),
+        "0" | "off" | "false" | "none" | "disable" | "disabled"
+    ) {
+        return None;
+    }
+    match trimmed.parse::<u64>() {
+        Ok(ms) => Some(Duration::from_millis(ms.max(NEX_SPINNER_MIN_MS))),
+        Err(_) => Some(Duration::from_millis(NEX_SPINNER_DEFAULT_MS)),
+    }
+}
+
+/// Resolve the live-indicator repaint interval from the environment.
+fn nex_spinner_interval() -> Option<Duration> {
+    parse_spinner_interval(std::env::var("WG_NEX_SPINNER_MS").ok().as_deref())
 }
 
 /// Per-turn reasoning bookkeeping shared between the streaming callback
@@ -495,6 +576,7 @@ impl NexPromptState {
             self.waiting_for_input.load(Ordering::SeqCst),
             self.color_enabled,
             self.working_indicator,
+            self.progress.frame(),
         )
     }
 
@@ -504,10 +586,16 @@ impl NexPromptState {
     /// (so a queued message is never cluttered by the status), leaving
     /// the lightning glyph as the sole busy indicator in that case.
     fn hint(&self, line: &str) -> Option<String> {
+        // Record whether the user is mid-compose so the repaint timer can
+        // hold its repaints (avoiding flicker / input lag) while they type
+        // a queued line. The hinter is the natural observer: rustyline
+        // calls it on every refresh with the live buffer.
+        let composing = !line.is_empty();
+        self.progress.set_composing(composing);
         if self.waiting_for_input.load(Ordering::SeqCst) {
             return None;
         }
-        if !line.is_empty() {
+        if composing {
             return None;
         }
         Some(render_nex_thinking_hint(self.progress.tokens()))
@@ -575,10 +663,17 @@ impl rustyline::highlight::Highlighter for NexReadlineHelper {
     }
 }
 
+/// Working-glyph pulse palette (bold 256-color oranges). Stepped once per
+/// repaint-timer tick to give the `↯` glyph a gentle breathing animation
+/// (214 base → 220 bright → 214 → 208 dim → repeat). Width is unaffected —
+/// only the SGR color changes — so the input column never shifts.
+const NEX_WORKING_PULSE: [u8; 4] = [214, 220, 214, 208];
+
 fn render_nex_prompt(
     waiting_for_input: bool,
     color_enabled: bool,
     working_indicator: &str,
+    frame: u64,
 ) -> String {
     if waiting_for_input {
         // Idle / ready: greater-than glyph + one trailing space.
@@ -590,17 +685,19 @@ fn render_nex_prompt(
     } else if color_enabled {
         // Working: the lightning glyph is swapped IN PLACE of the `>` (not
         // prepended), keeping the same 2-cell width and the trailing space
-        // so the input column never shifts. Fixed color, NOT animated:
-        // rustyline repaints the prompt on every keystroke and every
-        // ExternalPrinter::print, so a tick-driven color cycle would only
-        // advance while output streams (frozen during quiet tool calls) and
-        // would re-emit a new color on each keystroke — read as input lag.
-        // Reliable animation would need a timer forcing repaints, which
-        // rustyline cannot do without emitting output (added contention).
-        // See fix-nex-chat-2 for the full root-cause note.
-        format!("\x1b[1;38;5;214m{}\x1b[0m ", working_indicator)
+        // so the input column never shifts. The color pulses across frames,
+        // but `frame` advances ONLY on the dedicated repaint timer — never
+        // per-keystroke — so the animation is smooth and decoupled from
+        // typing. (fix-nex-chat-2 banned per-keystroke color cycling, which
+        // read as input lag; a fixed-cadence timer is what it said reliable
+        // animation would require. The render stays a pure function of
+        // `frame`, so two refreshes within the same tick are identical.)
+        let color = NEX_WORKING_PULSE[(frame as usize) % NEX_WORKING_PULSE.len()];
+        format!("\x1b[1;38;5;{}m{}\x1b[0m ", color, working_indicator)
     } else {
         // No-color / dumb terminal: ASCII star fallback + trailing space.
+        // No color to animate; the live token count still advances on the
+        // timer via the trailing hint, which is the primary motion cue.
         format!("{} ", working_indicator)
     }
 }
@@ -657,6 +754,26 @@ impl LiveTerminalOutput {
             }
         }
     }
+
+    /// Force the live rustyline prompt (working glyph + `thinking… N
+    /// tokens` hint) to redraw WITHOUT appending visible output, so the
+    /// repaint timer can animate the indicator even when no tokens are
+    /// streaming.
+    ///
+    /// rustyline's `external_print` clears the prompt rows, writes the
+    /// message, then redraws the prompt below it — appending a `\n` unless
+    /// the message already ends in one. We send a cursor-neutral
+    /// `cursor-up-one-row` + `newline`: it ends in `\n` (so rustyline adds
+    /// no extra newline) and the up-then-down nets back to the same row,
+    /// leaving the redraw exactly in place with no scroll. Going through
+    /// rustyline (rather than writing stderr directly) keeps its layout
+    /// model consistent, and the print pipe serializes this with streamed
+    /// output so the two never interleave mid-write.
+    fn repaint(&self) {
+        if let Ok(mut printer) = self.printer.lock() {
+            let _ = printer.print("\x1b[1A\n".to_string());
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -704,6 +821,10 @@ struct LiveTerminalInput {
     output: LiveTerminalOutput,
     waiting_for_input: Arc<AtomicBool>,
     progress: LiveProgress,
+    /// Dropping this sender disconnects the repaint timer's channel,
+    /// waking it immediately so it stops cleanly (see `Drop`).
+    spinner_stop: Option<std::sync::mpsc::Sender<()>>,
+    spinner_handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl LiveTerminalInput {
@@ -814,11 +935,52 @@ impl LiveTerminalInput {
             let _ = editor.save_history(&history_path);
         });
 
+        // Fixed-cadence repaint timer. It drives the live `thinking… N
+        // tokens` indicator off a steady clock instead of riding solely on
+        // token-flush prints, so the count + glyph keep animating during
+        // prefill and long quiet thinks. Disabled (no thread) when
+        // `WG_NEX_SPINNER_MS=0/off`. Gated on `!waiting_for_input` (idle
+        // boundaries stay quiet) and `!composing` (never repaint over a
+        // half-typed queued line) so it adds no input latency.
+        let (spinner_stop, spinner_rx) = std::sync::mpsc::channel::<()>();
+        let spinner_handle = match nex_spinner_interval() {
+            Some(interval) => {
+                let output_for_timer = output.clone();
+                let waiting_for_timer = waiting_for_input.clone();
+                let progress_for_timer = progress.clone();
+                Some(std::thread::spawn(move || {
+                    use std::sync::mpsc::RecvTimeoutError;
+                    loop {
+                        match spinner_rx.recv_timeout(interval) {
+                            Err(RecvTimeoutError::Timeout) => {}
+                            // Sender dropped (session ending) or a stop
+                            // signal arrived — exit without a final repaint.
+                            _ => break,
+                        }
+                        if waiting_for_timer.load(Ordering::SeqCst) {
+                            continue;
+                        }
+                        if progress_for_timer.composing() {
+                            continue;
+                        }
+                        progress_for_timer.tick_frame();
+                        output_for_timer.repaint();
+                    }
+                }))
+            }
+            None => {
+                drop(spinner_rx);
+                None
+            }
+        };
+
         Some(Self {
             rx,
             output,
             waiting_for_input,
             progress,
+            spinner_stop: Some(spinner_stop),
+            spinner_handle,
         })
     }
 
@@ -868,6 +1030,20 @@ impl LiveTerminalInput {
             }
         }
         lines
+    }
+}
+
+impl Drop for LiveTerminalInput {
+    fn drop(&mut self) {
+        // Stop the repaint timer before the session tears down so no stray
+        // repaint lands after the final output. Dropping the sender
+        // disconnects the timer's channel, waking its `recv_timeout`
+        // immediately; the join then returns near-instantly (no waiting a
+        // full interval).
+        self.spinner_stop.take();
+        if let Some(handle) = self.spinner_handle.take() {
+            let _ = handle.join();
+        }
     }
 }
 
@@ -4753,11 +4929,13 @@ fn stderr_cols() -> usize {
 #[cfg(test)]
 mod prompt_indicator_tests {
     use super::{
-        LiveProgress, NEX_WORKING_FALLBACK, NEX_WORKING_GLYPH, NexPromptState, NexStatusHint,
-        render_nex_prompt, render_nex_thinking_hint,
+        LiveProgress, NEX_SPINNER_DEFAULT_MS, NEX_SPINNER_MIN_MS, NEX_WORKING_FALLBACK,
+        NEX_WORKING_GLYPH, NEX_WORKING_PULSE, NexPromptState, NexStatusHint,
+        parse_spinner_interval, render_nex_prompt, render_nex_thinking_hint,
     };
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
     use unicode_width::UnicodeWidthStr;
 
     fn strip_ansi(input: &str) -> String {
@@ -4781,8 +4959,8 @@ mod prompt_indicator_tests {
 
     #[test]
     fn compact_prompt_keeps_input_column_stable() {
-        let idle = render_nex_prompt(true, false, NEX_WORKING_FALLBACK);
-        let working = render_nex_prompt(false, false, NEX_WORKING_FALLBACK);
+        let idle = render_nex_prompt(true, false, NEX_WORKING_FALLBACK, 0);
+        let working = render_nex_prompt(false, false, NEX_WORKING_FALLBACK, 0);
 
         // Idle and working share the same 2-cell width and trailing space —
         // the glyph swaps in place so the input column never shifts.
@@ -4794,7 +4972,7 @@ mod prompt_indicator_tests {
 
     #[test]
     fn colored_working_prompt_swaps_glyph_in_place_with_trailing_space() {
-        let rendered = render_nex_prompt(false, true, NEX_WORKING_GLYPH);
+        let rendered = render_nex_prompt(false, true, NEX_WORKING_GLYPH, 0);
         let plain = strip_ansi(&rendered);
 
         // Lightning glyph REPLACES the `>` in place (no prepended `>`),
@@ -4852,19 +5030,136 @@ mod prompt_indicator_tests {
     }
 
     #[test]
-    fn colored_working_prompt_is_fixed_color_across_repaints() {
-        // The prompt must be stable across repeated renders — no per-render
-        // color cycling that would flicker on every keystroke (fix-nex-chat-2).
-        let first = render_nex_prompt(false, true, NEX_WORKING_GLYPH);
-        let second = render_nex_prompt(false, true, NEX_WORKING_GLYPH);
-        let third = render_nex_prompt(false, true, NEX_WORKING_GLYPH);
+    fn colored_working_prompt_is_stable_within_a_frame() {
+        // fix-nex-chat-2 invariant: the render must be a pure function of
+        // the animation frame, so repeated refreshes WITHIN one timer tick
+        // (e.g. consecutive keystrokes) are byte-identical and never flicker
+        // the color. Animation comes ONLY from advancing `frame`, which the
+        // repaint timer does — not keystrokes.
+        let first = render_nex_prompt(false, true, NEX_WORKING_GLYPH, 7);
+        let second = render_nex_prompt(false, true, NEX_WORKING_GLYPH, 7);
+        let third = render_nex_prompt(false, true, NEX_WORKING_GLYPH, 7);
         assert_eq!(first, second);
         assert_eq!(second, third);
     }
 
     #[test]
+    fn colored_working_prompt_pulses_across_frames() {
+        // Across timer ticks the working glyph cycles through the pulse
+        // palette (so it visibly animates), while the glyph char and the
+        // 2-cell width stay fixed (the input column never shifts).
+        let frames: Vec<String> = (0..NEX_WORKING_PULSE.len() as u64)
+            .map(|f| render_nex_prompt(false, true, NEX_WORKING_GLYPH, f))
+            .collect();
+        // At least two distinct colorings appear over a full cycle.
+        let distinct: std::collections::HashSet<&String> = frames.iter().collect();
+        assert!(
+            distinct.len() >= 2,
+            "working glyph must animate across frames: {frames:?}"
+        );
+        // The cycle repeats with the palette period.
+        assert_eq!(
+            render_nex_prompt(false, true, NEX_WORKING_GLYPH, 0),
+            render_nex_prompt(
+                false,
+                true,
+                NEX_WORKING_GLYPH,
+                NEX_WORKING_PULSE.len() as u64
+            ),
+        );
+        // Animation is color-only: the visible glyph + width never change.
+        for rendered in &frames {
+            let plain = strip_ansi(rendered);
+            assert_eq!(plain, format!("{} ", NEX_WORKING_GLYPH));
+            assert_eq!(UnicodeWidthStr::width(plain.as_str()), 2);
+        }
+        // The no-color fallback has no color to animate: identical per frame.
+        assert_eq!(
+            render_nex_prompt(false, false, NEX_WORKING_FALLBACK, 0),
+            render_nex_prompt(false, false, NEX_WORKING_FALLBACK, 3),
+        );
+    }
+
+    #[test]
+    fn spinner_interval_parses_and_clamps() {
+        // Unset / empty / unparseable → default (never silently disabled).
+        assert_eq!(
+            parse_spinner_interval(None),
+            Some(Duration::from_millis(NEX_SPINNER_DEFAULT_MS))
+        );
+        assert_eq!(
+            parse_spinner_interval(Some("   ")),
+            Some(Duration::from_millis(NEX_SPINNER_DEFAULT_MS))
+        );
+        assert_eq!(
+            parse_spinner_interval(Some("not-a-number")),
+            Some(Duration::from_millis(NEX_SPINNER_DEFAULT_MS))
+        );
+        // Explicit disable forms.
+        for off in ["0", "off", "OFF", "false", "none", "disable", "disabled"] {
+            assert_eq!(
+                parse_spinner_interval(Some(off)),
+                None,
+                "{off} should disable"
+            );
+        }
+        // Valid override (with surrounding whitespace).
+        assert_eq!(
+            parse_spinner_interval(Some(" 150 ")),
+            Some(Duration::from_millis(150))
+        );
+        // Below the floor is clamped up, not disabled.
+        assert_eq!(
+            parse_spinner_interval(Some("1")),
+            Some(Duration::from_millis(NEX_SPINNER_MIN_MS))
+        );
+    }
+
+    #[test]
+    fn timer_frame_drives_glyph_animation_independent_of_tokens() {
+        // The repaint timer advances `frame` so the working glyph pulses
+        // even when the token count has not moved (prefill / stall), and
+        // token arrival advances the count without disturbing the
+        // animation. The two channels are fully decoupled.
+        let progress = LiveProgress::default();
+        // Timer ticks advance the animation frame without fabricating tokens…
+        progress.tick_frame();
+        progress.tick_frame();
+        assert_eq!(progress.frame(), 2);
+        assert_eq!(progress.tokens(), 0, "ticks must not fabricate tokens");
+        // …and token arrival advances the count without advancing the frame.
+        progress.add_tokens(5);
+        assert_eq!(progress.tokens(), 5);
+        assert_eq!(progress.frame(), 2, "tokens must not advance the frame");
+
+        // With color on, the glyph render reflects an advanced frame even
+        // though no NEW tokens arrived — the animation rides the timer, not
+        // token flushes. (Uses render_nex_prompt directly so the assertion
+        // does not depend on the test host's NO_COLOR/TERM environment.)
+        let f0 = render_nex_prompt(false, true, NEX_WORKING_GLYPH, 0);
+        let f1 = render_nex_prompt(false, true, NEX_WORKING_GLYPH, 1);
+        assert_ne!(f0, f1, "glyph color must advance with the frame");
+    }
+
+    #[test]
+    fn composing_flag_tracks_input_line_for_repaint_timer() {
+        // The hinter records compose-state so the repaint timer can hold
+        // its repaints while the user types a queued line, then resume the
+        // moment the line is empty again.
+        let progress = LiveProgress::default();
+        let waiting = Arc::new(AtomicBool::new(false));
+        let state = NexPromptState::new(waiting, progress.clone());
+
+        assert!(!progress.composing(), "starts not composing");
+        let _ = state.hint("draft a follow-up");
+        assert!(progress.composing(), "non-empty input marks composing");
+        let _ = state.hint("");
+        assert!(!progress.composing(), "empty input clears composing");
+    }
+
+    #[test]
     fn colored_idle_prompt_renders_plain_prompt_text() {
-        let rendered = render_nex_prompt(true, true, NEX_WORKING_GLYPH);
+        let rendered = render_nex_prompt(true, true, NEX_WORKING_GLYPH, 0);
         let plain = strip_ansi(&rendered);
 
         assert_eq!(plain, "> ");

--- a/src/executor/native/openai_client.rs
+++ b/src/executor/native/openai_client.rs
@@ -258,6 +258,57 @@ struct OaiStreamToolCallFunction {
 const DEFAULT_BASE_URL: &str = "https://openrouter.ai/api/v1";
 const DEFAULT_MAX_TOKENS: u32 = 16384;
 
+/// TCP connect timeout — a dead endpoint should fail fast.
+const CONNECT_TIMEOUT_SECS: u64 = 30;
+
+/// Total-request timeout for **non-streaming** requests. A non-streaming
+/// completion returns a single body, so an overall cap is the right tool.
+const NON_STREAMING_TIMEOUT_SECS: u64 = 300;
+
+/// Default per-read (idle) timeout for the streaming body, in seconds.
+///
+/// reqwest's `read_timeout` resets on *every* received frame, so a healthy
+/// stream that keeps emitting tokens never trips it no matter how long the
+/// generation runs — only a genuinely stalled / silently-dropped connection
+/// does. This deliberately replaces a blanket total-request timeout on the
+/// streaming path: with reqwest 0.12, `Response::bytes_stream()` funnels
+/// *every* body error (total-timeout firing, connection drop, framing
+/// error) through `Kind::Decode`, whose Display is the unhelpful
+/// "error decoding response body". A total timeout therefore cut a
+/// long-but-healthy generation off around the cap and surfaced as exactly
+/// the cryptic "Stream interrupted ... error decoding response body" the
+/// user reported (~6300 tokens ≈ 300s at a steady local rate). 600s leaves
+/// generous headroom for local llama.cpp / vLLM prompt-processing stalls
+/// before the first token. Override via `WG_STREAM_READ_TIMEOUT_SECS`.
+const DEFAULT_STREAM_READ_TIMEOUT_SECS: u64 = 600;
+
+/// Per-read (idle) timeout for streaming bodies, honoring the
+/// `WG_STREAM_READ_TIMEOUT_SECS` override (0/invalid → default).
+fn stream_read_timeout() -> Duration {
+    let secs = std::env::var("WG_STREAM_READ_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_STREAM_READ_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Build the shared HTTP client used for both streaming and non-streaming
+/// OpenAI-compatible requests.
+///
+/// Note there is **no** total-request `.timeout(...)` here: that would cap
+/// healthy long streams (see [`DEFAULT_STREAM_READ_TIMEOUT_SECS`]). The
+/// streaming path is protected by `read_timeout` (idle/inactivity), and the
+/// non-streaming path applies its own per-request total timeout in
+/// `send_with_retry`.
+fn build_oai_http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+        .read_timeout(stream_read_timeout())
+        .build()
+        .context("Failed to build HTTP client")
+}
+
 /// OpenAI-compatible chat completions client.
 ///
 /// Works with OpenRouter, direct OpenAI API, and any compatible endpoint.
@@ -288,10 +339,7 @@ pub struct OpenAiClient {
 impl OpenAiClient {
     /// Create a client with explicit configuration.
     pub fn new(api_key: String, model: &str, base_url: Option<&str>) -> Result<Self> {
-        let http = reqwest::Client::builder()
-            .timeout(Duration::from_secs(300))
-            .build()
-            .context("Failed to build HTTP client")?;
+        let http = build_oai_http_client()?;
 
         Ok(Self {
             http,
@@ -935,9 +983,11 @@ impl OpenAiClient {
             ));
         }
 
-        // Parse SSE stream and accumulate into a response
+        // Parse SSE stream and accumulate into a response. The buffer holds
+        // raw bytes so a multi-byte UTF-8 sequence split across two network
+        // chunks is reassembled intact (see `parse_next_oai_sse_data_bytes`).
         let mut stream = resp.bytes_stream();
-        let mut buffer = String::new();
+        let mut buffer: Vec<u8> = Vec::new();
 
         let mut response_id = String::new();
         let mut text_content = String::new();
@@ -954,32 +1004,32 @@ impl OpenAiClient {
             let chunk = match chunk_result {
                 Ok(c) => c,
                 Err(e) => {
-                    // Connection dropped mid-stream
+                    // Connection dropped mid-stream. Preserve the underlying
+                    // `reqwest::Error` in the chain (rather than stringifying
+                    // it) so upstream timeout/retry classification still works
+                    // — reqwest 0.12 collapses the *Display* to the generic
+                    // "error decoding response body" for all body errors.
                     if chunk_count == 0 {
-                        return Err(anyhow!(
-                            "Stream connection failed before receiving data: {}",
-                            e
-                        ));
+                        return Err(anyhow::Error::new(e)
+                            .context("Stream connection failed before receiving data"));
                     }
                     eprintln!(
                         "[openai-client] Stream interrupted after {} chunks: {}",
-                        chunk_count, e
+                        chunk_count,
+                        describe_reqwest_stream_error(&e)
                     );
                     // If we have a finish_reason, the response is likely complete
                     if finish_reason.is_some() {
                         break;
                     }
-                    return Err(anyhow!(
-                        "Stream interrupted after {} chunks: {}",
-                        chunk_count,
-                        e
-                    ));
+                    return Err(anyhow::Error::new(e)
+                        .context(format!("Stream interrupted after {} chunks", chunk_count)));
                 }
             };
-            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            buffer.extend_from_slice(&chunk);
 
             // Process complete SSE data lines from the buffer
-            while let Some(data) = parse_next_oai_sse_data(&mut buffer) {
+            while let Some(data) = parse_next_oai_sse_data_bytes(&mut buffer) {
                 if data == "[DONE]" {
                     break;
                 }
@@ -1114,7 +1164,9 @@ impl OpenAiClient {
         }
 
         let mut stream = resp.bytes_stream();
-        let mut buffer = String::new();
+        // Raw-byte buffer: reassembles UTF-8 sequences split across chunk
+        // boundaries (see `parse_next_oai_sse_data_bytes`).
+        let mut buffer: Vec<u8> = Vec::new();
         let mut response_id = String::new();
         let mut text_content = String::new();
         let mut reasoning_content = String::new();
@@ -1130,28 +1182,24 @@ impl OpenAiClient {
                 Ok(c) => c,
                 Err(e) => {
                     if chunk_count == 0 {
-                        return Err(anyhow!(
-                            "Stream connection failed before receiving data: {}",
-                            e
-                        ));
+                        return Err(anyhow::Error::new(e)
+                            .context("Stream connection failed before receiving data"));
                     }
                     eprintln!(
                         "[openai-client] Stream interrupted after {} chunks: {}",
-                        chunk_count, e
+                        chunk_count,
+                        describe_reqwest_stream_error(&e)
                     );
                     if finish_reason.is_some() {
                         break;
                     }
-                    return Err(anyhow!(
-                        "Stream interrupted after {} chunks: {}",
-                        chunk_count,
-                        e
-                    ));
+                    return Err(anyhow::Error::new(e)
+                        .context(format!("Stream interrupted after {} chunks", chunk_count)));
                 }
             };
-            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            buffer.extend_from_slice(&chunk);
 
-            while let Some(data) = parse_next_oai_sse_data(&mut buffer) {
+            while let Some(data) = parse_next_oai_sse_data_bytes(&mut buffer) {
                 if data == "[DONE]" {
                     break;
                 }
@@ -1332,6 +1380,9 @@ impl OpenAiClient {
                 .post(url)
                 .headers(headers)
                 .json(request)
+                // Non-streaming returns a single body, so a total-request
+                // timeout is appropriate here (unlike the streaming path).
+                .timeout(Duration::from_secs(NON_STREAMING_TIMEOUT_SECS))
                 .send()
                 .await;
 
@@ -2856,6 +2907,95 @@ fn parse_next_oai_sse_data(buffer: &mut String) -> Option<String> {
     }
 }
 
+/// Byte-oriented variant of [`parse_next_oai_sse_data`].
+///
+/// The streaming loop accumulates **raw bytes** (`Vec<u8>`) rather than a
+/// lossily-decoded `String`, because a network chunk can end in the middle
+/// of a multi-byte UTF-8 sequence. Decoding each chunk with
+/// `String::from_utf8_lossy` *before* re-assembly (the previous behavior)
+/// turned that split sequence into a U+FFFD replacement char, silently
+/// corrupting any non-ASCII output that happened to straddle a chunk
+/// boundary.
+///
+/// Splitting on `\n` (0x0A) is always safe: a UTF-8 continuation/lead byte
+/// is never 0x0A, so a complete SSE line never bisects a multi-byte
+/// character. We therefore only ever decode a *whole* line, where the byte
+/// boundaries are guaranteed valid. (`from_utf8_lossy` on a complete line is
+/// a no-op for well-formed UTF-8 and merely a safety net otherwise.)
+fn parse_next_oai_sse_data_bytes(buffer: &mut Vec<u8>) -> Option<String> {
+    loop {
+        let newline_pos = buffer.iter().position(|&b| b == b'\n')?;
+        let mut line_bytes = buffer[..newline_pos].to_vec();
+        buffer.drain(..newline_pos + 1);
+        if line_bytes.last() == Some(&b'\r') {
+            line_bytes.pop();
+        }
+        let line = String::from_utf8_lossy(&line_bytes);
+        let line = line.as_ref();
+
+        // Skip empty lines (SSE event separators) and comments
+        if line.is_empty() || line.starts_with(':') {
+            continue;
+        }
+
+        // Extract data from "data: ..." lines
+        if let Some(data) = line.strip_prefix("data: ") {
+            return Some(data.to_string());
+        }
+        if let Some(data) = line.strip_prefix("data:") {
+            return Some(data.to_string());
+        }
+
+        // Skip unknown SSE fields (event:, id:, retry:, etc.)
+    }
+}
+
+/// Build a diagnostic description of a streaming body error.
+///
+/// reqwest 0.12's `Response::bytes_stream()` funnels *every* body failure
+/// through `Kind::Decode`, so the bare `Display` is always the unhelpful
+/// "error decoding response body" — whether the real cause was a timeout,
+/// a dropped connection, or a framing error. This classifies the error and
+/// walks its source chain so logs reveal the *actual* cause, which is what
+/// lets a future investigator tell a server-side drop apart from a
+/// client-side timeout without a packet capture.
+fn describe_reqwest_stream_error(e: &reqwest::Error) -> String {
+    let mut kinds = Vec::new();
+    if e.is_timeout() {
+        kinds.push("timeout");
+    }
+    if e.is_connect() {
+        kinds.push("connect");
+    }
+    if e.is_request() {
+        kinds.push("request");
+    }
+    if e.is_body() {
+        kinds.push("body");
+    }
+    if e.is_decode() {
+        kinds.push("decode");
+    }
+    let class = if kinds.is_empty() {
+        "unknown".to_string()
+    } else {
+        kinds.join("+")
+    };
+
+    let mut chain = Vec::new();
+    let mut src = std::error::Error::source(e);
+    while let Some(s) = src {
+        chain.push(s.to_string());
+        src = s.source();
+    }
+
+    if chain.is_empty() {
+        format!("{} [class: {}]", e, class)
+    } else {
+        format!("{} [class: {}; cause: {}]", e, class, chain.join(" -> "))
+    }
+}
+
 /// Assemble a `MessagesResponse` from accumulated streaming state.
 fn assemble_oai_stream_response(
     response_id: String,
@@ -3421,6 +3561,76 @@ mod tests {
         let mut buf = "data: {\"cr\":true}\r\n\r\n".to_string();
         let data = parse_next_oai_sse_data(&mut buf).unwrap();
         assert_eq!(data, r#"{"cr":true}"#);
+    }
+
+    // ── Byte-oriented SSE parsing tests (decode resilience) ───────────────
+
+    #[test]
+    fn test_parse_oai_sse_bytes_basic() {
+        let mut buf = b"data: {\"id\":\"chatcmpl-1\"}\n\n".to_vec();
+        let data = parse_next_oai_sse_data_bytes(&mut buf).unwrap();
+        assert_eq!(data, r#"{"id":"chatcmpl-1"}"#);
+    }
+
+    #[test]
+    fn test_parse_oai_sse_bytes_crlf_and_comments() {
+        let mut buf = b": keep-alive\r\n\r\ndata: {\"ok\":true}\r\n".to_vec();
+        let data = parse_next_oai_sse_data_bytes(&mut buf).unwrap();
+        assert_eq!(data, r#"{"ok":true}"#);
+    }
+
+    #[test]
+    fn test_parse_oai_sse_bytes_incomplete_returns_none() {
+        let mut buf = b"data: {\"partial".to_vec();
+        assert!(parse_next_oai_sse_data_bytes(&mut buf).is_none());
+        assert_eq!(buf, b"data: {\"partial");
+    }
+
+    /// Regression: a multi-byte UTF-8 sequence split across two network
+    /// chunks must be reassembled intact. The old code decoded each chunk
+    /// with `from_utf8_lossy` *before* reassembly, which corrupted the split
+    /// sequence into U+FFFD. With a raw-byte buffer the bytes are joined
+    /// first and only the complete line is decoded.
+    #[test]
+    fn test_parse_oai_sse_bytes_split_multibyte_utf8() {
+        // "世界" + emoji: 3-byte and 4-byte sequences, deliberately split.
+        let payload = "data: {\"content\":\"世界🌍\"}\n";
+        let bytes = payload.as_bytes();
+
+        // Split mid-way through a multi-byte char (byte 18 lands inside one of
+        // the CJK sequences for this payload).
+        let split_at = 18;
+        let (first, second) = bytes.split_at(split_at);
+
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(first);
+        // Incomplete line so far — no full line yet.
+        assert!(parse_next_oai_sse_data_bytes(&mut buf).is_none());
+        buf.extend_from_slice(second);
+
+        let data = parse_next_oai_sse_data_bytes(&mut buf).unwrap();
+        assert_eq!(data, r#"{"content":"世界🌍"}"#);
+        // The parsed JSON round-trips with the exact characters intact.
+        assert!(data.contains("世界🌍"));
+        assert!(!data.contains('\u{FFFD}'));
+    }
+
+    /// Demonstrates the *old* per-chunk decode bug for contrast: decoding
+    /// each raw chunk with `from_utf8_lossy` before reassembly corrupts a
+    /// split multi-byte sequence. This documents why the byte buffer is
+    /// necessary.
+    #[test]
+    fn test_old_per_chunk_lossy_decode_corrupts_split_utf8() {
+        let s = "世界🌍";
+        let bytes = s.as_bytes();
+        let (first, second) = bytes.split_at(2); // mid first CJK char
+        let mut reassembled = String::new();
+        reassembled.push_str(&String::from_utf8_lossy(first));
+        reassembled.push_str(&String::from_utf8_lossy(second));
+        // The per-chunk lossy path injects replacement chars — proving the
+        // bug the byte buffer fixes.
+        assert!(reassembled.contains('\u{FFFD}'));
+        assert_ne!(reassembled, s);
     }
 
     // ── Parse error handling tests ────────────────────────────────────────

--- a/src/executor/native/tools/file.rs
+++ b/src/executor/native/tools/file.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 use tokio::sync::Mutex;
 
 use super::file_cache::FileCache;
+use super::fuzzy_match::{FuzzyOutcome, MatchLevel, fuzzy_replace};
 use super::{Tool, ToolOutput, ToolRegistry, truncate_for_tool};
 use crate::executor::native::client::ToolDefinition;
 
@@ -254,12 +255,15 @@ impl Tool for WriteFileTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "write_file".to_string(),
-            description: "Save content to a file on disk at the given path. Writes are \
-                          restricted to the current working directory tree — paths outside \
-                          cwd are rejected. Use this when the user explicitly asks to save, \
-                          store, create, or modify a file. Do NOT use this to display or \
-                          return content to the user — include it in your text response \
-                          instead."
+            description: "Save content to a file on disk at the given path, replacing the \
+                          entire file. Best for CREATING a new file or a full rewrite. To \
+                          CHANGE an existing file, prefer edit_file with a targeted \
+                          old_string/new_string replacement instead of rewriting the whole \
+                          file — repeatedly rewriting a file to fix small errors is wasteful \
+                          and reintroduces bugs. Writes are restricted to the current working \
+                          directory tree — paths outside cwd are rejected. Do NOT use this to \
+                          display or return content to the user — include it in your text \
+                          response instead."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -326,7 +330,18 @@ impl Tool for EditFileTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "edit_file".to_string(),
-            description: "Perform a string replacement in a file. The old_string must appear exactly once in the file. Optional normalization flags can help match strings with whitespace or line ending differences.".to_string(),
+            description: "PREFERRED way to change an existing file: make a small, targeted \
+                          string replacement instead of rewriting the whole file with \
+                          write_file. Replaces old_string with new_string. Matching is \
+                          robust — whitespace, indentation, and line endings (\\n vs \\r\\n) \
+                          are matched leniently, and the replacement is re-indented to the \
+                          file's actual indentation, so you do NOT need byte-perfect old_string. \
+                          old_string must identify a unique location; include a few surrounding \
+                          lines for context if it would otherwise be ambiguous. If it can't be \
+                          matched you get a near-miss diagnostic showing the closest line — fix \
+                          old_string and retry rather than falling back to a full rewrite. After \
+                          a failed build, fix each error with a focused edit_file call."
+                .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -336,19 +351,19 @@ impl Tool for EditFileTool {
                     },
                     "old_string": {
                         "type": "string",
-                        "description": "The exact text to find and replace"
+                        "description": "The text to find and replace. Whitespace/indentation/line-ending differences are tolerated; it must identify a unique location (add surrounding context lines if needed)."
                     },
                     "new_string": {
                         "type": "string",
-                        "description": "The replacement text"
+                        "description": "The replacement text. It is automatically re-indented to match the file when indentation is the only difference."
                     },
                     "normalize_whitespace": {
                         "type": "boolean",
-                        "description": "Normalize whitespace (spaces, tabs) before matching. When enabled, sequences of whitespace characters are treated as equivalent. Default: false"
+                        "description": "Opt-in: also collapse runs of interior whitespace when matching (e.g. treat 'a  b' and 'a b' as equal). Off by default to avoid over-matching. Leading/trailing whitespace, indentation, and line endings are ALREADY tolerated without this flag."
                     },
                     "normalize_line_endings": {
                         "type": "boolean",
-                        "description": "Treat \\n and \\r\\n as equivalent when matching. When enabled, both Windows and Unix line endings are treated as the same. Default: false"
+                        "description": "Deprecated/no-op: \\n and \\r\\n are always treated as equivalent now. Accepted for backward compatibility."
                     }
                 },
                 "required": ["path", "old_string", "new_string"]
@@ -369,14 +384,16 @@ impl Tool for EditFileTool {
             Some(s) => s,
             None => return ToolOutput::error("Missing required parameter: new_string".to_string()),
         };
-        let normalize_whitespace = input
+        // `normalize_whitespace` is an opt-in to ALSO collapse interior
+        // whitespace (the most aggressive level). Leading/trailing whitespace,
+        // indentation, and line endings are tolerated automatically without
+        // any flag. `normalize_line_endings` is now a no-op (always on) and is
+        // read only to stay backward-compatible with callers that set it.
+        let allow_collapse = input
             .get("normalize_whitespace")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        let normalize_line_endings = input
-            .get("normalize_line_endings")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+        let _ = input.get("normalize_line_endings");
 
         let safe_path = match resolve_inside_cwd(path_input, yolo_enabled()) {
             Ok(p) => p,
@@ -390,182 +407,30 @@ impl Tool for EditFileTool {
             Err(e) => return ToolOutput::error(format!("Failed to read file '{}': {}", path, e)),
         };
 
-        // Determine the normalized versions of content and old_string for matching
-        let (normalized_content, normalized_old) = if normalize_whitespace || normalize_line_endings
-        {
-            let content_normalized = if normalize_line_endings {
-                normalize_line_endings_str(&content)
-            } else {
-                content.clone()
-            };
-            let old_normalized = if normalize_line_endings {
-                normalize_line_endings_str(old_string)
-            } else {
-                old_string.to_string()
-            };
-
-            // Apply whitespace normalization if requested
-            let content_normalized = if normalize_whitespace {
-                normalize_whitespace_str(&content_normalized)
-            } else {
-                content_normalized
-            };
-            let old_normalized = if normalize_whitespace {
-                normalize_whitespace_str(&old_normalized)
-            } else {
-                old_normalized
-            };
-
-            (content_normalized, old_normalized)
-        } else {
-            (content.clone(), old_string.to_string())
-        };
-
-        let count = normalized_content.matches(&normalized_old).count();
-        if count == 0 {
-            return ToolOutput::error(format!(
-                "old_string not found in '{}'. Make sure the string matches exactly.",
-                path
-            ));
-        }
-        if count > 1 {
-            return ToolOutput::error(format!(
-                "old_string found {} times in '{}'. It must be unique. Provide more context.",
-                count, path
-            ));
-        }
-
-        // Find the actual position in the original (non-normalized) content
-        let start_pos = match normalized_content.find(&normalized_old) {
-            Some(pos) => pos,
-            None => {
-                return ToolOutput::error(format!(
-                    "old_string not found in '{}'. Make sure the string matches exactly.",
-                    path
-                ));
-            }
-        };
-
-        // Calculate the end position in the normalized string
-        let end_pos = start_pos + normalized_old.len();
-
-        // Now find the corresponding positions in the original content
-        let original_start = if normalize_whitespace || normalize_line_endings {
-            find_original_position(
-                &content,
-                &normalized_content,
-                start_pos,
-                normalize_whitespace,
-                normalize_line_endings,
-            )
-        } else {
-            start_pos
-        };
-        let original_end = if normalize_whitespace || normalize_line_endings {
-            find_original_position(
-                &content,
-                &normalized_content,
-                end_pos,
-                normalize_whitespace,
-                normalize_line_endings,
-            )
-        } else {
-            end_pos
-        };
-
-        // Perform the replacement using the original positions
-        let mut new_content = content[..original_start].to_string();
-        new_content.push_str(new_string);
-        new_content.push_str(&content[original_end..]);
-
-        match fs::write(path, &new_content) {
-            Ok(()) => ToolOutput::success(format!("Successfully edited {}", path)),
-            Err(e) => ToolOutput::error(format!("Failed to write file '{}': {}", path, e)),
-        }
-    }
-}
-
-/// Normalize line endings: convert \r\n to \n
-fn normalize_line_endings_str(s: &str) -> String {
-    s.replace("\r\n", "\n")
-}
-
-/// Normalize whitespace: collapse multiple whitespace to single space
-fn normalize_whitespace_str(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut last_was_whitespace = false;
-    for c in s.chars() {
-        if c.is_whitespace() {
-            if !last_was_whitespace {
-                result.push(' ');
-                last_was_whitespace = true;
-            }
-        } else {
-            result.push(c);
-            last_was_whitespace = false;
-        }
-    }
-    result
-}
-
-/// Find the corresponding position in the original string for a position in the normalized string.
-/// This is needed because normalization can change string length.
-fn find_original_position(
-    original: &str,
-    normalized: &str,
-    normalized_pos: usize,
-    normalize_ws: bool,
-    normalize_le: bool,
-) -> usize {
-    if !normalize_ws && !normalize_le {
-        return normalized_pos;
-    }
-
-    let mut orig_pos = 0;
-    let mut norm_pos = 0;
-    let mut orig_chars = original.chars().peekable();
-    let mut norm_chars = normalized.chars().peekable();
-
-    while norm_pos < normalized_pos {
-        let norm_char = match norm_chars.next() {
-            Some(c) => c,
-            None => break,
-        };
-
-        // Advance through original to find matching position
-        if normalize_le && norm_char == '\n' {
-            // In normalized string, \n represents both \n and \r\n
-            let remaining: String = orig_chars.clone().collect();
-            if remaining.starts_with("\r\n") {
-                orig_chars.next();
-                orig_chars.next();
-                orig_pos += 2;
-            } else if remaining.starts_with('\n') {
-                orig_chars.next();
-                orig_pos += 1;
-            }
-            norm_pos += 1;
-        } else if normalize_ws && norm_char == ' ' {
-            // Skip all whitespace in original
-            while let Some(&c) = orig_chars.peek() {
-                if c.is_whitespace() {
-                    orig_chars.next();
-                    orig_pos += c.len_utf8();
-                } else {
-                    break;
+        match fuzzy_replace(&content, old_string, new_string, allow_collapse) {
+            FuzzyOutcome::Unique { new_content, level } => match fs::write(path, &new_content) {
+                Ok(()) => {
+                    let note = if level == MatchLevel::Exact {
+                        format!("Successfully edited {}", path)
+                    } else {
+                        format!("Successfully edited {} ({} match)", path, level.label())
+                    };
+                    ToolOutput::success(note)
                 }
+                Err(e) => ToolOutput::error(format!("Failed to write file '{}': {}", path, e)),
+            },
+            FuzzyOutcome::Ambiguous { count, level } => ToolOutput::error(format!(
+                "old_string found {} times in '{}' ({} match). It must be unique — \
+                 provide more surrounding context so it identifies a single location.",
+                count,
+                path,
+                level.label()
+            )),
+            FuzzyOutcome::NoMatch { diagnostic } => {
+                ToolOutput::error(format!("{} in '{}'", diagnostic, path))
             }
-            norm_pos += 1;
-        } else {
-            // Regular character - consume one from original
-            if let Some(c) = orig_chars.next() {
-                orig_pos += c.len_utf8();
-            }
-            norm_pos += 1;
         }
     }
-
-    orig_pos
 }
 
 // ── glob ────────────────────────────────────────────────────────────────

--- a/src/executor/native/tools/fuzzy_match.rs
+++ b/src/executor/native/tools/fuzzy_match.rs
@@ -1,0 +1,622 @@
+//! Fuzzy / robust string matching for the `edit_file` tool.
+//!
+//! ## Why this exists
+//!
+//! A strict EXACT-MATCH `edit_file` is the single biggest cause of
+//! full-file-rewrite thrash on local / weaker models: the model reads a
+//! file, tries a targeted `old_string` edit, gets the indentation or a
+//! trailing space slightly wrong, the edit fails with a bare "not found",
+//! and the model gives up and rewrites the whole file with `write_file`
+//! instead (re-introducing bugs, burning tokens and latency). This was
+//! observed directly while watching qwen3 build a TUI — `main.rs` rewritten
+//! 4× (2.3KB → 17KB → 19.5KB → …) rather than patched.
+//!
+//! ## What this does
+//!
+//! [`fuzzy_replace`] runs a strictness cascade, strict → loose, and accepts
+//! the first level that yields exactly one match:
+//!
+//! 1. **Exact substring** — byte-for-byte (preserves within-line edits and
+//!    the historical semantics).
+//! 2. **Line-based, line-ending tolerant** — `\n` ≡ `\r\n`, and a final line
+//!    with/without a trailing newline.
+//! 3. **+ trailing-whitespace tolerant** — ignore trailing spaces/tabs per
+//!    line.
+//! 4. **+ indentation tolerant** — ignore *leading* whitespace per line; the
+//!    replacement is re-indented to the file's actual indentation so the edit
+//!    lands correctly formatted.
+//! 5. **+ internal-whitespace collapse** — OPT-IN only (the caller's
+//!    `normalize_whitespace` flag). Off by default because collapsing
+//!    interior whitespace can match semantically different code.
+//!
+//! On no match at any level it returns a **near-miss diagnostic** that shows
+//! the closest candidate block in the file side-by-side with the requested
+//! `old_string`, so the model can correct the edit instead of falling back to
+//! a rewrite.
+//!
+//! ## Design note — why fuzzy str-replace, not apply_patch / search-replace blocks
+//!
+//! See `docs/research/nex-fuzzy-edit-design.md` for the full rationale. In
+//! short: `edit_file` is already the canonical, audited tool surface; making
+//! its matching tolerant is strictly higher-leverage and lower-risk than
+//! introducing a second diff/patch wire format (apply_patch V4A / Aider
+//! search-replace), and the indentation re-anchoring here gives most of what
+//! Aider's fuzzy-context blocks provide without a new tool.
+
+/// Strictness levels, tried in order from strict to loose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MatchLevel {
+    /// Byte-for-byte substring match.
+    Exact,
+    /// Line-based; `\n` ≡ `\r\n` and trailing-newline-at-EOF tolerant.
+    LineEndings,
+    /// Additionally ignore trailing whitespace per line.
+    TrailingWs,
+    /// Additionally ignore leading whitespace (indentation) per line.
+    Indentation,
+    /// Additionally collapse runs of interior whitespace (opt-in).
+    Collapse,
+}
+
+impl MatchLevel {
+    /// Human-readable label for diagnostics / success notes.
+    pub fn label(self) -> &'static str {
+        match self {
+            MatchLevel::Exact => "exact",
+            MatchLevel::LineEndings => "line-ending-insensitive",
+            MatchLevel::TrailingWs => "trailing-whitespace-insensitive",
+            MatchLevel::Indentation => "indentation-insensitive",
+            MatchLevel::Collapse => "whitespace-insensitive",
+        }
+    }
+}
+
+/// Outcome of [`fuzzy_replace`].
+#[derive(Debug)]
+pub enum FuzzyOutcome {
+    /// Exactly one match. `new_content` is the full updated file body.
+    Unique {
+        new_content: String,
+        level: MatchLevel,
+    },
+    /// `old_string` matched in more than one place at the first level that
+    /// matched at all. The caller should ask the model for more context.
+    Ambiguous { count: usize, level: MatchLevel },
+    /// No match at any enabled level. `diagnostic` is a ready-to-return,
+    /// model-facing message including the closest candidate.
+    NoMatch { diagnostic: String },
+}
+
+/// Replace `old` with `new` in `content` using the strictness cascade.
+///
+/// `allow_collapse` enables the most aggressive interior-whitespace-collapse
+/// level (the caller's opt-in `normalize_whitespace` flag).
+pub fn fuzzy_replace(content: &str, old: &str, new: &str, allow_collapse: bool) -> FuzzyOutcome {
+    if old.is_empty() {
+        return FuzzyOutcome::NoMatch {
+            diagnostic: "old_string is empty — provide the text to replace.".to_string(),
+        };
+    }
+
+    // ── Level 1: exact substring (fast path, within-line capable) ──────────
+    let exact_count = content.matches(old).count();
+    if exact_count == 1 {
+        let start = content.find(old).expect("counted one match");
+        let mut new_content = String::with_capacity(content.len() + new.len());
+        new_content.push_str(&content[..start]);
+        new_content.push_str(new);
+        new_content.push_str(&content[start + old.len()..]);
+        return FuzzyOutcome::Unique {
+            new_content,
+            level: MatchLevel::Exact,
+        };
+    }
+    if exact_count > 1 {
+        return FuzzyOutcome::Ambiguous {
+            count: exact_count,
+            level: MatchLevel::Exact,
+        };
+    }
+
+    // ── Levels 2-5: line-based cascade ─────────────────────────────────────
+    let file_lines = split_inclusive_lines(content);
+    let old_lines = split_inclusive_lines(old);
+    let n = old_lines.len();
+
+    // A single within-line fragment that didn't exact-match cannot be matched
+    // by whole-line comparison; fall straight to diagnostics.
+    if n == 0 {
+        return FuzzyOutcome::NoMatch {
+            diagnostic: format!("old_string not found. {}", no_match_hint()),
+        };
+    }
+
+    let file_bodies: Vec<&str> = file_lines.iter().map(|l| line_body(l)).collect();
+    let old_bodies: Vec<&str> = old_lines.iter().map(|l| line_body(l)).collect();
+
+    let mut levels = vec![
+        MatchLevel::LineEndings,
+        MatchLevel::TrailingWs,
+        MatchLevel::Indentation,
+    ];
+    if allow_collapse {
+        levels.push(MatchLevel::Collapse);
+    }
+
+    for level in levels {
+        let starts = find_windows(&file_bodies, &old_bodies, level);
+        match starts.len() {
+            0 => continue,
+            1 => {
+                let new_content = build_replacement(
+                    &file_lines,
+                    &file_bodies,
+                    &old_bodies,
+                    starts[0],
+                    n,
+                    new,
+                    level,
+                );
+                return FuzzyOutcome::Unique { new_content, level };
+            }
+            count => return FuzzyOutcome::Ambiguous { count, level },
+        }
+    }
+
+    // ── No match anywhere: build a near-miss diagnostic ────────────────────
+    FuzzyOutcome::NoMatch {
+        diagnostic: near_miss_diagnostic(&file_bodies, &old_bodies),
+    }
+}
+
+/// Split `s` into lines, each element INCLUDING its trailing terminator
+/// (`\n` or `\r\n`). A final line without a terminator is included as-is.
+fn split_inclusive_lines(s: &str) -> Vec<&str> {
+    if s.is_empty() {
+        return Vec::new();
+    }
+    s.split_inclusive('\n').collect()
+}
+
+/// The body of a line: the text with any trailing `\n` / `\r\n` removed.
+fn line_body(line: &str) -> &str {
+    let l = line.strip_suffix('\n').unwrap_or(line);
+    l.strip_suffix('\r').unwrap_or(l)
+}
+
+/// Leading whitespace (spaces / tabs) prefix of a string.
+fn leading_ws(s: &str) -> &str {
+    let end = s.find(|c: char| c != ' ' && c != '\t').unwrap_or(s.len());
+    &s[..end]
+}
+
+/// Normalize a line body for comparison at the given strictness level.
+fn norm(body: &str, level: MatchLevel) -> String {
+    match level {
+        MatchLevel::Exact | MatchLevel::LineEndings => body.to_string(),
+        MatchLevel::TrailingWs => body.trim_end().to_string(),
+        MatchLevel::Indentation => body.trim().to_string(),
+        MatchLevel::Collapse => collapse_ws(body.trim()),
+    }
+}
+
+/// Collapse every run of interior whitespace to a single space.
+fn collapse_ws(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_ws = false;
+    for c in s.chars() {
+        if c.is_whitespace() {
+            if !prev_ws {
+                out.push(' ');
+                prev_ws = true;
+            }
+        } else {
+            out.push(c);
+            prev_ws = false;
+        }
+    }
+    out
+}
+
+/// Find every start index in `file_bodies` where a window of `old_bodies.len()`
+/// lines matches `old_bodies` under `level` normalization.
+fn find_windows(file_bodies: &[&str], old_bodies: &[&str], level: MatchLevel) -> Vec<usize> {
+    let n = old_bodies.len();
+    let mut starts = Vec::new();
+    if n == 0 || n > file_bodies.len() {
+        return starts;
+    }
+    let old_norm: Vec<String> = old_bodies.iter().map(|b| norm(b, level)).collect();
+    for start in 0..=(file_bodies.len() - n) {
+        if (0..n).all(|k| norm(file_bodies[start + k], level) == old_norm[k]) {
+            starts.push(start);
+        }
+    }
+    starts
+}
+
+/// Build the full updated file content by replacing the matched line window
+/// `[start, start+n)` with `new`, preserving the file's newline style and
+/// re-indenting `new` to the file's actual indentation when the match ignored
+/// leading whitespace.
+fn build_replacement(
+    file_lines: &[&str],
+    file_bodies: &[&str],
+    old_bodies: &[&str],
+    start: usize,
+    n: usize,
+    new: &str,
+    level: MatchLevel,
+) -> String {
+    let prefix: String = file_lines[..start].concat();
+    let suffix: String = file_lines[start + n..].concat();
+
+    // Newline style + whether the matched block ended with a terminator.
+    let term = if file_lines[start].ends_with("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let last_has_terminator = file_lines[start + n - 1].ends_with('\n');
+
+    // Replacement lines (terminators stripped; rejoined with `term`).
+    let mut new_bodies: Vec<String> = split_inclusive_lines(new)
+        .iter()
+        .map(|l| line_body(l).to_string())
+        .collect();
+    // `new` non-empty but with no interior newline still yields one body;
+    // a truly empty `new` yields none → the block is deleted.
+    if new.is_empty() {
+        new_bodies.clear();
+    }
+
+    // Re-indent only when the match ignored leading whitespace.
+    if level >= MatchLevel::Indentation && !new_bodies.is_empty() {
+        let old_base = old_bodies
+            .iter()
+            .find(|b| !b.trim().is_empty())
+            .map(|b| leading_ws(b))
+            .unwrap_or("");
+        let file_base = file_bodies[start..start + n]
+            .iter()
+            .find(|b| !b.trim().is_empty())
+            .map(|b| leading_ws(b))
+            .unwrap_or("");
+        if old_base != file_base {
+            for body in new_bodies.iter_mut() {
+                if body.trim().is_empty() {
+                    continue; // leave blank lines untouched
+                }
+                if !old_base.is_empty() && body.starts_with(old_base) {
+                    *body = format!("{}{}", file_base, &body[old_base.len()..]);
+                } else if old_base.is_empty() {
+                    *body = format!("{}{}", file_base, body);
+                }
+            }
+        }
+    }
+
+    let mut middle = new_bodies.join(term);
+    if last_has_terminator && !new_bodies.is_empty() {
+        middle.push_str(term);
+    }
+
+    let mut out = String::with_capacity(prefix.len() + middle.len() + suffix.len());
+    out.push_str(&prefix);
+    out.push_str(&middle);
+    out.push_str(&suffix);
+    out
+}
+
+/// Generic hint appended to no-match diagnostics.
+fn no_match_hint() -> &'static str {
+    "Re-read the file and copy the target text exactly (whitespace and \
+     indentation are matched leniently, so small formatting differences are \
+     fine), then retry edit_file. Do NOT rewrite the whole file with \
+     write_file — make a targeted edit."
+}
+
+/// Build a near-miss diagnostic: find the closest line window and show it
+/// side-by-side with the requested `old_string`.
+fn near_miss_diagnostic(file_bodies: &[&str], old_bodies: &[&str]) -> String {
+    let n = old_bodies.len();
+    let mut msg = String::new();
+    msg.push_str(
+        "old_string not found (tried exact, line-ending, trailing-whitespace, and \
+                  indentation-insensitive matching).\n",
+    );
+
+    if let Some((start, matched)) = best_window(file_bodies, old_bodies) {
+        let span_end = (start + n).min(file_bodies.len());
+        msg.push_str(&format!(
+            "Closest candidate at lines {}-{} ({}/{} lines align). Compare:\n\n",
+            start + 1,
+            span_end,
+            matched,
+            n
+        ));
+        // Cap the rendered block so huge edits don't flood the model.
+        let cap = 30usize;
+        let shown = n.min(cap);
+        for k in 0..shown {
+            let want = old_bodies[k];
+            let got = file_bodies.get(start + k).copied().unwrap_or("");
+            let mark = if want.trim() == got.trim() {
+                " "
+            } else {
+                "✗"
+            };
+            msg.push_str(&format!(
+                "  {} your old_string: {}\n",
+                mark,
+                truncate_line(want)
+            ));
+            msg.push_str(&format!(
+                "  {} file (line {:>4}): {}\n",
+                mark,
+                start + k + 1,
+                truncate_line(got)
+            ));
+        }
+        if n > cap {
+            msg.push_str(&format!("  … ({} more lines omitted)\n", n - cap));
+        }
+        msg.push('\n');
+    } else {
+        msg.push_str("No similar block was found in the file.\n\n");
+    }
+
+    msg.push_str(no_match_hint());
+    msg
+}
+
+/// Truncate a single line for diagnostic display.
+fn truncate_line(s: &str) -> String {
+    const MAX: usize = 120;
+    if s.len() <= MAX {
+        s.to_string()
+    } else {
+        let end = s.floor_char_boundary(MAX);
+        format!("{}…", &s[..end])
+    }
+}
+
+/// Find the window (of length = old_bodies.len()) in the file with the most
+/// trim-equal lines. Returns (start_index, matched_line_count). Ties broken by
+/// the earliest position. Returns None if the file has no lines.
+fn best_window(file_bodies: &[&str], old_bodies: &[&str]) -> Option<(usize, usize)> {
+    let n = old_bodies.len();
+    if file_bodies.is_empty() || n == 0 {
+        return None;
+    }
+    // If old is longer than the file, anchor at 0 and score what overlaps.
+    let last_start = file_bodies.len().saturating_sub(n);
+    let mut best: Option<(usize, usize, usize)> = None; // (start, matched, prefix_score)
+    for start in 0..=last_start {
+        let mut matched = 0usize;
+        let mut prefix_score = 0usize;
+        for k in 0..n {
+            let want = old_bodies[k].trim();
+            let got = file_bodies.get(start + k).map(|s| s.trim()).unwrap_or("");
+            if want == got {
+                matched += 1;
+                prefix_score += want.len();
+            } else {
+                prefix_score += common_prefix_len(want, got);
+            }
+        }
+        let better = match best {
+            None => true,
+            Some((_, bm, bp)) => matched > bm || (matched == bm && prefix_score > bp),
+        };
+        if better {
+            best = Some((start, matched, prefix_score));
+        }
+    }
+    best.map(|(s, m, _)| (s, m))
+}
+
+/// Length (in bytes) of the common leading prefix of two strings.
+fn common_prefix_len(a: &str, b: &str) -> usize {
+    a.bytes().zip(b.bytes()).take_while(|(x, y)| x == y).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique(content: &str, old: &str, new: &str) -> (String, MatchLevel) {
+        match fuzzy_replace(content, old, new, false) {
+            FuzzyOutcome::Unique { new_content, level } => (new_content, level),
+            other => panic!("expected unique match, got {:?}", other),
+        }
+    }
+
+    // ── exact ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn exact_substring_within_line() {
+        let (out, level) = unique("let x = 1;", "x = 1", "y = 2");
+        assert_eq!(out, "let y = 2;");
+        assert_eq!(level, MatchLevel::Exact);
+    }
+
+    #[test]
+    fn exact_multiline_block() {
+        let (out, _) = unique("a\nb\nc\n", "a\nb", "A\nB");
+        assert_eq!(out, "A\nB\nc\n");
+    }
+
+    // ── trailing whitespace ────────────────────────────────────────────────
+
+    #[test]
+    fn tolerates_trailing_whitespace_in_file() {
+        // File line has trailing spaces; old_string does not.
+        let (out, level) = unique("code   \nnext", "code\nnext", "CODE\nNEXT");
+        assert_eq!(out, "CODE\nNEXT");
+        assert_eq!(level, MatchLevel::TrailingWs);
+    }
+
+    #[test]
+    fn tolerates_trailing_whitespace_in_old_string() {
+        // old_string has a trailing space the file lacks.
+        let (out, _) = unique("hello world", "hello world ", "hi there");
+        assert_eq!(out, "hi there");
+    }
+
+    // ── line endings ───────────────────────────────────────────────────────
+
+    #[test]
+    fn tolerates_crlf_vs_lf() {
+        let (out, level) = unique("line1\r\nline2\r\nline3\r\n", "line1\nline2", "A\nB");
+        assert_eq!(out, "A\r\nB\r\nline3\r\n");
+        assert_eq!(level, MatchLevel::LineEndings);
+    }
+
+    #[test]
+    fn tolerates_missing_trailing_newline() {
+        let (out, _) = unique("line1\n", "line1", "LINE1");
+        assert_eq!(out, "LINE1\n");
+    }
+
+    // ── indentation ────────────────────────────────────────────────────────
+
+    #[test]
+    fn tolerates_indentation_and_reindents_replacement() {
+        // File indents the block with 2 spaces; the model supplied it with 4.
+        // (Fewer-space indentation would be an exact substring of more, so the
+        // file must be LESS indented than old_string to actually exercise the
+        // indentation level rather than the exact fast path.)
+        let content = "fn f() {\n  let x = 1;\n}\n";
+        let (out, level) = unique(content, "    let x = 1;", "    let x = 42;");
+        // Replacement re-indented to the file's 2-space indentation.
+        assert_eq!(out, "fn f() {\n  let x = 42;\n}\n");
+        assert_eq!(level, MatchLevel::Indentation);
+    }
+
+    #[test]
+    fn tolerates_tab_vs_space_indentation() {
+        let content = "function() {\n\tindent\n}";
+        let (out, level) = unique(content, "    indent", "        NEW");
+        assert!(out.contains("NEW"), "got: {:?}", out);
+        assert_eq!(level, MatchLevel::Indentation);
+    }
+
+    #[test]
+    fn reindents_multiline_block_preserving_relative_indent() {
+        let content = "class C:\n    def m(self):\n        pass\n";
+        // Model supplies the body at top level (no indent); file has 8 spaces.
+        let (out, _) = unique(content, "        pass", "        x = 1\n        return x");
+        assert_eq!(
+            out,
+            "class C:\n    def m(self):\n        x = 1\n        return x\n"
+        );
+    }
+
+    // ── collapse is opt-in ─────────────────────────────────────────────────
+
+    #[test]
+    fn interior_whitespace_not_collapsed_by_default() {
+        // "hello world" (one space) must NOT match "hello   world" (three).
+        match fuzzy_replace("hello   world", "hello world", "x", false) {
+            FuzzyOutcome::NoMatch { .. } => {}
+            other => panic!("expected NoMatch without collapse, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn interior_whitespace_collapsed_when_opted_in() {
+        match fuzzy_replace("hello   world", "hello world", "hi", true) {
+            FuzzyOutcome::Unique { new_content, level } => {
+                assert_eq!(new_content, "hi");
+                assert_eq!(level, MatchLevel::Collapse);
+            }
+            other => panic!("expected collapse match, got {:?}", other),
+        }
+    }
+
+    // ── ambiguity ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn exact_multiple_matches_is_ambiguous() {
+        match fuzzy_replace("foo foo foo", "foo", "bar", false) {
+            FuzzyOutcome::Ambiguous { count, level } => {
+                assert_eq!(count, 3);
+                assert_eq!(level, MatchLevel::Exact);
+            }
+            other => panic!("expected ambiguous, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fuzzy_multiple_matches_is_ambiguous() {
+        // old_string "  foo" is not an exact substring (file uses a tab and a
+        // single space), but two lines match under indentation tolerance.
+        let content = "\tfoo\nbar\n foo\n";
+        match fuzzy_replace(content, "  foo", "FOO", false) {
+            FuzzyOutcome::Ambiguous { count, level } => {
+                assert_eq!(count, 2);
+                assert_eq!(level, MatchLevel::Indentation);
+            }
+            other => panic!("expected ambiguous fuzzy, got {:?}", other),
+        }
+    }
+
+    // ── near-miss diagnostics ──────────────────────────────────────────────
+
+    #[test]
+    fn no_match_returns_near_miss_with_candidate() {
+        let content = "fn main() {\n    let total = compute();\n    println!(\"{total}\");\n}\n";
+        let diag = match fuzzy_replace(
+            content,
+            "let totals = compute();",
+            "let total = compute();",
+            false,
+        ) {
+            FuzzyOutcome::NoMatch { diagnostic } => diagnostic,
+            other => panic!("expected NoMatch, got {:?}", other),
+        };
+        assert!(diag.contains("not found"), "diag: {}", diag);
+        assert!(diag.contains("Closest candidate"), "diag: {}", diag);
+        // Points at the real line and shows the file's actual text.
+        assert!(diag.contains("compute()"), "diag: {}", diag);
+        // Steers away from full rewrites.
+        assert!(diag.contains("write_file"), "diag: {}", diag);
+    }
+
+    #[test]
+    fn no_match_empty_old_string() {
+        match fuzzy_replace("anything", "", "x", false) {
+            FuzzyOutcome::NoMatch { diagnostic } => assert!(diagnostic.contains("empty")),
+            other => panic!("expected NoMatch, got {:?}", other),
+        }
+    }
+
+    // ── deletion ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_replacement_deletes_matched_block() {
+        // Indentation mismatch forces the line-based path, which deletes the
+        // whole matched line (terminator included) rather than leaving a blank.
+        let (out, level) = unique("a\n  remove me\nb\n", "    remove me", "");
+        assert_eq!(out, "a\nb\n");
+        assert_eq!(level, MatchLevel::Indentation);
+    }
+
+    #[test]
+    fn exact_empty_replacement_deletes_substring_only() {
+        // When old_string is an exact substring, only that substring is
+        // removed (historical behavior) — include the newline for a full line.
+        let (out, level) = unique("a\nremove me\nb\n", "remove me", "");
+        assert_eq!(out, "a\n\nb\n");
+        assert_eq!(level, MatchLevel::Exact);
+    }
+
+    // ── unicode safety ─────────────────────────────────────────────────────
+
+    #[test]
+    fn unicode_lines_match_and_truncation_is_char_safe() {
+        let (out, _) = unique("héllo\nwörld\n", "wörld", "wörld!");
+        assert_eq!(out, "héllo\nwörld!\n");
+    }
+}

--- a/src/executor/native/tools/mod.rs
+++ b/src/executor/native/tools/mod.rs
@@ -10,6 +10,7 @@ pub mod deep_research;
 pub mod delegate;
 pub mod file;
 pub mod file_cache;
+pub mod fuzzy_match;
 pub mod helper_routing;
 pub mod map;
 pub mod progress;

--- a/tests/integration_nex_streaming_resilience.rs
+++ b/tests/integration_nex_streaming_resilience.rs
@@ -1,0 +1,393 @@
+//! Streaming resilience tests for the OpenAI-compatible (`nex`) client.
+//!
+//! These reproduce — deterministically, against an in-process mock TCP SSE
+//! server — the failure the user reported against a local llama.cpp endpoint:
+//!
+//!   [openai-client] Stream interrupted after ~6300 chunks: error decoding
+//!   response body
+//!
+//! ## Root-cause evidence
+//!
+//! With reqwest 0.12, `Response::bytes_stream()` funnels *every* body error
+//! through `Kind::Decode`, whose `Display` is the generic
+//! "error decoding response body" — so a total-request timeout firing
+//! mid-stream, a dropped connection, and a framing error are all
+//! indistinguishable from the message alone. The client used to set a 300s
+//! **total** request timeout, which capped a long-but-healthy generation
+//! around the 300s mark (≈6300 tokens at a steady local rate) and surfaced as
+//! exactly that cryptic error. The fix replaces the total timeout on the
+//! streaming path with a per-read (idle) timeout, which resets on every
+//! frame and so never kills a healthy stream.
+//!
+//! - [`total_timeout_reproduces_the_symptom`] proves a total timeout firing
+//!   mid-stream yields `is_timeout() == true` *and* Display
+//!   "error decoding response body" — i.e. it reproduces the symptom and
+//!   shows the message hides the real cause.
+//! - [`fixed_client_completes_a_long_slow_stream`] proves the shipped client
+//!   (read-timeout, no total cap) rides out a slow generation that the total
+//!   timeout would have cut, returning the full content.
+//! - [`read_timeout_aborts_only_a_stalled_stream`] proves the read-timeout we
+//!   rely on still protects against a genuinely stalled / dropped upstream,
+//!   without harming a slow-but-alive one.
+//! - [`connection_drop_then_retry_recovers`] proves a mid-stream connection
+//!   drop is handled by the retry path and recovers seamlessly.
+//! - [`split_multibyte_utf8_is_reassembled`] proves a multi-byte UTF-8
+//!   sequence split across network chunks is decoded intact (the byte-buffer
+//!   SSE parser), not corrupted into U+FFFD.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+
+use futures_util::StreamExt;
+
+use worksgood::executor::native::client::{ContentBlock, Message, MessagesRequest, Role};
+use worksgood::executor::native::openai_client::OpenAiClient;
+use worksgood::executor::native::provider::Provider;
+
+// ---------------------------------------------------------------------------
+// Mock SSE server (chunked transfer-encoding, controllable timing/drops)
+// ---------------------------------------------------------------------------
+
+const CHUNKED_HEADERS: &str = "HTTP/1.1 200 OK\r\n\
+     Content-Type: text/event-stream\r\n\
+     Cache-Control: no-cache\r\n\
+     Transfer-Encoding: chunked\r\n\
+     \r\n";
+
+/// Write one HTTP chunked-transfer chunk wrapping `body` bytes.
+fn write_http_chunk(stream: &mut TcpStream, body: &[u8]) -> std::io::Result<()> {
+    write!(stream, "{:X}\r\n", body.len())?;
+    stream.write_all(body)?;
+    stream.write_all(b"\r\n")?;
+    stream.flush()
+}
+
+/// Terminating zero-length chunk — marks a *clean* end of the chunked body.
+fn write_http_end(stream: &mut TcpStream) -> std::io::Result<()> {
+    stream.write_all(b"0\r\n\r\n")?;
+    stream.flush()
+}
+
+/// Drain the inbound HTTP request (headers + small JSON body) so the client's
+/// write side doesn't get reset while we stream the response back.
+fn drain_request(stream: &mut TcpStream) {
+    stream
+        .set_read_timeout(Some(Duration::from_millis(250)))
+        .ok();
+    let mut buf = [0u8; 8192];
+    let _ = stream.read(&mut buf);
+}
+
+/// One OpenAI streaming token frame carrying `content`.
+fn token_frame(content: &str) -> String {
+    format!(
+        "data: {{\"id\":\"gen-mock\",\"choices\":[{{\"index\":0,\"delta\":{{\"content\":{}}},\"finish_reason\":null}}]}}\n\n",
+        serde_json::to_string(content).unwrap()
+    )
+}
+
+/// The final stop frame + `[DONE]` sentinel.
+fn done_frames() -> String {
+    "data: {\"id\":\"gen-mock\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+     data: [DONE]\n\n"
+        .to_string()
+}
+
+/// Spawn a mock server. `handler(conn_idx, stream)` runs per accepted
+/// connection (so retries can behave differently). Returns the base URL.
+fn spawn_mock<F>(handler: F) -> String
+where
+    F: Fn(usize, &mut TcpStream) + Send + Sync + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    std::thread::spawn(move || {
+        let mut conn_idx = 0usize;
+        for incoming in listener.incoming() {
+            match incoming {
+                Ok(mut stream) => {
+                    handler(conn_idx, &mut stream);
+                    conn_idx += 1;
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    url
+}
+
+fn test_request() -> MessagesRequest {
+    MessagesRequest {
+        model: "mock-model".to_string(),
+        max_tokens: 4096,
+        system: Some("test".to_string()),
+        messages: vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: "stream please".to_string(),
+            }],
+        }],
+        tools: vec![],
+        stream: true,
+    }
+}
+
+fn response_text(resp: &worksgood::executor::native::client::MessagesResponse) -> String {
+    resp.content
+        .iter()
+        .filter_map(|b| match b {
+            ContentBlock::Text { text } => Some(text.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// 1. Total timeout firing mid-stream reproduces the exact symptom
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn total_timeout_reproduces_the_symptom() {
+    // Server streams steadily for ~3s; each gap is short (200ms) so a *read*
+    // timeout would never trip — only a total/wall-clock timeout can.
+    let url = spawn_mock(|_idx, stream| {
+        drain_request(stream);
+        if stream.write_all(CHUNKED_HEADERS.as_bytes()).is_err() {
+            return;
+        }
+        for i in 0..15 {
+            if write_http_chunk(stream, token_frame(&i.to_string()).as_bytes()).is_err() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        let _ = write_http_chunk(stream, done_frames().as_bytes());
+        let _ = write_http_end(stream);
+    });
+
+    // A *total* request timeout — the old client's behavior — applied to the
+    // streaming body. It must fire mid-stream (server runs ~3s).
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(1))
+        .build()
+        .unwrap();
+
+    let resp = client
+        .post(format!("{url}/chat/completions"))
+        .body("{}")
+        .send()
+        .await
+        .expect("headers arrive before the timeout");
+
+    let mut stream = resp.bytes_stream();
+    let mut err = None;
+    while let Some(item) = stream.next().await {
+        if let Err(e) = item {
+            err = Some(e);
+            break;
+        }
+    }
+
+    let err = err.expect("a total timeout must interrupt the in-flight stream");
+    // The crux: the Display is the generic decode message the user saw...
+    assert!(
+        err.to_string().contains("error decoding response body"),
+        "expected the cryptic decode message, got: {err}"
+    );
+    // ...yet the *real* cause is a timeout, only visible via is_timeout().
+    assert!(
+        err.is_timeout(),
+        "the underlying cause must classify as a timeout: {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. The shipped client rides out a long, slow-but-healthy generation
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fixed_client_completes_a_long_slow_stream() {
+    // ~3s of steady streaming — longer than the old 1s-equivalent cap in
+    // test #1, but every gap is short. The fixed client (read-timeout, no
+    // total cap) must complete and return ALL tokens.
+    let url = spawn_mock(|_idx, stream| {
+        drain_request(stream);
+        if stream.write_all(CHUNKED_HEADERS.as_bytes()).is_err() {
+            return;
+        }
+        for i in 0..15 {
+            if write_http_chunk(stream, token_frame(&i.to_string()).as_bytes()).is_err() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        let _ = write_http_chunk(stream, done_frames().as_bytes());
+        let _ = write_http_end(stream);
+    });
+
+    let client = OpenAiClient::new("test-key".to_string(), "mock-model", Some(&url))
+        .unwrap()
+        .with_streaming(true);
+
+    let resp = client
+        .send_streaming(&test_request(), &|_| {})
+        .await
+        .expect("a slow-but-alive stream must complete, not be cut by a timeout");
+
+    // 15 tokens "0".."14" concatenated.
+    assert_eq!(response_text(&resp), "01234567891011121314");
+}
+
+// ---------------------------------------------------------------------------
+// 3. read_timeout aborts a stalled stream but spares a slow-but-alive one
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn read_timeout_aborts_only_a_stalled_stream() {
+    // conn 0: healthy, short gaps -> must complete under a 500ms read-timeout.
+    // conn 1: sends two frames then goes silent for 2s -> read-timeout fires.
+    let url = spawn_mock(|idx, stream| {
+        drain_request(stream);
+        if stream.write_all(CHUNKED_HEADERS.as_bytes()).is_err() {
+            return;
+        }
+        if idx == 0 {
+            for i in 0..6 {
+                if write_http_chunk(stream, token_frame(&i.to_string()).as_bytes()).is_err() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            let _ = write_http_chunk(stream, done_frames().as_bytes());
+            let _ = write_http_end(stream);
+        } else {
+            let _ = write_http_chunk(stream, token_frame("a").as_bytes());
+            let _ = write_http_chunk(stream, token_frame("b").as_bytes());
+            std::thread::sleep(Duration::from_secs(2)); // stall past read-timeout
+            // never sends the terminating chunk
+        }
+    });
+
+    let client = reqwest::Client::builder()
+        .read_timeout(Duration::from_millis(500))
+        .build()
+        .unwrap();
+
+    // Healthy stream: completes without error.
+    let resp = client
+        .post(format!("{url}/chat/completions"))
+        .body("{}")
+        .send()
+        .await
+        .unwrap();
+    let mut stream = resp.bytes_stream();
+    let mut ok = true;
+    while let Some(item) = stream.next().await {
+        if item.is_err() {
+            ok = false;
+            break;
+        }
+    }
+    assert!(ok, "a slow-but-alive stream must survive the read-timeout");
+
+    // Stalled stream: read-timeout fires.
+    let resp = client
+        .post(format!("{url}/chat/completions"))
+        .body("{}")
+        .send()
+        .await
+        .unwrap();
+    let mut stream = resp.bytes_stream();
+    let mut err = None;
+    while let Some(item) = stream.next().await {
+        if let Err(e) = item {
+            err = Some(e);
+            break;
+        }
+    }
+    let err = err.expect("a stalled stream must trip the read-timeout");
+    assert!(err.is_timeout(), "stall must classify as a timeout: {err:?}");
+    assert!(err.to_string().contains("error decoding response body"));
+}
+
+// ---------------------------------------------------------------------------
+// 4. A mid-stream connection drop is recovered by the retry path
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connection_drop_then_retry_recovers() {
+    // conn 0: a few frames then an ABRUPT close (no terminating 0-chunk) ->
+    //         hyper sees an incomplete chunked body -> decode error.
+    // conn 1: a clean, complete stream.
+    let url = spawn_mock(|idx, stream| {
+        drain_request(stream);
+        if stream.write_all(CHUNKED_HEADERS.as_bytes()).is_err() {
+            return;
+        }
+        if idx == 0 {
+            let _ = write_http_chunk(stream, token_frame("partial").as_bytes());
+            // Drop the connection mid-stream: no `0\r\n\r\n`.
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+        } else {
+            let _ = write_http_chunk(stream, token_frame("hello ").as_bytes());
+            let _ = write_http_chunk(stream, token_frame("world").as_bytes());
+            let _ = write_http_chunk(stream, done_frames().as_bytes());
+            let _ = write_http_end(stream);
+        }
+    });
+
+    let client = OpenAiClient::new("test-key".to_string(), "mock-model", Some(&url))
+        .unwrap()
+        .with_streaming(true);
+
+    let resp = client
+        .send_streaming(&test_request(), &|_| {})
+        .await
+        .expect("the retry path must recover from a transient mid-stream drop");
+
+    assert_eq!(response_text(&resp), "hello world");
+}
+
+// ---------------------------------------------------------------------------
+// 5. Split multi-byte UTF-8 across network chunks is reassembled intact
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn split_multibyte_utf8_is_reassembled() {
+    // Emit a single SSE token frame whose JSON contains multi-byte chars,
+    // but split the raw bytes mid-character across two HTTP chunks with a
+    // gap, forcing reqwest to surface them as separate `Bytes`.
+    let url = spawn_mock(|_idx, stream| {
+        drain_request(stream);
+        if stream.write_all(CHUNKED_HEADERS.as_bytes()).is_err() {
+            return;
+        }
+        let frame = token_frame("世界🌍 héllo");
+        let bytes = frame.as_bytes();
+        // Split one byte into the first multi-byte sequence, so the lead byte
+        // is in chunk 1 and its continuation bytes are in chunk 2.
+        let first_multibyte = bytes.iter().position(|&b| b >= 0x80).unwrap();
+        let split = first_multibyte + 1;
+        let _ = write_http_chunk(stream, &bytes[..split]);
+        std::thread::sleep(Duration::from_millis(80));
+        let _ = write_http_chunk(stream, &bytes[split..]);
+        let _ = write_http_chunk(stream, done_frames().as_bytes());
+        let _ = write_http_end(stream);
+    });
+
+    let client = OpenAiClient::new("test-key".to_string(), "mock-model", Some(&url))
+        .unwrap()
+        .with_streaming(true);
+
+    let resp = client.send_streaming(&test_request(), &|_| {}).await.unwrap();
+    let text = response_text(&resp);
+    assert_eq!(text, "世界🌍 héllo");
+    assert!(
+        !text.contains('\u{FFFD}'),
+        "multi-byte chars split across chunks must not be corrupted: {text:?}"
+    );
+}

--- a/tests/integration_nex_streaming_resilience.rs
+++ b/tests/integration_nex_streaming_resilience.rs
@@ -310,7 +310,10 @@ async fn read_timeout_aborts_only_a_stalled_stream() {
         }
     }
     let err = err.expect("a stalled stream must trip the read-timeout");
-    assert!(err.is_timeout(), "stall must classify as a timeout: {err:?}");
+    assert!(
+        err.is_timeout(),
+        "stall must classify as a timeout: {err:?}"
+    );
     assert!(err.to_string().contains("error decoding response body"));
 }
 
@@ -383,7 +386,10 @@ async fn split_multibyte_utf8_is_reassembled() {
         .unwrap()
         .with_streaming(true);
 
-    let resp = client.send_streaming(&test_request(), &|_| {}).await.unwrap();
+    let resp = client
+        .send_streaming(&test_request(), &|_| {})
+        .await
+        .unwrap();
     let text = response_text(&resp);
     assert_eq!(text, "世界🌍 héllo");
     assert!(

--- a/tests/integration_provider.rs
+++ b/tests/integration_provider.rs
@@ -57,9 +57,16 @@ fn openai_mock_response(model: &str) -> String {
     )
 }
 
-/// Start a mock HTTP server that responds to any POST with `body`.
+/// Start a mock HTTP server that responds to any request with `body`.
 /// Returns the base URL (e.g. "http://127.0.0.1:PORT").
-/// The server handles exactly `num_requests` requests then stops.
+/// The server accepts exactly `num_requests` connections then stops (it replies
+/// `Connection: close`, so one request == one connection).
+///
+/// NOTE: a provider built through `create_provider_ext` against an
+/// OpenAI-compatible endpoint issues two context-window probe requests
+/// (`GET /props`, `GET /v1/models`) *before* its first real call — budget for
+/// those when sizing `num_requests`. Tests that construct `OpenAiClient`
+/// directly skip the probe and need only the request count they make.
 fn start_mock_server(body: String, num_requests: usize) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -469,7 +476,16 @@ fn test_per_role_with_mock_servers() {
     let openai_body = openai_mock_response("gpt-4o-mini");
 
     let anthropic_url = start_mock_server(anthropic_body.clone(), 1);
-    let openai_url = start_mock_server(openai_body.clone(), 1);
+    // The OpenAI-compatible provider is built through `create_provider_ext`,
+    // which runs a context-window probe before any send: it issues
+    // `GET /props` (llama.cpp n_ctx) then `GET /v1/models` (vLLM max_model_len),
+    // and only then does the actual `POST /v1/chat/completions`. Each uses a
+    // fresh connection (the mock replies `Connection: close`), so the mock must
+    // accept all three. With a budget of 1 the probe consumed the single
+    // connection and the real send hit "Connection refused" — the pre-existing
+    // flake this test had. The Anthropic provider is not probed (its hint is not
+    // in `context_probe::PROBEABLE_HINTS`), so its mock still needs only 1.
+    let openai_url = start_mock_server(openai_body.clone(), 3);
 
     let config_content = format!(
         r#"

--- a/tests/smoke/manifest.toml
+++ b/tests/smoke/manifest.toml
@@ -702,6 +702,15 @@ description = "Drives standalone `nex` through a real PTY against a local mock O
 timeout_seconds = 120
 
 [[scenario]]
+name = "nex_thinking_timer_pty"
+script = "scenarios/nex_thinking_timer_pty.sh"
+owners = [
+    "refresh-nex-thinking",
+]
+description = "Pins refresh-nex-thinking: the live `thinking… N tokens` working indicator repaints on a FIXED ~100ms timer decoupled from token arrival. Drives `wg nex` through a real PTY against a local SSE server that STALLS (sends nothing for ~1.5s of prefill, then a token, then stalls again). With the timer ON the `↯ prefilling…` indicator must repaint many times during the stall (one per tick, ZERO tokens arriving); with `WG_NEX_SPINNER_MS=off` (== pre-fix repaint-on-token-flush-only) it freezes at a single paint — so the contrast proves the timer is what unfreezes it. A small embedded VT100 emulator replays the captured bytes and asserts the cursor-neutral repaint NEVER scrolls the screen, and the indicator is cleanly cleared at the idle prompt on turn end."
+timeout_seconds = 120
+
+[[scenario]]
 name = "agency_inline_spawn_registers_executor_claude"
 script = "scenarios/agency_inline_spawn_registers_executor_claude.sh"
 owners = [

--- a/tests/smoke/manifest.toml
+++ b/tests/smoke/manifest.toml
@@ -1444,3 +1444,12 @@ owners = [
 ]
 description = "Pins add-yolo-mode: `wg nex --yolo` prints a loud 'YOLO MODE' startup banner announcing the workspace write sandbox is disabled (write_file/edit_file may write outside cwd, no confirmation), and the --yolo + --read-only conflict resolves in favor of read-only (warning 'read-only wins', 'yolo mode is OFF', active YOLO banner suppressed, read-only banner shown). Credential-free: the banner is emitted before any model round-trip, so a bogus endpoint suffices."
 timeout_seconds = 60
+
+[[scenario]]
+name = "nex_streaming_resilience"
+script = "scenarios/nex_streaming_resilience.sh"
+owners = [
+    "diagnose-fix-nex",
+]
+description = "Pins diagnose-fix-nex: the nex (OpenAI-compatible) streaming client must ride out a long, slow-but-healthy generation instead of failing with '[openai-client] Stream interrupted after ~N chunks: error decoding response body'. Root cause: reqwest 0.12 bytes_stream() collapses EVERY body error to Kind::Decode ('error decoding response body'), so the old 300s TOTAL request timeout cut a healthy long stream around the cap (~6300 tokens at a steady local rate). Fix: per-read (idle) timeout that resets on each frame (no total cap on streaming), plus a raw-byte SSE buffer so multi-byte UTF-8 split across chunk boundaries is not corrupted to U+FFFD. Drives the REAL OpenAiClient::send_streaming path over a TCP socket with chunked SSE (in-process mock llama.cpp): total-timeout reproduces the exact symptom + is_timeout cause; fixed client completes a slow 3s stream; read-timeout still aborts a genuinely stalled stream; a mid-stream connection drop recovers via retry; split multi-byte UTF-8 reassembles intact."
+timeout_seconds = 180

--- a/tests/smoke/scenarios/nex_streaming_resilience.sh
+++ b/tests/smoke/scenarios/nex_streaming_resilience.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Scenario: nex_streaming_resilience
+#
+# Pins diagnose-fix-nex: the nex (OpenAI-compatible) streaming client must
+# ride out a long, slow-but-healthy generation without the cryptic
+# "[openai-client] Stream interrupted after ~N chunks: error decoding
+# response body" the user hit against a local llama.cpp endpoint.
+#
+# Root cause (see docs/nex-streaming-resilience.md): reqwest 0.12's
+# `bytes_stream()` collapses EVERY body error to Kind::Decode = "error
+# decoding response body", so the old 300s TOTAL request timeout cut a
+# healthy long stream around the cap (~6300 tokens at a steady local rate)
+# and surfaced as that generic message. The fix swaps the total timeout for
+# a per-read (idle) timeout that resets on each frame, plus a raw-byte SSE
+# buffer so multi-byte UTF-8 split across chunks is not corrupted.
+#
+# These tests drive the REAL `OpenAiClient::send_streaming` path over a real
+# TCP socket with chunked SSE (an in-process mock llama.cpp), exercising:
+#   - total_timeout_reproduces_the_symptom    (proves the symptom + cause)
+#   - fixed_client_completes_a_long_slow_stream (proves the fix)
+#   - read_timeout_aborts_only_a_stalled_stream (idle protection retained)
+#   - connection_drop_then_retry_recovers       (seamless retry)
+#   - split_multibyte_utf8_is_reassembled       (decode resilience)
+#
+# Backed by tests/integration_nex_streaming_resilience.rs. A regression here
+# (e.g. reintroducing a total timeout on the streaming path, or per-chunk
+# lossy UTF-8 decode) blocks `wg done` on tasks that own this scenario.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+. "$HERE/_helpers.sh"
+
+repo_root="$(cd "$HERE/../../.." && pwd)"
+
+if ! command -v cargo >/dev/null 2>&1; then
+    loud_skip "MISSING CARGO" "cargo not on PATH"
+fi
+
+if [[ ! -f "$repo_root/Cargo.toml" ]]; then
+    loud_skip "NOT IN WG REPO" "Cargo.toml not at $repo_root"
+fi
+
+cd "$repo_root"
+
+log=$(mktemp -t nex_streaming_resilience.XXXXXX.log)
+add_cleanup_hook "rm -f $log"
+
+if ! cargo test --test integration_nex_streaming_resilience -- --nocapture >"$log" 2>&1; then
+    loud_fail "integration_nex_streaming_resilience failed:
+$(tail -60 "$log")"
+fi
+
+if ! grep -q "test result: ok\. 5 passed" "$log"; then
+    loud_fail "expected '5 passed' from integration_nex_streaming_resilience. Output:
+$(tail -60 "$log")"
+fi
+
+echo "PASS: nex streaming rides out long/slow gens; resilient to drops + split UTF-8"
+exit 0

--- a/tests/smoke/scenarios/nex_thinking_timer_pty.sh
+++ b/tests/smoke/scenarios/nex_thinking_timer_pty.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# Scenario: nex_thinking_timer_pty
+#
+# Pins refresh-nex-thinking: the live `thinking… N tokens` working
+# indicator must repaint on a FIXED ~100ms timer, decoupled from token
+# arrival, so it animates smoothly and never freezes during prefill or
+# mid-stream stalls.
+#
+# The harness drives `wg nex` through a real PTY against a local SSE
+# server that deliberately STALLS: it sends nothing for ~1.5s (prefill),
+# then a token, then stalls again, then finishes. With the timer ON the
+# `↯ prefilling…` indicator must repaint MANY times during the stall
+# (one per tick); with the timer disabled (`WG_NEX_SPINNER_MS=off`, which
+# reproduces the pre-fix repaint-on-token-flush-only behavior) it freezes
+# at a single paint. A small embedded VT100 emulator replays the captured
+# bytes and asserts the cursor-neutral repaint never SCROLLS the screen.
+#
+# This fails on `main` (no timer → the indicator freezes during the
+# stall) and passes after the fix.
+
+set -euo pipefail
+
+source "$(dirname "$0")/_helpers.sh"
+
+require_wg
+
+if ! command -v nex >/dev/null 2>&1; then
+    loud_skip "MISSING NEX BINARY" "nex not found on PATH; run 'cargo install --path . --locked' from this checkout"
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    loud_skip "MISSING PYTHON" "python3 is required for the PTY harness"
+fi
+
+run_case() {
+    local label="$1"
+    local spinner_mode="$2"
+    local scratch
+    scratch="$(make_scratch)"
+
+    (cd "$scratch" && wg init --no-agency >/dev/null)
+
+    if ! python3 - "$scratch" "$label" "$spinner_mode" <<'PY'; then
+import errno
+import fcntl
+import json
+import os
+import pty
+import re
+import select
+import signal
+import struct
+import subprocess
+import sys
+import termios
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+scratch, label, spinner_mode = sys.argv[1:4]
+
+# How long the server withholds output, in seconds. Long enough that a
+# ~100ms repaint timer ticks many times (>= REPAINT_MIN), even on a
+# loaded CI host.
+PREFILL_STALL = 1.5
+MIDSTREAM_STALL = 1.5
+# With the timer ON we expect ~PREFILL_STALL/0.1 repaints; require a
+# conservative floor. With it OFF the indicator is painted once.
+REPAINT_MIN_ON = 4
+REPAINT_MAX_OFF = 2
+
+ROWS, COLS = 36, 120
+ansi_re = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def clean(text):
+    return ansi_re.sub("", text).replace("\r", "\n")
+
+
+def fail(message, transcript=""):
+    print(f"{label}: {message}", file=sys.stderr)
+    if transcript:
+        print("---- cleaned transcript tail ----", file=sys.stderr)
+        print(clean(transcript)[-1500:], file=sys.stderr)
+    raise SystemExit(1)
+
+
+def sse(handler, obj, delay=0.0):
+    handler.wfile.write(("data: " + json.dumps(obj, separators=(",", ":")) + "\n\n").encode())
+    handler.wfile.flush()
+    if delay:
+        time.sleep(delay)
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_a):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0") or "0")
+        self.rfile.read(length)
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("cache-control", "no-cache")
+        self.send_header("connection", "close")
+        self.end_headers()
+        # PREFILL STALL — no bytes at all. The indicator should keep
+        # animating `↯ prefilling…` purely off the timer.
+        time.sleep(PREFILL_STALL)
+        sse(self, {"id": "x", "choices": [{"index": 0, "delta": {"role": "assistant", "content": "GO "}, "finish_reason": None}]})
+        # MID-STREAM STALL — count is now > 0 but does not change; the
+        # `thinking… N tokens` line must keep repainting off the timer.
+        time.sleep(MIDSTREAM_STALL)
+        for i in range(3):
+            sse(self, {"id": "x", "choices": [{"index": 0, "delta": {"content": f"tok{i} "}, "finish_reason": None}]}, delay=0.03)
+        sse(self, {"id": "x", "choices": [{"index": 0, "delta": {"content": "DONE_MARKER\n"}, "finish_reason": None}]})
+        sse(self, {"id": "x", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}], "usage": {"prompt_tokens": 3, "completion_tokens": 5}})
+        try:
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        except Exception:
+            pass
+
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+endpoint = f"http://127.0.0.1:{server.server_port}"
+
+master, slave = pty.openpty()
+fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
+attrs = termios.tcgetattr(slave)
+attrs[3] &= ~termios.ECHO
+termios.tcsetattr(slave, termios.TCSANOW, attrs)
+
+env = os.environ.copy()
+env.pop("WG_FAKE_LLM", None)
+env.pop("NO_COLOR", None)
+env["NEX_DIR"] = os.path.join(scratch, ".nex")
+env["WG_NEX_LIVE_INPUT"] = "1"
+env["TERM"] = "xterm-256color"
+if spinner_mode == "off":
+    env["WG_NEX_SPINNER_MS"] = "off"
+# else: default cadence (timer on)
+
+
+def child_setup():
+    os.setsid()
+    try:
+        fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+    except OSError:
+        pass
+
+
+proc = subprocess.Popen(
+    ["wg", "nex", "--no-mcp", "--max-turns", "8", "-m", "thinking-timer-smoke", "-e", endpoint],
+    cwd=scratch,
+    env=env,
+    stdin=slave,
+    stdout=slave,
+    stderr=slave,
+    close_fds=True,
+    preexec_fn=child_setup,
+)
+os.close(slave)
+os.set_blocking(master, False)
+
+raw = bytearray()
+
+
+def read_some(timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select([master], [], [], 0.05)
+        if not ready:
+            continue
+        try:
+            chunk = os.read(master, 65536)
+        except OSError as e:
+            if e.errno in (errno.EIO, errno.EBADF):
+                return
+            raise
+        if chunk:
+            raw.extend(chunk)
+
+
+def text():
+    return raw.decode("utf-8", errors="replace")
+
+
+def wait_for(needle, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if needle in clean(text()):
+            return
+        read_some(0.1)
+    fail(f"timed out waiting for {needle!r}", text())
+
+
+def send_line(line):
+    for byte in (line + "\n").encode("utf-8"):
+        os.write(master, bytes([byte]))
+        time.sleep(0.01)
+
+
+# --- minimal VT100 replay so we can assert the repaint never scrolls ---
+def count_scrolls(data):
+    grid_row = 0
+    grid_col = 0
+    scrolls = 0
+    i = 0
+    csi = re.compile(r"\x1b\[([0-9;]*)([A-Za-z])")
+    while i < len(data):
+        ch = data[i]
+        if ch == "\x1b" and i + 1 < len(data) and data[i + 1] == "[":
+            m = csi.match(data, i)
+            if m:
+                params, fin = m.group(1), m.group(2)
+                first = params.split(";")[0]
+                n = int(first) if first else 1
+                if fin == "A":
+                    grid_row = max(0, grid_row - n)
+                elif fin == "B":
+                    grid_row = min(ROWS - 1, grid_row + n)
+                elif fin == "C":
+                    grid_col = min(COLS - 1, grid_col + n)
+                elif fin == "D":
+                    grid_col = max(0, grid_col - n)
+                elif fin in ("H", "f"):
+                    parts = params.split(";")
+                    grid_row = (int(parts[0]) - 1) if parts and parts[0] else 0
+                    grid_col = (int(parts[1]) - 1) if len(parts) > 1 and parts[1] else 0
+                i = m.end()
+                continue
+        if ch == "\r":
+            grid_col = 0
+        elif ch == "\n":
+            grid_row += 1
+            if grid_row >= ROWS:
+                grid_row = ROWS - 1
+                scrolls += 1
+        elif ord(ch) >= 32:
+            if grid_col >= COLS:
+                grid_col = 0
+                grid_row += 1
+                if grid_row >= ROWS:
+                    grid_row = ROWS - 1
+                    scrolls += 1
+            grid_col += 1
+        i += 1
+    return scrolls
+
+
+def prefilling_repaints(data):
+    return data.count("prefilling…")
+
+
+try:
+    wait_for(">", 15)
+    send_line("hello there")
+    # The whole stalled turn is ~PREFILL+MIDSTREAM seconds; read past it.
+    wait_for("DONE_MARKER", 20)
+    captured = text()
+
+    repaints = prefilling_repaints(captured)
+    scrolls = count_scrolls(captured)
+
+    if spinner_mode == "off":
+        # Timer disabled == pre-fix behaviour: the prefill indicator is
+        # painted at most once and then FROZEN for the whole stall.
+        if repaints > REPAINT_MAX_OFF:
+            fail(
+                f"with the timer OFF the prefill indicator must not repaint "
+                f"(saw {repaints}, expected <= {REPAINT_MAX_OFF})",
+                captured,
+            )
+    else:
+        # Timer on: the indicator repaints once per ~100ms tick even
+        # though ZERO tokens arrived during the prefill stall.
+        if repaints < REPAINT_MIN_ON:
+            fail(
+                f"live thinking indicator did not repaint on the timer during "
+                f"the prefill stall (saw {repaints} paints, expected >= "
+                f"{REPAINT_MIN_ON}); it froze instead of animating",
+                captured,
+            )
+    # The cursor-neutral repaint must never scroll the screen, regardless
+    # of mode.
+    if scrolls != 0:
+        fail(f"repaint scrolled the screen {scrolls} time(s); it must redraw in place", captured)
+
+    # Drain to the idle prompt and assert the indicator is cleanly gone —
+    # no `thinking…`/`prefilling…` trailing the ready `> ` prompt (clean
+    # stop at turn end; no leftover repaint).
+    wait_for("tok2", 10)
+    time.sleep(0.6)
+    read_some(0.5)
+    final = clean(text())
+    idle_matches = list(re.finditer(r"(?m)^[ \t]*>[ \t]*$", final))
+    if not idle_matches:
+        fail("idle prompt never reappeared after the stalled turn completed", text())
+    tail = final[idle_matches[-1].end():]
+    if "thinking…" in tail or "prefilling…" in tail:
+        fail("live thinking indicator was not cleared at turn end", text())
+
+    send_line("/quit")
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline and proc.poll() is None:
+        read_some(0.2)
+    if proc.poll() is None:
+        os.killpg(proc.pid, signal.SIGTERM)
+        fail("nex did not exit after /quit", text())
+    if proc.returncode != 0:
+        fail(f"nex exited with {proc.returncode}", text())
+
+    print(f"PASS: {label} (mode={spinner_mode}) prefill repaints={repaints} scrolls={scrolls}")
+finally:
+    try:
+        server.shutdown()
+    except Exception:
+        pass
+    try:
+        os.close(master)
+    except OSError:
+        pass
+PY
+        loud_fail "$label PTY thinking-timer harness failed (spinner_mode=$spinner_mode)"
+    fi
+}
+
+# Timer ON (default ~100ms): the indicator must animate through the stall.
+run_case "wg nex thinking timer on" default
+# Timer OFF (== pre-fix repaint-on-flush-only): the indicator freezes,
+# proving the timer is what unfreezes it.
+run_case "wg nex thinking timer off" off
+
+echo "PASS: nex live thinking indicator repaints on a fixed timer (and freezes cleanly when disabled), with no screen scroll"

--- a/tests/test_edit_file_edge_cases.rs
+++ b/tests/test_edit_file_edge_cases.rs
@@ -1,21 +1,28 @@
-//! Tests for edit_file edge cases and failure scenarios.
+//! Tests for edit_file edge cases — now exercising the FUZZY/robust matcher.
 //!
-//! This test module reproduces and prevents common edit_file failures identified
-//! in the investigation report (.wg/reports/edit-tool-investigation.md).
+//! Originally (see .wg/reports/edit-tool-investigation.md) edit_file required
+//! EXACT byte-for-byte matching, and this module documented the resulting
+//! failures (whitespace / line-ending / indentation / trailing-newline
+//! mismatches). The `add-fuzzy-robust` task flipped those failures into
+//! tolerant matches: edit_file now matches despite whitespace, indentation,
+//! and line-ending differences, re-indents the replacement to the file, and
+//! returns a near-miss diagnostic (not a bare "not found") when it truly can't
+//! match — so the model makes a targeted edit instead of rewriting the file.
 //!
-//! Key findings from investigation:
-//! - The edit_file tool requires EXACT byte-for-byte matching
-//! - Common failures: whitespace mismatches, line ending differences, trailing newline issues
-//! - Error messages are informative but could be more helpful
+//! The tests below therefore assert the NEW tolerant contract. The one
+//! deliberate boundary kept strict: interior-whitespace collapse (e.g.
+//! "hello world" vs "hello   world") stays a no-match unless the caller opts in
+//! via `normalize_whitespace`, to avoid over-matching semantically different
+//! code.
 //!
 //! Test cases cover:
-//! 1. Line ending sensitivity (Windows \r\n vs Unix \n)
-//! 2. Whitespace variations (spaces, tabs, mixed)
+//! 1. Line ending tolerance (Windows \r\n vs Unix \n)
+//! 2. Whitespace / indentation tolerance (spaces, tabs, mixed)
 //! 3. Partial vs full line matching
-//! 4. Exact match requirements
+//! 4. Exact / unique match requirements
 //! 5. Unicode character handling
 //! 6. Multiple match prevention
-//! 7. Error message verification
+//! 7. Near-miss diagnostics on no-match
 //!
 //! Run with: cargo test test_edit_file_edge_cases
 
@@ -119,9 +126,9 @@ async fn test_edit_with_windows_line_endings() {
     assert_eq!(content, "line1\r\nLINE2_MODIFIED\r\nline3\r\n");
 }
 
-/// Test: Mismatch between Unix search string and Windows file fails
+/// Test: Unix search string matches a Windows (\r\n) file — fuzzy tolerance.
 #[tokio::test]
-async fn test_edit_fails_on_line_ending_mismatch() {
+async fn test_edit_tolerates_line_ending_mismatch() {
     let dir = temp_dir();
     let file_path = dir.path().join("mismatch.txt");
 
@@ -136,13 +143,14 @@ async fn test_edit_fails_on_line_ending_mismatch() {
     )
     .await;
 
-    assert!(!is_success(&result), "Should fail on line ending mismatch");
-    let msg = error_msg(&result);
     assert!(
-        msg.contains("not found") || msg.contains("exactly"),
-        "Error should mention exact matching requirement: {}",
-        msg
+        is_success(&result),
+        "Should tolerate \\n vs \\r\\n line-ending differences: {:?}",
+        result
     );
+    // The file's CRLF convention is preserved in the replacement.
+    let content = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(content, "A\r\nB\r\nline3\r\n");
 }
 
 /// Test: Mixed line endings in file content
@@ -170,9 +178,9 @@ async fn test_edit_with_mixed_line_endings() {
 
 // ── 2. Whitespace Variation Tests ───────────────────────────────────────────
 
-/// Test: Extra spaces in search string causes failure
+/// Test: A trailing space in the search string is tolerated (fuzzy).
 #[tokio::test]
-async fn test_edit_fails_with_extra_spaces() {
+async fn test_edit_tolerates_extra_trailing_space() {
     let dir = temp_dir();
     let file_path = dir.path().join("spaces.txt");
 
@@ -187,12 +195,20 @@ async fn test_edit_fails_with_extra_spaces() {
     )
     .await;
 
-    assert!(!is_success(&result), "Extra space should cause mismatch");
+    assert!(
+        is_success(&result),
+        "Trailing-space difference should be tolerated: {:?}",
+        result
+    );
+    assert_eq!(fs::read_to_string(&file_path).unwrap(), "hi there");
 }
 
-/// Test: Missing space in search string causes failure
+/// Test: Interior-whitespace differences are NOT collapsed by default.
+///
+/// This is the deliberate strict boundary — "hello world" must not silently
+/// match "hello   world" unless the caller opts into `normalize_whitespace`.
 #[tokio::test]
-async fn test_edit_fails_with_missing_spaces() {
+async fn test_edit_interior_whitespace_not_collapsed_by_default() {
     let dir = temp_dir();
     let file_path = dir.path().join("spaces2.txt");
 
@@ -207,12 +223,47 @@ async fn test_edit_fails_with_missing_spaces() {
     )
     .await;
 
-    assert!(!is_success(&result), "Missing spaces should cause mismatch");
+    assert!(
+        !is_success(&result),
+        "Interior whitespace must not be collapsed without opt-in"
+    );
+    // But the no-match is a helpful near-miss, not a bare failure.
+    let msg = error_msg(&result);
+    assert!(
+        msg.contains("not found") && msg.contains("Closest candidate"),
+        "No-match should include a near-miss diagnostic: {}",
+        msg
+    );
 }
 
-/// Test: Tab vs space difference
+/// Test: Interior-whitespace collapse works when explicitly opted in.
 #[tokio::test]
-async fn test_edit_fails_with_tab_space_mismatch() {
+async fn test_edit_interior_whitespace_collapsed_when_opted_in() {
+    let dir = temp_dir();
+    let file_path = dir.path().join("spaces3.txt");
+
+    fs::write(&file_path, "hello   world").unwrap();
+
+    let registry = make_tool_registry();
+    let input = serde_json::json!({
+        "path": file_path.to_str().unwrap(),
+        "old_string": "hello world",
+        "new_string": "hi there",
+        "normalize_whitespace": true,
+    });
+    let result = registry.execute("edit_file", &input).await;
+
+    assert!(
+        is_success(&result),
+        "normalize_whitespace should collapse interior spaces: {:?}",
+        result
+    );
+    assert_eq!(fs::read_to_string(&file_path).unwrap(), "hi there");
+}
+
+/// Test: Tab vs space indentation is tolerated and the edit lands.
+#[tokio::test]
+async fn test_edit_tolerates_tab_space_mismatch() {
     let dir = temp_dir();
     let file_path = dir.path().join("tabs.txt");
 
@@ -228,14 +279,17 @@ async fn test_edit_fails_with_tab_space_mismatch() {
     .await;
 
     assert!(
-        !is_success(&result),
-        "Tab vs space mismatch should cause failure"
+        is_success(&result),
+        "Tab vs space indentation should be tolerated: {:?}",
+        result
     );
+    let content = fs::read_to_string(&file_path).unwrap();
+    assert!(content.contains("NEW"), "edit should land: {}", content);
 }
 
-/// Test: Trailing whitespace difference
+/// Test: Trailing whitespace in the file is tolerated.
 #[tokio::test]
-async fn test_edit_fails_with_trailing_whitespace_difference() {
+async fn test_edit_tolerates_trailing_whitespace_difference() {
     let dir = temp_dir();
     let file_path = dir.path().join("trailing.txt");
 
@@ -251,9 +305,11 @@ async fn test_edit_fails_with_trailing_whitespace_difference() {
     .await;
 
     assert!(
-        !is_success(&result),
-        "Trailing whitespace difference should cause failure"
+        is_success(&result),
+        "Trailing-whitespace difference should be tolerated: {:?}",
+        result
     );
+    assert_eq!(fs::read_to_string(&file_path).unwrap(), "CODE\nNEXT");
 }
 
 /// Test: Leading whitespace difference (search string not a substring of file content)
@@ -649,12 +705,17 @@ async fn test_edit_trailing_newline_vs_not() {
         is_success(&result1),
         "Match with trailing newline should work"
     );
+    // Reset for the second case.
+    fs::write(&file_path, "line1\n").unwrap();
 
+    // A missing trailing newline is now tolerated (the file's newline is kept).
     let result2 = edit_file(&registry, file_path.to_str().unwrap(), "line1", "LINE1").await;
     assert!(
-        !is_success(&result2),
-        "Missing trailing newline should fail when file has it"
+        is_success(&result2),
+        "Missing trailing newline should be tolerated: {:?}",
+        result2
     );
+    assert_eq!(fs::read_to_string(&file_path).unwrap(), "LINE1\n");
 }
 
 /// Test: Replacement string is empty

--- a/tests/test_edit_file_fix_build_repro.rs
+++ b/tests/test_edit_file_fix_build_repro.rs
@@ -1,0 +1,163 @@
+//! Repro for the `add-fuzzy-robust` task: a "fix build errors" flow makes
+//! TARGETED edits instead of repeated full-file rewrites.
+//!
+//! ## Background
+//!
+//! Watching nex (qwen3) build a Game-of-Life TUI, after each `cargo build`
+//! error the model REWROTE THE WHOLE FILE with `write_file` (main.rs 2.3KB →
+//! 17KB → 19.5KB → …) instead of patching. Root cause: the strict exact-match
+//! `edit_file` failed whenever the model's `old_string` was slightly off
+//! (indentation it eyeballed wrong, a stray trailing space, a CRLF/LF
+//! difference), so the model fell back to `write_file`.
+//!
+//! This test reproduces that exact situation: it feeds `edit_file` the kind of
+//! *imperfect* `old_string`s a model produces after reading a file, fixing a
+//! sequence of build errors. With the fuzzy matcher each targeted edit now
+//! lands — no full rewrite needed. Under the old strict matcher every one of
+//! these would have returned "old_string not found".
+
+use std::fs;
+use tempfile::{Builder, TempDir};
+
+use worksgood::executor::native::tools::{ToolOutput, ToolRegistry};
+
+fn make_tool_registry() -> ToolRegistry {
+    let mut registry = ToolRegistry::new();
+    worksgood::executor::native::tools::file::register_file_tools(&mut registry);
+    registry
+}
+
+fn temp_dir() -> TempDir {
+    Builder::new()
+        .prefix("edit-file-repro-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .unwrap()
+}
+
+async fn edit_file(registry: &ToolRegistry, path: &str, old: &str, new: &str) -> ToolOutput {
+    let input = serde_json::json!({ "path": path, "old_string": old, "new_string": new });
+    registry.execute("edit_file", &input).await
+}
+
+/// A small program with three "compile errors" the agent will fix one by one,
+/// each via a targeted edit whose `old_string` is imperfect in a different way.
+const BUGGY_SRC: &str = "fn main() {\n\
+    \x20   let mut grid = vec![vec![false; W]; H];\n\
+    \x20   let count = neighbours(&grid, 0, 0)\n\
+    \x20   println!(\"{}\", count);\n\
+}\n";
+
+#[tokio::test]
+async fn fix_build_errors_uses_targeted_edits_not_rewrites() {
+    let dir = temp_dir();
+    let file_path = dir.path().join("main.rs");
+    fs::write(&file_path, BUGGY_SRC).unwrap();
+    let path = file_path.to_str().unwrap();
+    let registry = make_tool_registry();
+
+    // ── Error 1: undefined `W`/`H`. The model copies the line but over-indents
+    //    it (6 spaces instead of the file's 4). Strict matching would fail here;
+    //    fuzzy indentation tolerance lands it AND re-anchors the replacement to
+    //    the file's real 4-space indentation.
+    let r1 = edit_file(
+        &registry,
+        path,
+        "      let mut grid = vec![vec![false; W]; H];",
+        "      let mut grid = vec![vec![false; 64]; 32];",
+    )
+    .await;
+    assert!(
+        !r1.is_error,
+        "edit 1 (indentation off) should land: {:?}",
+        r1
+    );
+
+    // ── Error 2: missing semicolon. The model reproduces the line but adds a
+    //    stray trailing space. Trailing-whitespace tolerance lands it.
+    let r2 = edit_file(
+        &registry,
+        path,
+        "    let count = neighbours(&grid, 0, 0) ",
+        "    let count = neighbours(&grid, 0, 0);",
+    )
+    .await;
+    assert!(
+        !r2.is_error,
+        "edit 2 (trailing space) should land: {:?}",
+        r2
+    );
+
+    // ── Error 3: tweak the println. The model uses \r\n line endings (pasted
+    //    from a Windows terminal) but the file is LF. Line-ending tolerance
+    //    lands it.
+    let r3 = edit_file(
+        &registry,
+        path,
+        "    println!(\"{}\", count);\r\n}",
+        "    println!(\"count = {}\", count);\n}",
+    )
+    .await;
+    assert!(!r3.is_error, "edit 3 (CRLF vs LF) should land: {:?}", r3);
+
+    // Every fix was a targeted edit; the file now reflects all three.
+    let final_src = fs::read_to_string(&file_path).unwrap();
+    assert!(
+        final_src.contains("vec![vec![false; 64]; 32]"),
+        "{final_src}"
+    );
+    assert!(
+        final_src.contains("neighbours(&grid, 0, 0);"),
+        "{final_src}"
+    );
+    assert!(
+        final_src.contains("println!(\"count = {}\", count);"),
+        "{final_src}"
+    );
+    // Indentation stayed consistent with the file (4 spaces), not the 2 the
+    // model supplied — the replacement was re-anchored.
+    assert!(
+        final_src.contains("\n    let mut grid = vec![vec![false; 64]; 32];"),
+        "replacement should be re-indented to the file: {final_src}"
+    );
+}
+
+/// When a targeted edit genuinely cannot match, the tool returns a near-miss
+/// diagnostic pointing at the closest line — NOT a bare "not found" that pushes
+/// the model toward a full rewrite.
+#[tokio::test]
+async fn unmatchable_edit_returns_near_miss_not_bare_failure() {
+    let dir = temp_dir();
+    let file_path = dir.path().join("lib.rs");
+    fs::write(
+        &file_path,
+        "pub fn total(items: &[u32]) -> u32 {\n    items.iter().sum()\n}\n",
+    )
+    .unwrap();
+    let path = file_path.to_str().unwrap();
+    let registry = make_tool_registry();
+
+    // Model misremembers the signature (`totals`, `i32`).
+    let r = edit_file(
+        &registry,
+        path,
+        "pub fn totals(items: &[i32]) -> i32 {",
+        "pub fn total(items: &[u32]) -> u64 {",
+    )
+    .await;
+
+    assert!(r.is_error, "genuinely-wrong old_string should not match");
+    let msg = r.content;
+    assert!(
+        msg.contains("Closest candidate"),
+        "should show candidate: {msg}"
+    );
+    assert!(
+        msg.contains("pub fn total(items"),
+        "should echo the real line: {msg}"
+    );
+    // Steers the model back to a targeted retry, away from write_file rewrites.
+    assert!(
+        msg.contains("write_file"),
+        "should discourage full rewrite: {msg}"
+    );
+}


### PR DESCRIPTION
Follow-up polish on top of #43 (main @ bd4c3787).

## Commits
- **refresh-nex-thinking**: timer-driven (~100ms) repaint of the `thinking… N tokens` indicator (was event-only — froze during stalls/prefill)
- **add-fuzzy-robust**: fuzzy/robust file editing to kill full-file-rewrite thrash on weaker/local models
- **diagnose-fix-nex**: fix for the streaming interruption ('error decoding response body' ~6300 chunks)
- **fix-pre-existing-2**: follow-up test fix

Each verified locally (build+test). CI gates the merge.