### PR TITLE
fix(platform_timeout): probe gtimeout/timeout, watchdog fallback on macOS without coreutils

### DIFF
--- a/src/platform_timeout.rs
+++ b/src/platform_timeout.rs
@@ -1,20 +1,31 @@
 //! Cross-platform replacement for `timeout(1)`.
 //!
-//! Unix has `timeout(1)`, which wraps a command and kills it (exit code 124)
-//! if it runs past a deadline. Windows has no equivalent — `TIMEOUT.EXE` is an
-//! interactive "press any key to continue, else wait N seconds" utility, and
-//! fails with "Default option is not allowed more than '1' time(s)" when
-//! invoked with `timeout(1)`-style arguments. Any workgraph code that shells
-//! out to `timeout` therefore breaks on native Windows.
+//! Unix *usually* has `timeout(1)`, which wraps a command and kills it (exit
+//! code 124) if it runs past a deadline. But it is not guaranteed: macOS ships
+//! NO `timeout` binary by default — coreutils provides it, and then usually
+//! under the name `gtimeout`. Windows has no equivalent at all — `TIMEOUT.EXE`
+//! is an interactive "press any key to continue, else wait N seconds" utility
+//! and fails with "Default option is not allowed more than '1' time(s)" when
+//! invoked with `timeout(1)`-style arguments.
 //!
 //! [`spawn_with_timeout`] hides the platform difference behind one API:
 //!
-//! - On Unix: prefixes the command with `timeout <secs>s`, preserving the
-//!   exit-code-124-on-timeout semantics callers may be relying on.
-//! - On Windows: spawns the program directly and arms a background thread
-//!   that runs `taskkill /F /T /PID <pid>` at the deadline. The thread is
+//! - On Unix, when a GNU `timeout` binary is available: prefixes the command
+//!   with `<bin> <secs>s`, preserving the exit-code-124-on-timeout semantics
+//!   callers may be relying on. The binary is resolved once (cached) by
+//!   probing PATH for `gtimeout` then `timeout`, mirroring the shell wrapper's
+//!   `command -v gtimeout || command -v timeout` probe in
+//!   `src/commands/spawn/execution.rs`.
+//! - On Unix with NO `timeout` binary (default macOS-without-coreutils), and
+//!   always on Windows: spawns the program directly and arms a background
+//!   watchdog thread that kills the child at the deadline. The thread is
 //!   disarmed (via an atomic flag) when the returned [`TimeoutGuard`] drops,
 //!   so children that exit in time don't risk a PID-reuse race.
+//!
+//! In the watchdog fallback the child is killed with `SIGKILL` (Unix) /
+//! `taskkill /F /T` (Windows) rather than exiting 124 — callers that
+//! specifically branch on exit code 124 should not rely on it when no
+//! `timeout` binary is present.
 //!
 //! Callers bind the guard to a `_killer` local that lives as long as the
 //! child-wait call:
@@ -26,30 +37,35 @@
 //!     30,
 //! )?;
 //! let output = child.wait_with_output()?;
-//! // _killer drops here; disarms the Windows kill-thread if still pending.
+//! // _killer drops here; disarms the watchdog kill-thread if still pending.
 //! ```
 
 use std::ffi::OsStr;
 use std::io;
 use std::process::{Child, Command};
-
-#[cfg(windows)]
 use std::sync::Arc;
-#[cfg(windows)]
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// RAII guard that disarms the Windows kill-thread when dropped.
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::sync::OnceLock;
+
+/// RAII guard that disarms the watchdog kill-thread when dropped.
 ///
-/// Zero-sized on Unix (there's no kill-thread — `timeout(1)` handles it).
+/// `done` is `Some` only when a watchdog thread was armed (always on Windows;
+/// on Unix only in the no-`timeout`-binary fallback). When an external
+/// `timeout(1)`/`gtimeout` enforces the deadline there is nothing to disarm and
+/// `done` is `None`.
 pub struct TimeoutGuard {
-    #[cfg(windows)]
-    done: Arc<AtomicBool>,
+    done: Option<Arc<AtomicBool>>,
 }
 
-#[cfg(windows)]
 impl Drop for TimeoutGuard {
     fn drop(&mut self) {
-        self.done.store(true, Ordering::Release);
+        if let Some(done) = &self.done {
+            done.store(true, Ordering::Release);
+        }
     }
 }
 
