### PR TITLE
test: fix flaky session_lock PID-reuse tests (transient comm during fork/exec window)

### DIFF
--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -597,6 +597,54 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    /// Spawn a foreign (`sleep`) child for the PID-reuse tests, then — on Linux —
+    /// wait until its `/proc/<pid>/comm` reflects the post-`exec` image rather
+    /// than the still-shared parent (test-harness) comm.
+    ///
+    /// A freshly `spawn()`ed child is `fork`ed from the test binary and, until
+    /// its `exec` of `sleep` completes, transiently shares the parent's `comm`
+    /// (`worksgood-<hash>` / the cargo test binary). During that window
+    /// `pid_reused_by_foreign`'s "same executable as us" guard
+    /// (src/session_lock.rs:578-584) sees `their_comm == mine_comm` and returns
+    /// `false` — so asserting foreignness during the window flakes on loaded CI
+    /// runners where the `exec` is delayed (observed on graphwork/wg CI runs
+    /// 29090834963, 29090740682, 29102594830). Production PID reuse involves
+    /// stable, long-lived recycled processes and is unaffected; this raciness is
+    /// purely a test-harness artifact. Waiting for `exec` to land removes the
+    /// race without weakening the real identity/liveness checks.
+    fn spawn_foreign_child() -> std::process::Child {
+        let child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        #[cfg(target_os = "linux")]
+        {
+            let pid = child.id();
+            let comm_of = |p: u32| {
+                pid_process_identity(p)
+                    .and_then(|id| id.split_whitespace().next().map(str::to_owned))
+            };
+            let mine_comm = comm_of(std::process::id()).unwrap_or_default();
+            // Poll until the child's comm is readable and differs from ours,
+            // i.e. `exec` has replaced the shared image. ~2s of 1ms polls is far
+            // longer than an `exec` takes even on a saturated runner; a genuine
+            // hang surfaces as the test's own assertion, not an infinite loop.
+            for _ in 0..2000 {
+                match comm_of(pid) {
+                    Some(their_comm)
+                        if !their_comm.is_empty()
+                            && !mine_comm.is_empty()
+                            && their_comm != mine_comm =>
+                    {
+                        break;
+                    }
+                    _ => std::thread::sleep(std::time::Duration::from_millis(1)),
+                }
+            }
+        }
+        child
+    }
+
     #[test]
     fn acquire_creates_lock_file_with_pid() {
         let dir = tempdir().unwrap();
@@ -807,10 +855,9 @@ mod tests {
 
         // A live, unrelated (non-wg) process IS foreign — this is the
         // multi-day PID-reuse shape that used to wedge the supervisor.
-        let mut child = std::process::Command::new("sleep")
-            .arg("30")
-            .spawn()
-            .expect("spawn sleep");
+        // `spawn_foreign_child` waits for the child's `exec` to land so its
+        // `/proc` comm no longer shadows the test binary's (see helper doc).
+        let mut child = spawn_foreign_child();
         let sleep_pid = child.id();
         assert!(pid_is_alive(sleep_pid), "sleep child should be alive");
         if cfg!(target_os = "linux") {
@@ -833,10 +880,7 @@ mod tests {
         // live handler lock is held. Pre-fix this returned Some(foreign_pid)
         // forever (the wedge); now the recycled sentinel is reaped.
         let dir = tempdir().unwrap();
-        let mut child = std::process::Command::new("sleep")
-            .arg("30")
-            .spawn()
-            .expect("spawn sleep");
+        let mut child = spawn_foreign_child();
         let sleep_pid = child.id();
 
         let _lock = SessionLock::acquire(dir.path(), HandlerKind::InteractiveNex).unwrap();
@@ -867,10 +911,7 @@ mod tests {
         // A lock file whose PID is alive but foreign (recycled) must be
         // recovered on acquire, not treated as a live handler forever.
         let dir = tempdir().unwrap();
-        let mut child = std::process::Command::new("sleep")
-            .arg("30")
-            .spawn()
-            .expect("spawn sleep");
+        let mut child = spawn_foreign_child();
         let sleep_pid = child.id();
 
         std::fs::create_dir_all(dir.path()).unwrap();


### PR DESCRIPTION
## Root cause

Between `fork` and `exec`, a freshly spawned child transiently shares its parent's `/proc/<pid>/comm` before the exec of the target binary (`sleep`) lands. `pid_reused_by_foreign`'s "same executable as us" guard at `src/session_lock.rs:578-584` compares `their_comm` against `mine_comm` and returns `false` (i.e. "not foreign") when the two transiently match — so asserting foreignness immediately after `spawn()` races the child's own `exec`, and flakes under CI load when the exec is delayed.

## Evidence

Observed as failing runs on unrelated PRs:
- #51 run 29090834963 (stable)
- #52 run 29090740682 (nightly)
- #49 runs 29102594830 (nightly) and its follow-up stable failure

## Fix

Added a `spawn_foreign_child()` test helper that spawns the `sleep` child and (on Linux) polls `/proc/<pid>/comm` until it differs from the parent's comm — i.e. until `exec` has actually landed — before returning. Applied to the 3 tests that spawn a `sleep` child to simulate a foreign/recycled PID and then assert foreignness. Production code is untouched.