@@ -70,36 +86,249 @@ where
 {
     #[cfg(unix)]
     {
-        let mut cmd = Command::new("timeout");
-        cmd.arg(format!("{}s", timeout_secs)).arg(program);
-        configure(&mut cmd);
-        let child = cmd.spawn()?;
-        Ok((child, TimeoutGuard {}))
+        if let Some(bin) = resolve_timeout_bin() {
+            let mut cmd = Command::new(bin);
+            cmd.arg(format!("{}s", timeout_secs)).arg(program);
+            configure(&mut cmd);
+            let child = cmd.spawn()?;
+            return Ok((child, TimeoutGuard { done: None }));
+        }
+        // No `timeout`/`gtimeout` on PATH (e.g. macOS without coreutils):
+        // fall back to the same watchdog-thread strategy used on Windows.
+        spawn_with_watchdog(program, configure, timeout_secs)
     }
     #[cfg(windows)]
     {
-        use std::thread;
-        use std::time::Duration;
+        spawn_with_watchdog(program, configure, timeout_secs)
+    }
+}
 
-        let mut cmd = Command::new(program);
-        configure(&mut cmd);
-        let child = cmd.spawn()?;
-        let pid = child.id();
+/// Spawn `program` directly and arm a background thread that kills the child
+/// (and its process tree, best effort) once `timeout_secs` elapses, unless the
+/// returned guard is dropped first.
+///
+/// This is the Windows path, and the Unix fallback when no `timeout` binary is
+/// available. The two platforms differ only in how the kill is delivered — see
+/// [`kill_process_tree`].
+fn spawn_with_watchdog<P, F>(
+    program: P,
+    configure: F,
+    timeout_secs: u64,
+) -> io::Result<(Child, TimeoutGuard)>
+where
+    P: AsRef<OsStr>,
+    F: FnOnce(&mut Command) -> &mut Command,
+{
+    use std::thread;
+    use std::time::Duration;
 
-        let done = Arc::new(AtomicBool::new(false));
-        let done_clone = Arc::clone(&done);
-        thread::spawn(move || {
-            thread::sleep(Duration::from_secs(timeout_secs));
-            if !done_clone.load(Ordering::Acquire) {
-                // Best-effort: kill the process tree. /T walks children,
-                // /F forces. We ignore the exit status — the child may
-                // have just finished on its own, which is fine.
-                let _ = Command::new("taskkill")
-                    .args(["/F", "/T", "/PID", &pid.to_string()])
-                    .output();
+    let mut cmd = Command::new(program);
+    configure(&mut cmd);
+    let child = cmd.spawn()?;
+    let pid = child.id();
+
+    let done = Arc::new(AtomicBool::new(false));
+    let done_clone = Arc::clone(&done);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_secs(timeout_secs));
+        if !done_clone.load(Ordering::Acquire) {
+            kill_process_tree(pid);
+        }
+    });
+
+    Ok((child, TimeoutGuard { done: Some(done) }))
+}
+
+/// Best-effort kill of the process (tree) identified by `pid`. Errors are
+/// ignored: the child may have just finished on its own, which is fine.
+#[cfg(windows)]
+fn kill_process_tree(pid: u32) {
+    // /T walks children, /F forces.
+    let _ = Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &pid.to_string()])
+        .output();
+}
+
+/// Best-effort kill of the process identified by `pid`. Errors are ignored:
+/// the child may have just finished on its own (and its pid been reaped),
+/// which is fine.
+#[cfg(unix)]
+fn kill_process_tree(pid: u32) {
+    // SAFETY: `kill(2)` is always safe to call — it validates the pid and
+    // signal itself and reports failure via errno rather than UB. We ignore
+    // the return value because this is best-effort at a deadline.
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+/// Resolve the GNU `timeout` binary once, caching the result for the process
+/// lifetime. Probes PATH for `gtimeout` then `timeout`, mirroring the shell
+/// wrapper's `command -v gtimeout || command -v timeout` order in
+/// `src/commands/spawn/execution.rs`. Returns `None` when neither is present
+/// (default macOS-without-coreutils), which drives the watchdog fallback.
+#[cfg(unix)]
+fn resolve_timeout_bin() -> Option<&'static Path> {
+    static TIMEOUT_BIN: OnceLock<Option<PathBuf>> = OnceLock::new();
+    TIMEOUT_BIN
+        .get_or_init(|| which_first(&["gtimeout", "timeout"]))
+        .as_deref()
+}
+
+/// Minimal `which(1)`: return the first `candidate` (in order) found as an
+/// executable file on any `$PATH` entry. A candidate earlier in the list wins
+/// over one later, even if the later one appears earlier on PATH — matching
+/// `command -v a || command -v b`.
+#[cfg(unix)]
+fn which_first(candidates: &[&str]) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    let dirs: Vec<PathBuf> = std::env::split_paths(&path_var).collect();
+    which_first_in(&dirs, candidates)
+}
+
+/// `which_first` factored to take explicit search dirs, so probe order is
+/// unit-testable without mutating the process environment.
+#[cfg(unix)]
+fn which_first_in(dirs: &[PathBuf], candidates: &[&str]) -> Option<PathBuf> {
+    for name in candidates {
+        for dir in dirs {
+            if dir.as_os_str().is_empty() {
+                continue;
             }
-        });
+            let candidate = dir.join(name);
+            if is_executable_file(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
 
-        Ok((child, TimeoutGuard { done }))
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    match std::fs::metadata(path) {
+        Ok(md) => md.is_file() && (md.permissions().mode() & 0o111 != 0),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    /// The watchdog fallback (the path taken on macOS without coreutils)
+    /// enforces the deadline: a `sleep 30` armed with a 1s budget must be
+    /// killed well before it would finish on its own.
+    #[test]
+    fn watchdog_fallback_enforces_deadline() {
+        let start = Instant::now();
+        let (mut child, _killer) =
+            spawn_with_watchdog("sleep", |c| c.arg("30"), 1).expect("spawn sleep");
+        let status = child.wait().expect("wait");
+        let elapsed = start.elapsed();
+
+        assert!(
+            !status.success(),
+            "child should have been killed, not exited cleanly"
+        );
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "watchdog did not enforce the 1s deadline: slept {elapsed:?}"
+        );
+    }
+
+    /// A child that finishes before the deadline is left alone: the guard
+    /// disarms the watchdog on drop and the process exits successfully.
+    #[test]
+    fn watchdog_does_not_kill_fast_child() {
+        let (mut child, killer) = spawn_with_watchdog("true", |c| c, 30).expect("spawn true");
+        let status = child.wait().expect("wait");
+        drop(killer);
+        assert!(status.success(), "fast child should exit 0, got {status:?}");
+    }
+
+    /// The public API enforces the deadline regardless of which path it takes
+    /// (external `timeout` binary on most Linux, watchdog fallback on macOS).
+    /// This guards the existing call sites: `spawn_with_timeout` still kills a
+    /// runaway child.
+    #[test]
+    fn spawn_with_timeout_enforces_deadline() {
+        let start = Instant::now();
+        let (mut child, _killer) =
+            spawn_with_timeout("sleep", |c| c.arg("30"), 1).expect("spawn sleep");
+        let status = child.wait().expect("wait");
+        assert!(!status.success(), "runaway child should have been killed");
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "deadline not enforced"
+        );
+    }
+
+    /// Probe order: `gtimeout` wins over `timeout` when both are on PATH, even
+    /// if `timeout` sits in an earlier directory — matching the shell wrapper's
+    /// `command -v gtimeout || command -v timeout`.
+    #[cfg(unix)]
+    #[test]
+    fn probe_prefers_gtimeout_over_timeout() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base =
+            std::env::temp_dir().join(format!("wg-probe-{}-{}", std::process::id(), "prefer"));
+        let dir_a = base.join("a"); // earlier on PATH, only `timeout`
+        let dir_b = base.join("b"); // later on PATH, has `gtimeout`
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::create_dir_all(&dir_b).unwrap();
+
+        let write_exe = |p: &Path| {
+            std::fs::write(p, b"#!/bin/sh\nexit 0\n").unwrap();
+            let mut perm = std::fs::metadata(p).unwrap().permissions();
+            perm.set_mode(0o755);
+            std::fs::set_permissions(p, perm).unwrap();
+        };
+        write_exe(&dir_a.join("timeout"));
+        write_exe(&dir_b.join("gtimeout"));
+        write_exe(&dir_b.join("timeout"));
+
+        let dirs = vec![dir_a.clone(), dir_b.clone()];
+        let resolved = which_first_in(&dirs, &["gtimeout", "timeout"]).unwrap();
+        assert_eq!(
+            resolved.file_name().unwrap(),
+            "gtimeout",
+            "gtimeout must win over timeout regardless of PATH order"
+        );
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    /// When only `timeout` is present it is selected; when neither is present
+    /// the probe returns `None`, which drives the watchdog fallback.
+    #[cfg(unix)]
+    #[test]
+    fn probe_falls_back_to_timeout_then_none() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base =
+            std::env::temp_dir().join(format!("wg-probe-{}-{}", std::process::id(), "fallback"));
+        let with_timeout = base.join("with");
+        let empty = base.join("empty");
+        std::fs::create_dir_all(&with_timeout).unwrap();
+        std::fs::create_dir_all(&empty).unwrap();
+
+        let exe = with_timeout.join("timeout");
+        std::fs::write(&exe, b"#!/bin/sh\nexit 0\n").unwrap();
+        let mut perm = std::fs::metadata(&exe).unwrap().permissions();
+        perm.set_mode(0o755);
+        std::fs::set_permissions(&exe, perm).unwrap();
+
+        let only_timeout =
+            which_first_in(&[with_timeout.clone()], &["gtimeout", "timeout"]).unwrap();
+        assert_eq!(only_timeout.file_name().unwrap(), "timeout");
+
+        let none = which_first_in(&[empty.clone()], &["gtimeout", "timeout"]);
+        assert!(none.is_none(), "no binary present should probe to None");
+
+        std::fs::remove_dir_all(&base).ok();
     }
 }


### PR DESCRIPTION
## Symptom (found in production use)

On a stock macOS dev box (no coreutils), **every** in-process lightweight LLM call fails immediately:

```
Failed to spawn claude CLI for lightweight LLM call: No such file or directory (os error 2)
```

raised at `src/service/llm.rs` (the `.context(...)` on `spawn_with_timeout`). Observed today with all six FLIP satellite tasks failing this way — the daemon never reaches the `claude` CLI at all.

## Root cause

`src/platform_timeout.rs` did `Command::new("timeout")` unconditionally on unix:

```rust
let mut cmd = Command::new("timeout");
cmd.arg(format!("{}s", timeout_secs)).arg(program);
```

macOS ships **no** `timeout(1)` binary by default — coreutils provides it, usually as `gtimeout`. So the spawn ENOENTs before `program` (`claude`) is ever exec'd. macOS-without-coreutils is a **default developer environment**, not an exotic edge case.

## Lineage

This is the exact bug class the (closed) **PR #36** fixed for the shell *wrapper*: `src/commands/spawn/execution.rs` now probes `command -v gtimeout || command -v timeout` at runtime. But **PR #22**'s in-process Rust path (`spawn_with_timeout`) reintroduced the hardcode. This PR brings the Rust path in line with the wrapper's precedent.

## Fix

1. **Runtime probe, cached once** (`OnceLock`): resolve the GNU `timeout` binary by searching PATH for `gtimeout` then `timeout` — the same order as the wrapper's `command -v gtimeout || command -v timeout`.
2. **No-binary fallback** (default macOS): when neither exists, don't fail. Spawn the program directly and arm a watchdog thread that `SIGKILL`s the child at the deadline — reusing the exact pattern the **Windows arm already implemented** (`taskkill`). Both are now unified into one `spawn_with_watchdog` helper; the `TimeoutGuard` drop disarms the thread so an in-time child doesn't hit a PID-reuse race.
3. Linux with `timeout` on PATH keeps the external-binary path and its exit-code-124-on-timeout semantics unchanged.

## Tests (`cargo test --lib platform_timeout`, all pass)

- `probe_prefers_gtimeout_over_timeout` — probe order matches the wrapper.
- `probe_falls_back_to_timeout_then_none` — only-`timeout` selected; neither → `None` (drives fallback).
- `watchdog_fallback_enforces_deadline` — the no-binary path kills a `sleep 30` armed with a 1s budget well within the deadline.
- `watchdog_does_not_kill_fast_child` — an in-time child is left alone.
- `spawn_with_timeout_enforces_deadline` — the public API enforces the deadline regardless of which path it takes (guards existing call sites).

## Validation

- `cargo build --locked`, `cargo clippy --locked --lib`, `cargo fmt --check`, `cargo test --lib` — all green.
- **No `Cargo.lock` churn** (rquest versions are yanked; lockfile untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
