### PR TITLE
feat: --scope disposable guard on wg add (R8)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -388,6 +388,12 @@ pub enum Commands {
         /// Create as a blocking subtask: child is created, parent waits for child to complete
         #[arg(long)]
         subtask: bool,
+
+        /// Privilege scope for the spawned agent (R8). `--scope disposable`
+        /// runs the worker with WG_SCOPE=disposable and forbids it from minting
+        /// a persistent persona (`wg agent create`, `wg add --tag persistent`).
+        #[arg(long)]
+        scope: Option<String>,
     },
 
     /// Edit an existing task

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -437,9 +437,12 @@ pub fn run_with_remote_provider(
         anyhow::bail!("Task title cannot be empty");
     }
 
-    // R8: a disposable-scoped agent may not mint a persistent persona via
-    // `wg add --tag persistent`.
-    worksgood::scope_guard::enforce_persistent_tag(tags)?;
+    // R8 (default-deny): a disposable-scoped agent may only create
+    // disposable-scoped children. An ordinary untagged durable add inherits
+    // `scope:disposable`; an explicit `persistent` tag or a non-disposable
+    // `--scope` is denied. Non-disposable callers are unaffected.
+    let scoped_tags = worksgood::scope_guard::resolve_add_scope(tags)?;
+    let tags: &[String] = &scoped_tags;
 
     // Validate --subtask: requires WG_TASK_ID (must be called from within an agent context)
     let subtask_parent_id = if subtask {
@@ -1071,9 +1074,10 @@ pub fn run_remote(
         anyhow::bail!("Task title cannot be empty");
     }
 
-    // R8: a disposable-scoped agent may not mint a persistent persona via
-    // `wg add --tag persistent` (also gated for cross-repo adds).
-    worksgood::scope_guard::enforce_persistent_tag(tags)?;
+    // R8 (default-deny): as in `run`, a disposable-scoped caller may only create
+    // disposable-scoped children — enforced for cross-repo adds too.
+    let scoped_tags = worksgood::scope_guard::resolve_add_scope(tags)?;
+    let tags: &[String] = &scoped_tags;
 
     // Deprecation warning for --provider flag
     if let Some(p) = provider {

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -437,10 +437,10 @@ pub fn run_with_remote_provider(
         anyhow::bail!("Task title cannot be empty");
     }
 
-    // R8 (default-deny): a disposable-scoped agent may only create
-    // disposable-scoped children. An ordinary untagged durable add inherits
-    // `scope:disposable`; an explicit `persistent` tag or a non-disposable
-    // `--scope` is denied. Non-disposable callers are unaffected.
+    // R8 (default-deny): a disposable-scoped agent may only create *explicitly*
+    // disposable child work (`--scope disposable` / `--tag disposable`). An
+    // ordinary untagged durable add, an explicit `persistent` tag, or a
+    // non-disposable `--scope` is refused. Non-disposable callers are unaffected.
     let scoped_tags = worksgood::scope_guard::resolve_add_scope(tags)?;
     let tags: &[String] = &scoped_tags;
 
@@ -1075,7 +1075,7 @@ pub fn run_remote(
     }
 
     // R8 (default-deny): as in `run`, a disposable-scoped caller may only create
-    // disposable-scoped children — enforced for cross-repo adds too.
+    // explicitly disposable child work — enforced for cross-repo adds too.
     let scoped_tags = worksgood::scope_guard::resolve_add_scope(tags)?;
     let tags: &[String] = &scoped_tags;
 

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -437,6 +437,10 @@ pub fn run_with_remote_provider(
         anyhow::bail!("Task title cannot be empty");
     }
 
+    // R8: a disposable-scoped agent may not mint a persistent persona via
+    // `wg add --tag persistent`.
+    worksgood::scope_guard::enforce_persistent_tag(tags)?;
+
     // Validate --subtask: requires WG_TASK_ID (must be called from within an agent context)
     let subtask_parent_id = if subtask {
         let parent_id = std::env::var("WG_TASK_ID").map_err(|_| {
@@ -1066,6 +1070,10 @@ pub fn run_remote(
     if title.trim().is_empty() {
         anyhow::bail!("Task title cannot be empty");
     }
+
+    // R8: a disposable-scoped agent may not mint a persistent persona via
+    // `wg add --tag persistent` (also gated for cross-repo adds).
+    worksgood::scope_guard::enforce_persistent_tag(tags)?;
 
     // Deprecation warning for --provider flag
     if let Some(p) = provider {

--- a/src/commands/agent_crud.rs
+++ b/src/commands/agent_crud.rs
@@ -46,6 +46,9 @@ pub fn run_create(
     preferred_model: Option<&str>,
     preferred_provider: Option<&str>,
 ) -> Result<()> {
+    // R8: a disposable-scoped agent may not mint a persistent persona.
+    worksgood::scope_guard::enforce(worksgood::scope_guard::PersistentSpawn::Agent)?;
+
     let agency_dir = workgraph_dir.join("agency");
     agency::init(&agency_dir).context("Failed to initialise agency directory")?;
 

--- a/src/dispatch/plan.rs
+++ b/src/dispatch/plan.rs
@@ -1866,4 +1866,46 @@ mod tests {
         assert_eq!(plan.placement, Placement::Local);
         assert_ne!(plan.executor, ExecutorKind::RemoteRunner);
     }
+
+    // ── R8: WG_SCOPE propagation (Erik, PR #56 rd3) ──────────────────────────
+
+    /// The allowed disposable route is scope-carrying: a task tagged
+    /// `scope:disposable` (what `wg add --scope disposable` persists) produces a
+    /// SpawnPlan whose env sets `WG_SCOPE=disposable`, so the child worker is
+    /// itself contained and cannot mint durable grandchildren.
+    #[test]
+    fn plan_spawn_propagates_wg_scope_from_scope_disposable_tag() {
+        let config = Config::default();
+        let mut task = base_task("disposable-child");
+        task.tags.push("scope:disposable".to_string());
+
+        let plan = plan_spawn(&task, &config, None, Some("opus")).unwrap();
+        assert_eq!(
+            plan.env
+                .get(crate::scope_guard::WG_SCOPE_ENV)
+                .map(String::as_str),
+            Some("disposable"),
+            "an allowed --scope disposable child must spawn with WG_SCOPE=disposable"
+        );
+    }
+
+    /// The reason the `wg add` boundary refuses a *bare* `disposable` tag: it is
+    /// NOT a `scope:` tag, so `plan_spawn` cannot recover a scope from it — the
+    /// child would spawn UNSCOPED and could mint durable grandchildren. This
+    /// pins the dispatcher-side half of Erik's PR #56 rd3 hole, motivating the
+    /// scope_guard refusal.
+    #[test]
+    fn plan_spawn_does_not_scope_a_bare_disposable_tag() {
+        let config = Config::default();
+        let mut task = base_task("bare-tag-child");
+        task.tags.push("disposable".to_string());
+
+        let plan = plan_spawn(&task, &config, None, Some("opus")).unwrap();
+        assert_eq!(
+            plan.env.get(crate::scope_guard::WG_SCOPE_ENV),
+            None,
+            "a bare `disposable` tag carries no scope: prefix, so plan_spawn leaves \
+             the worker UNSCOPED — exactly why the wg add boundary refuses it"
+        );
+    }
 }

--- a/src/dispatch/plan.rs
+++ b/src/dispatch/plan.rs
@@ -562,6 +562,13 @@ pub fn plan_spawn(
         env.insert("WG_REASONING".to_string(), reasoning.as_str().to_string());
     }
 
+    // R8: propagate the task's privilege scope (`scope:<value>` tag, set by
+    // `wg add --scope`) so the guard can deny persistent spawns from a
+    // disposable worker. See `crate::scope_guard`.
+    if let Some(scope) = crate::scope_guard::scope_from_tags(&task.tags) {
+        env.insert(crate::scope_guard::WG_SCOPE_ENV.to_string(), scope);
+    }
+
     let provenance = SpawnProvenance {
         executor_source,
         model_source,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub mod registry {
 }
 pub mod review;
 pub mod runs;
+pub mod scope_guard;
 pub mod secret;
 pub mod service;
 pub mod session_lock;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1006,7 +1006,17 @@ fn main() -> Result<()> {
             priority,
             cron,
             subtask,
+            scope,
         } => {
+            // R8: persist an explicit --scope as a `scope:<value>` tag so the
+            // dispatcher can propagate WG_SCOPE to the spawned worker.
+            let tag = if let Some(scope_val) = scope.as_deref() {
+                let mut tags = tag;
+                tags.push(worksgood::scope_guard::scope_tag(scope_val)?);
+                tags
+            } else {
+                tag
+            };
             // Determine effective paused/unplaced state:
             // - --paused always pauses (user-managed draft, skips placement)
             // - --no-place: unplaced=true, paused=false (immediate dispatch)

--- a/src/scope_guard.rs
+++ b/src/scope_guard.rs
@@ -1,0 +1,153 @@
+//! R8 disposable scope guard.
+//!
+//! A task created with `wg add --scope disposable` runs its agent with
+//! `WG_SCOPE=disposable` in the environment (the dispatcher's [`SpawnPlan`]
+//! propagates it — see `dispatch::plan`). A disposable-scoped agent must not be
+//! able to mint a *persistent* persona: it may not run `wg agent create` or
+//! `wg add --tag persistent`.
+//!
+//! This is the policy gate for R8 (docs/02 §3.2 in the family-team project):
+//! the action is structurally possible today — any agent can call `wg agent
+//! create` with any role — so we deny it at the CLI boundary when the caller is
+//! disposable-scoped. Only the reserved scope value `disposable` restricts
+//! anything; every other value (including unscoped) is unaffected.
+//!
+//! [`SpawnPlan`]: crate::dispatch::plan::SpawnPlan
+
+use anyhow::{Result, bail};
+
+/// Environment variable the dispatcher sets on a scoped worker and the guard
+/// reads back at the CLI boundary.
+pub const WG_SCOPE_ENV: &str = "WG_SCOPE";
+
+/// The one scope value that is actually restricted today.
+pub const SCOPE_DISPOSABLE: &str = "disposable";
+
+/// Tag prefix used to persist a task's scope on the task itself
+/// (e.g. `scope:disposable`). Kept as a tag so no schema field is added.
+pub const SCOPE_TAG_PREFIX: &str = "scope:";
+
+/// A privileged spawn a disposable-scoped agent is forbidden from performing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistentSpawn {
+    /// `wg agent create` — mints a persistent named agent/persona.
+    Agent,
+    /// `wg add --tag persistent` — creates a task tagged `persistent`.
+    Task,
+}
+
+impl PersistentSpawn {
+    /// The user-facing command this action corresponds to.
+    fn command(self) -> &'static str {
+        match self {
+            PersistentSpawn::Agent => "wg agent create",
+            PersistentSpawn::Task => "wg add --tag persistent",
+        }
+    }
+}
+
+/// Extract a scope value from a task's tags (`scope:<value>`), if present.
+///
+/// The first `scope:` tag wins. Returns `None` when the task is unscoped.
+pub fn scope_from_tags(tags: &[String]) -> Option<String> {
+    tags.iter()
+        .find_map(|t| t.strip_prefix(SCOPE_TAG_PREFIX))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Pure policy check: does `scope` forbid `action`?
+///
+/// Only `scope == Some("disposable")` restricts anything; every other value
+/// (including `None`) is allowed. Kept pure — the scope is passed in rather than
+/// read from the environment — so it is deterministic under parallel tests.
+pub fn check_scope(scope: Option<&str>, action: PersistentSpawn) -> Result<()> {
+    if scope == Some(SCOPE_DISPOSABLE) {
+        bail!(
+            "scope=disposable forbids `{}`: a disposable agent may not mint a persistent \
+             persona (R8). Have a persistent agent perform this action, or drop \
+             `--scope disposable`.",
+            action.command()
+        );
+    }
+    Ok(())
+}
+
+/// Read the current process scope from `WG_SCOPE` (empty/whitespace ⇒ unscoped).
+pub fn current_scope() -> Option<String> {
+    std::env::var(WG_SCOPE_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Enforce the scope policy for `action` against the current process
+/// environment. Called at the `wg agent create` CLI boundary.
+pub fn enforce(action: PersistentSpawn) -> Result<()> {
+    check_scope(current_scope().as_deref(), action)
+}
+
+/// Enforce the scope policy for `wg add` iff the new task is tagged
+/// `persistent`. A no-op for every other add.
+pub fn enforce_persistent_tag(tags: &[String]) -> Result<()> {
+    if tags.iter().any(|t| t == "persistent") {
+        enforce(PersistentSpawn::Task)?;
+    }
+    Ok(())
+}
+
+/// Validate a user-supplied `--scope` value and return the tag that persists it.
+///
+/// Scope values are lowercase alphanumerics plus `-`/`_` (they become part of a
+/// tag and an env var value). Returns `scope:<value>`.
+pub fn scope_tag(value: &str) -> Result<String> {
+    let v = value.trim();
+    if v.is_empty() {
+        bail!("--scope value cannot be empty");
+    }
+    if !v
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        bail!(
+            "invalid --scope value '{}': use letters, digits, '-' or '_'",
+            value
+        );
+    }
+    Ok(format!("{}{}", SCOPE_TAG_PREFIX, v))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disposable_forbids_both_spawns() {
+        assert!(check_scope(Some(SCOPE_DISPOSABLE), PersistentSpawn::Agent).is_err());
+        assert!(check_scope(Some(SCOPE_DISPOSABLE), PersistentSpawn::Task).is_err());
+    }
+
+    #[test]
+    fn non_disposable_is_allowed() {
+        assert!(check_scope(None, PersistentSpawn::Agent).is_ok());
+        assert!(check_scope(Some("persistent"), PersistentSpawn::Task).is_ok());
+        assert!(check_scope(Some("team"), PersistentSpawn::Agent).is_ok());
+    }
+
+    #[test]
+    fn tag_roundtrip() {
+        assert_eq!(scope_tag("disposable").unwrap(), "scope:disposable");
+        assert_eq!(
+            scope_from_tags(&["scope:disposable".to_string()]).as_deref(),
+            Some("disposable")
+        );
+        assert!(scope_tag("").is_err());
+        assert!(scope_tag("has space").is_err());
+    }
+
+    #[test]
+    fn enforce_persistent_tag_only_gates_persistent() {
+        // No persistent tag → always ok regardless of env.
+        assert!(enforce_persistent_tag(&["urgent".to_string()]).is_ok());
+    }
+}

--- a/src/scope_guard.rs
+++ b/src/scope_guard.rs
@@ -10,11 +10,24 @@
 //! the action is structurally possible today — any agent can call `wg agent
 //! create` with any role, or mint durable follow-up work with `wg add` — so we
 //! deny it at the CLI boundary when the caller is disposable-scoped. The `wg
-//! add` boundary is **default-deny**: from disposable scope the only allowed
-//! add is *explicitly* disposable child work (`--scope disposable` /
-//! `--tag disposable`); every other add is refused (see
-//! [`resolve_add_scope_for`]). Only the reserved scope value `disposable`
-//! restricts anything; every other value (including unscoped) is unaffected.
+//! add` boundary is **default-deny**: from disposable scope the *only* allowed
+//! add is an **explicit, scope-carrying** disposable child — `--scope
+//! disposable`, which persists a `scope:disposable` tag; every other add is
+//! refused (see [`resolve_add_scope_for`]). Only the reserved scope value
+//! `disposable` restricts anything; every other value (including unscoped) is
+//! unaffected.
+//!
+//! Why *scope-carrying* and not a bare `disposable` tag (Erik, PR #56 rd3): the
+//! dispatcher's [`plan_spawn`] recovers a worker's scope only from a
+//! `scope:<value>` tag (see [`scope_from_tags`]). A bare `disposable` tag is
+//! therefore invisible to the dispatcher, so a child created with `--tag
+//! disposable` would spawn **unscoped** and could mint durable grandchildren —
+//! containment defeated one generation later. The allowed route must persist
+//! `scope:disposable` so `WG_SCOPE=disposable` propagates and the child is
+//! itself contained. [`resolve_add_scope_for`] guarantees this invariant: any
+//! tag set it returns for a disposable caller carries `scope:disposable`.
+//!
+//! [`plan_spawn`]: crate::dispatch::plan::plan_spawn
 //!
 //! [`SpawnPlan`]: crate::dispatch::plan::SpawnPlan
 
@@ -106,22 +119,32 @@ pub fn resolve_add_scope(tags: &[String]) -> Result<Vec<String>> {
 /// When the caller is **not** disposable-scoped the tags are returned verbatim.
 ///
 /// When the caller **is** `disposable`-scoped the policy is **default-deny**:
-/// from disposable scope the *only* thing that may be created is **explicitly
-/// disposable / non-durable child work**. Concretely:
+/// from disposable scope the *only* thing that may be created is an **explicit,
+/// scope-carrying disposable child** — i.e. `--scope disposable`, which
+/// persists a `scope:disposable` tag. Concretely:
 ///
-///   * an explicit child `--scope disposable` (a `scope:disposable` tag), or an
-///     explicit `disposable` tag, is **allowed** verbatim — a disposable agent
-///     may spawn a disposable child;
+///   * an explicit child `--scope disposable` (a `scope:disposable` tag) is
+///     **allowed** — a disposable agent may spawn a disposable child, and the
+///     `scope:disposable` tag guarantees the dispatcher propagates
+///     `WG_SCOPE=disposable` so the child is itself contained;
 ///   * an explicit `persistent` tag, or an explicit `scope:<x>` naming any scope
 ///     other than `disposable`, is **denied** — a disposable agent may not
-///     escalate a child into durable / persistent graph state; and
-///   * an ordinary untagged durable `wg add "x"` (the case Erik flagged on
-///     PR #56 — minting durable follow-up work simply by omitting the tag) is
-///     **denied**. It is *not* silently downgraded: the merge plan requires
-///     that only *explicitly* disposable child work be allowed, so the caller
-///     must opt in with `--scope disposable` (or `--tag disposable`).
+///     escalate a child into durable / persistent graph state;
+///   * a **bare `disposable` tag** (`--tag disposable`, no `scope:` prefix) is
+///     **denied**. This is Erik's PR #56 rd3 hole: a bare tag is invisible to
+///     [`plan_spawn`] (which reads only `scope:` tags via [`scope_from_tags`]),
+///     so the child would spawn *unscoped* and could mint durable grandchildren.
+///     The caller must opt in with the scope-carrying `--scope disposable`; and
+///   * an ordinary untagged durable `wg add "x"` (minting durable follow-up work
+///     simply by omitting the tag) is **denied**. It is *not* silently
+///     downgraded — the caller must opt in with `--scope disposable`.
 ///
 /// The returned `Vec` is the tag set that should be persisted on the new task.
+/// **Invariant:** for a disposable caller, any `Ok` result carries a
+/// `scope:disposable` tag — so no allowed form can reach [`plan_spawn`] as an
+/// unscoped worker.
+///
+/// [`plan_spawn`]: crate::dispatch::plan::plan_spawn
 pub fn resolve_add_scope_for(caller_scope: Option<&str>, tags: &[String]) -> Result<Vec<String>> {
     // Only the reserved `disposable` scope constrains anything.
     if caller_scope != Some(SCOPE_DISPOSABLE) {
@@ -133,8 +156,9 @@ pub fn resolve_add_scope_for(caller_scope: Option<&str>, tags: &[String]) -> Res
         check_scope(caller_scope, PersistentSpawn::Task)?;
     }
 
-    // An explicit child `--scope` is either the allowed disposable case or an
-    // escalation to deny.
+    // The ONLY allowed add from disposable scope is an explicit, scope-carrying
+    // `--scope disposable` (a `scope:disposable` tag). Any other `scope:<x>` is
+    // an escalation → deny.
     if let Some(child_scope) = scope_from_tags(tags) {
         if child_scope != SCOPE_DISPOSABLE {
             bail!(
@@ -144,24 +168,34 @@ pub fn resolve_add_scope_for(caller_scope: Option<&str>, tags: &[String]) -> Res
                  durable work."
             );
         }
-        // Child is explicitly disposable-scoped — allowed, verbatim.
+        // Child is explicitly disposable-scoped. Uphold the module invariant: the
+        // returned tag set MUST carry `scope:disposable` so `plan_spawn`
+        // propagates `WG_SCOPE=disposable` and the child cannot mint durable
+        // grandchildren. It does here by construction (the `scope:disposable`
+        // tag we just matched); assert it so a future refactor can't regress the
+        // containment boundary.
+        debug_assert_eq!(
+            scope_from_tags(tags).as_deref(),
+            Some(SCOPE_DISPOSABLE),
+            "allowed disposable child must carry scope:disposable"
+        );
         return Ok(tags.to_vec());
     }
 
-    // A child explicitly tagged `disposable` (non-durable) is allowed, verbatim.
-    if tags.iter().any(|t| t == "disposable") {
-        return Ok(tags.to_vec());
-    }
-
-    // Ordinary untagged durable `wg add "x"` from disposable scope: DENY.
-    // This is Erik's blocking case — a disposable worker must not mint durable
-    // follow-up graph work by omitting the tag. Only *explicitly* disposable
-    // child work is allowed from disposable scope; the caller must opt in.
+    // Everything else is refused. This includes:
+    //   * a BARE `disposable` tag (Erik's PR #56 rd3 hole) — it is NOT a `scope:`
+    //     tag, so `plan_spawn` would spawn the child unscoped, able to mint
+    //     durable grandchildren; and
+    //   * an ordinary untagged durable `wg add "x"` — minting durable follow-up
+    //     work by omitting the tag.
+    // Only an explicit, scope-carrying `--scope disposable` is allowed.
     bail!(
-        "scope=disposable forbids a durable `wg add`: a disposable agent may only create \
-         explicitly disposable child work — pass `--scope disposable` (or `--tag disposable`) \
-         to mint a disposable child. Durable follow-up graph work must be created by a \
-         persistent agent (R8)."
+        "scope=disposable forbids this `wg add`: a disposable agent may only create an \
+         explicitly disposable, scope-carrying child — pass `--scope disposable`, which \
+         persists a `scope:disposable` tag the dispatcher propagates as WG_SCOPE. A bare \
+         `--tag disposable` is not accepted: it carries no `scope:` prefix, so the child \
+         would spawn unscoped and could mint durable grandchildren. Durable follow-up work \
+         must be created by a persistent agent (R8)."
     );
 }
 
@@ -273,10 +307,28 @@ mod tests {
     }
 
     #[test]
-    fn disposable_explicit_disposable_tag_child_is_allowed() {
-        // A child explicitly tagged `disposable` (non-durable) is allowed verbatim.
+    fn disposable_bare_disposable_tag_child_is_denied() {
+        // Erik's PR #56 rd3 hole: a BARE `disposable` tag carries no `scope:`
+        // prefix, so `plan_spawn` (which reads only `scope:` tags) would spawn
+        // the child UNSCOPED — free to mint durable grandchildren. It must be
+        // refused; only the scope-carrying `--scope disposable` is allowed.
+        assert!(
+            resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["disposable".to_string()]).is_err(),
+            "a bare `--tag disposable` from disposable scope must be refused"
+        );
+    }
+
+    #[test]
+    fn disposable_allowed_result_always_carries_scope_tag() {
+        // Module invariant: every Ok result for a disposable caller carries
+        // `scope:disposable`, so no allowed form reaches plan_spawn unscoped.
         let resolved =
-            resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["disposable".to_string()]).unwrap();
-        assert_eq!(resolved, vec!["disposable".to_string()]);
+            resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:disposable".to_string()])
+                .unwrap();
+        assert_eq!(
+            scope_from_tags(&resolved).as_deref(),
+            Some(SCOPE_DISPOSABLE),
+            "allowed disposable add must carry scope:disposable for propagation"
+        );
     }
 }

--- a/src/scope_guard.rs
+++ b/src/scope_guard.rs
@@ -87,13 +87,61 @@ pub fn enforce(action: PersistentSpawn) -> Result<()> {
     check_scope(current_scope().as_deref(), action)
 }
 
-/// Enforce the scope policy for `wg add` iff the new task is tagged
-/// `persistent`. A no-op for every other add.
-pub fn enforce_persistent_tag(tags: &[String]) -> Result<()> {
-    if tags.iter().any(|t| t == "persistent") {
-        enforce(PersistentSpawn::Task)?;
+/// Resolve the tag set for a `wg add`, enforcing the R8 disposable boundary as
+/// a **default-deny** policy against the current process environment.
+///
+/// See [`resolve_add_scope_for`] for the rule; this wrapper simply reads the
+/// caller's scope from `WG_SCOPE`. Called at the `wg add` CLI boundary.
+pub fn resolve_add_scope(tags: &[String]) -> Result<Vec<String>> {
+    resolve_add_scope_for(current_scope().as_deref(), tags)
+}
+
+/// Pure core of [`resolve_add_scope`] — the caller's scope is passed in rather
+/// than read from the environment, so it is deterministic under parallel tests.
+///
+/// When the caller is **not** disposable-scoped the tags are returned verbatim.
+///
+/// When the caller **is** `disposable`-scoped the policy is default-deny: a
+/// disposable agent may only ever create disposable-scoped children, so
+///
+///   * an explicit `persistent` tag, or an explicit `scope:<x>` naming any scope
+///     other than `disposable`, is **denied** — a disposable agent may not
+///     escalate a child into durable / persistent graph state; and
+///   * every other add (ordinary untagged durable `wg add "x"`, the case Erik
+///     flagged) is forced to **inherit** `scope:disposable`, so it mints a
+///     disposable child instead of durable follow-up work.
+///
+/// The returned `Vec` is the tag set that should be persisted on the new task.
+pub fn resolve_add_scope_for(caller_scope: Option<&str>, tags: &[String]) -> Result<Vec<String>> {
+    // Only the reserved `disposable` scope constrains anything.
+    if caller_scope != Some(SCOPE_DISPOSABLE) {
+        return Ok(tags.to_vec());
     }
-    Ok(())
+
+    // Explicit persistent tag → hard deny (the original R8 case).
+    if tags.iter().any(|t| t == "persistent") {
+        check_scope(caller_scope, PersistentSpawn::Task)?;
+    }
+
+    // An explicit child `--scope` other than `disposable` is an escalation → deny.
+    if let Some(child_scope) = scope_from_tags(tags) {
+        if child_scope != SCOPE_DISPOSABLE {
+            bail!(
+                "scope=disposable forbids `wg add --scope {child_scope}`: a disposable \
+                 agent may only create disposable-scoped children (R8). Drop the \
+                 `--scope {child_scope}` override, or have a persistent agent create \
+                 durable work."
+            );
+        }
+        // Child is already disposable-scoped — nothing to inherit.
+        return Ok(tags.to_vec());
+    }
+
+    // Default-deny durable state: force the untagged child to inherit disposable
+    // scope so no durable follow-up graph work can be minted from disposable scope.
+    let mut resolved = tags.to_vec();
+    resolved.push(scope_tag(SCOPE_DISPOSABLE)?);
+    Ok(resolved)
 }
 
 /// Validate a user-supplied `--scope` value and return the tag that persists it.
@@ -146,8 +194,49 @@ mod tests {
     }
 
     #[test]
-    fn enforce_persistent_tag_only_gates_persistent() {
-        // No persistent tag → always ok regardless of env.
-        assert!(enforce_persistent_tag(&["urgent".to_string()]).is_ok());
+    fn resolve_add_scope_leaves_non_disposable_callers_untouched() {
+        // Unscoped / non-disposable callers: tags pass through verbatim, no scope inherited.
+        assert_eq!(
+            resolve_add_scope_for(None, &["urgent".to_string()]).unwrap(),
+            vec!["urgent".to_string()]
+        );
+        assert_eq!(
+            resolve_add_scope_for(Some("team"), &["persistent".to_string()]).unwrap(),
+            vec!["persistent".to_string()]
+        );
+    }
+
+    #[test]
+    fn disposable_untagged_add_inherits_disposable_scope() {
+        // The case Erik flagged: an ordinary untagged durable add from disposable
+        // scope must NOT mint durable work — it inherits scope:disposable instead.
+        let resolved = resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["urgent".to_string()]).unwrap();
+        assert!(resolved.contains(&"urgent".to_string()));
+        assert_eq!(scope_from_tags(&resolved).as_deref(), Some(SCOPE_DISPOSABLE));
+    }
+
+    #[test]
+    fn disposable_add_persistent_tag_is_denied() {
+        assert!(resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["persistent".to_string()]).is_err());
+    }
+
+    #[test]
+    fn disposable_add_escalating_scope_is_denied() {
+        // Trying to hand a child a non-disposable scope is an escalation.
+        assert!(resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:team".to_string()]).is_err());
+    }
+
+    #[test]
+    fn disposable_add_already_disposable_is_idempotent() {
+        // An explicit --scope disposable child is allowed and not double-tagged.
+        let resolved =
+            resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:disposable".to_string()]).unwrap();
+        assert_eq!(
+            resolved
+                .iter()
+                .filter(|t| t.as_str() == "scope:disposable")
+                .count(),
+            1
+        );
     }
 }

--- a/src/scope_guard.rs
+++ b/src/scope_guard.rs
@@ -3,14 +3,18 @@
 //! A task created with `wg add --scope disposable` runs its agent with
 //! `WG_SCOPE=disposable` in the environment (the dispatcher's [`SpawnPlan`]
 //! propagates it — see `dispatch::plan`). A disposable-scoped agent must not be
-//! able to mint a *persistent* persona: it may not run `wg agent create` or
-//! `wg add --tag persistent`.
+//! able to mint durable/persistent graph state: it may not run `wg agent
+//! create`, `wg add --tag persistent`, or an ordinary durable `wg add`.
 //!
 //! This is the policy gate for R8 (docs/02 §3.2 in the family-team project):
 //! the action is structurally possible today — any agent can call `wg agent
-//! create` with any role — so we deny it at the CLI boundary when the caller is
-//! disposable-scoped. Only the reserved scope value `disposable` restricts
-//! anything; every other value (including unscoped) is unaffected.
+//! create` with any role, or mint durable follow-up work with `wg add` — so we
+//! deny it at the CLI boundary when the caller is disposable-scoped. The `wg
+//! add` boundary is **default-deny**: from disposable scope the only allowed
+//! add is *explicitly* disposable child work (`--scope disposable` /
+//! `--tag disposable`); every other add is refused (see
+//! [`resolve_add_scope_for`]). Only the reserved scope value `disposable`
+//! restricts anything; every other value (including unscoped) is unaffected.
 //!
 //! [`SpawnPlan`]: crate::dispatch::plan::SpawnPlan
 
@@ -101,15 +105,21 @@ pub fn resolve_add_scope(tags: &[String]) -> Result<Vec<String>> {
 ///
 /// When the caller is **not** disposable-scoped the tags are returned verbatim.
 ///
-/// When the caller **is** `disposable`-scoped the policy is default-deny: a
-/// disposable agent may only ever create disposable-scoped children, so
+/// When the caller **is** `disposable`-scoped the policy is **default-deny**:
+/// from disposable scope the *only* thing that may be created is **explicitly
+/// disposable / non-durable child work**. Concretely:
 ///
+///   * an explicit child `--scope disposable` (a `scope:disposable` tag), or an
+///     explicit `disposable` tag, is **allowed** verbatim — a disposable agent
+///     may spawn a disposable child;
 ///   * an explicit `persistent` tag, or an explicit `scope:<x>` naming any scope
 ///     other than `disposable`, is **denied** — a disposable agent may not
 ///     escalate a child into durable / persistent graph state; and
-///   * every other add (ordinary untagged durable `wg add "x"`, the case Erik
-///     flagged) is forced to **inherit** `scope:disposable`, so it mints a
-///     disposable child instead of durable follow-up work.
+///   * an ordinary untagged durable `wg add "x"` (the case Erik flagged on
+///     PR #56 — minting durable follow-up work simply by omitting the tag) is
+///     **denied**. It is *not* silently downgraded: the merge plan requires
+///     that only *explicitly* disposable child work be allowed, so the caller
+///     must opt in with `--scope disposable` (or `--tag disposable`).
 ///
 /// The returned `Vec` is the tag set that should be persisted on the new task.
 pub fn resolve_add_scope_for(caller_scope: Option<&str>, tags: &[String]) -> Result<Vec<String>> {
@@ -123,7 +133,8 @@ pub fn resolve_add_scope_for(caller_scope: Option<&str>, tags: &[String]) -> Res
         check_scope(caller_scope, PersistentSpawn::Task)?;
     }
 
-    // An explicit child `--scope` other than `disposable` is an escalation → deny.
+    // An explicit child `--scope` is either the allowed disposable case or an
+    // escalation to deny.
     if let Some(child_scope) = scope_from_tags(tags) {
         if child_scope != SCOPE_DISPOSABLE {
             bail!(
@@ -133,15 +144,25 @@ pub fn resolve_add_scope_for(caller_scope: Option<&str>, tags: &[String]) -> Res
                  durable work."
             );
         }
-        // Child is already disposable-scoped — nothing to inherit.
+        // Child is explicitly disposable-scoped — allowed, verbatim.
         return Ok(tags.to_vec());
     }
 
-    // Default-deny durable state: force the untagged child to inherit disposable
-    // scope so no durable follow-up graph work can be minted from disposable scope.
-    let mut resolved = tags.to_vec();
-    resolved.push(scope_tag(SCOPE_DISPOSABLE)?);
-    Ok(resolved)
+    // A child explicitly tagged `disposable` (non-durable) is allowed, verbatim.
+    if tags.iter().any(|t| t == "disposable") {
+        return Ok(tags.to_vec());
+    }
+
+    // Ordinary untagged durable `wg add "x"` from disposable scope: DENY.
+    // This is Erik's blocking case — a disposable worker must not mint durable
+    // follow-up graph work by omitting the tag. Only *explicitly* disposable
+    // child work is allowed from disposable scope; the caller must opt in.
+    bail!(
+        "scope=disposable forbids a durable `wg add`: a disposable agent may only create \
+         explicitly disposable child work — pass `--scope disposable` (or `--tag disposable`) \
+         to mint a disposable child. Durable follow-up graph work must be created by a \
+         persistent agent (R8)."
+    );
 }
 
 /// Validate a user-supplied `--scope` value and return the tag that persists it.
@@ -207,30 +228,37 @@ mod tests {
     }
 
     #[test]
-    fn disposable_untagged_add_inherits_disposable_scope() {
+    fn disposable_untagged_add_is_denied() {
         // The case Erik flagged: an ordinary untagged durable add from disposable
-        // scope must NOT mint durable work — it inherits scope:disposable instead.
-        let resolved = resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["urgent".to_string()]).unwrap();
-        assert!(resolved.contains(&"urgent".to_string()));
-        assert_eq!(scope_from_tags(&resolved).as_deref(), Some(SCOPE_DISPOSABLE));
+        // scope must be REFUSED — a disposable agent may not mint durable
+        // follow-up work by omitting the tag. It is not silently downgraded.
+        assert!(resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["urgent".to_string()]).is_err());
+        // Even a fully untagged add is refused.
+        assert!(resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &[]).is_err());
     }
 
     #[test]
     fn disposable_add_persistent_tag_is_denied() {
-        assert!(resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["persistent".to_string()]).is_err());
+        assert!(
+            resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["persistent".to_string()]).is_err()
+        );
     }
 
     #[test]
     fn disposable_add_escalating_scope_is_denied() {
         // Trying to hand a child a non-disposable scope is an escalation.
-        assert!(resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:team".to_string()]).is_err());
+        assert!(
+            resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:team".to_string()]).is_err()
+        );
     }
 
     #[test]
-    fn disposable_add_already_disposable_is_idempotent() {
-        // An explicit --scope disposable child is allowed and not double-tagged.
+    fn disposable_explicit_disposable_scope_child_is_allowed() {
+        // The one allowed case: an explicit --scope disposable child. Allowed
+        // verbatim and not double-tagged.
         let resolved =
-            resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:disposable".to_string()]).unwrap();
+            resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:disposable".to_string()])
+                .unwrap();
         assert_eq!(
             resolved
                 .iter()
@@ -238,5 +266,17 @@ mod tests {
                 .count(),
             1
         );
+        assert_eq!(
+            scope_from_tags(&resolved).as_deref(),
+            Some(SCOPE_DISPOSABLE)
+        );
+    }
+
+    #[test]
+    fn disposable_explicit_disposable_tag_child_is_allowed() {
+        // A child explicitly tagged `disposable` (non-durable) is allowed verbatim.
+        let resolved =
+            resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["disposable".to_string()]).unwrap();
+        assert_eq!(resolved, vec!["disposable".to_string()]);
     }
 }

--- a/tests/integration_scope_guard.rs
+++ b/tests/integration_scope_guard.rs
@@ -6,7 +6,7 @@
 //! `wg add --tag persistent`. These tests pin the policy at the library
 //! boundary so the CLI handlers can rely on it.
 
-use worksgood::scope_guard::{check_scope, scope_from_tags, PersistentSpawn, SCOPE_DISPOSABLE};
+use worksgood::scope_guard::{PersistentSpawn, SCOPE_DISPOSABLE, check_scope, scope_from_tags};
 
 /// The load-bearing R8 policy: a disposable scope forbids every persistent
 /// spawn, while unscoped / non-disposable scopes are unaffected.

--- a/tests/integration_scope_guard.rs
+++ b/tests/integration_scope_guard.rs
@@ -6,7 +6,15 @@
 //! `wg add --tag persistent`. These tests pin the policy at the library
 //! boundary so the CLI handlers can rely on it.
 
-use worksgood::scope_guard::{PersistentSpawn, SCOPE_DISPOSABLE, check_scope, scope_from_tags};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+use worksgood::graph::{Node, WorkGraph};
+use worksgood::parser::{load_graph, save_graph};
+use worksgood::scope_guard::{
+    PersistentSpawn, SCOPE_DISPOSABLE, check_scope, resolve_add_scope_for, scope_from_tags,
+};
 
 /// The load-bearing R8 policy: a disposable scope forbids every persistent
 /// spawn, while unscoped / non-disposable scopes are unaffected.
@@ -46,4 +54,181 @@ fn test_scope_persisted_as_tag() {
         Some("disposable"),
     );
     assert_eq!(scope_from_tags(&["urgent".to_string()]), None);
+}
+
+/// Default-deny at the library boundary: a disposable caller may only ever mint
+/// disposable-scoped children.
+#[test]
+fn test_disposable_caller_default_deny_resolution() {
+    // Untagged durable add → inherits scope:disposable (no durable state minted).
+    let resolved =
+        resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["urgent".to_string()]).unwrap();
+    assert_eq!(
+        scope_from_tags(&resolved).as_deref(),
+        Some(SCOPE_DISPOSABLE),
+        "untagged add from disposable scope must inherit disposable scope"
+    );
+
+    // Explicit persistent tag / non-disposable scope → denied.
+    assert!(
+        resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["persistent".to_string()]).is_err(),
+        "disposable caller must not create a persistent-tagged task"
+    );
+    assert!(
+        resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:team".to_string()]).is_err(),
+        "disposable caller must not escalate a child to a non-disposable scope"
+    );
+
+    // Non-disposable callers are unaffected — tags pass through verbatim.
+    assert_eq!(
+        resolve_add_scope_for(None, &["urgent".to_string()]).unwrap(),
+        vec!["urgent".to_string()],
+        "unscoped callers must be unaffected"
+    );
+}
+
+// ── CLI end-to-end regressions (Erik's ask on PR #56) ──────────────────────
+
+fn wg_binary() -> PathBuf {
+    let mut path = std::env::current_exe().expect("could not get current exe path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push("wg");
+    assert!(
+        path.exists(),
+        "wg binary not found at {:?}. Run `cargo build` first.",
+        path
+    );
+    path
+}
+
+fn setup_workgraph(dir: &Path) -> PathBuf {
+    let wg_dir = dir.join(".wg");
+    fs::create_dir_all(&wg_dir).unwrap();
+    let graph = WorkGraph::new();
+    save_graph(&graph, &wg_dir.join("graph.jsonl")).unwrap();
+    wg_dir
+}
+
+fn wg_add(wg_dir: &Path, args: &[&str], env: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(wg_binary());
+    cmd.arg("--dir")
+        .arg(wg_dir)
+        .arg("add")
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Drop ambient agent env so the test hits the temp graph via --dir, not the
+    // live project graph, and controls scope explicitly.
+    cmd.env_remove("WG_DIR")
+        .env_remove("WG_SCOPE")
+        .env_remove("WG_TASK_ID");
+    // A real disposable worker runs in agent context; simulate it so the add is
+    // placed immediately rather than parked as an interactive draft.
+    cmd.env("WG_AGENT_ID", "agent-disposable");
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("failed to run wg add")
+}
+
+fn task_tags(wg_dir: &Path, id: &str) -> Vec<String> {
+    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    graph
+        .get_task(id)
+        .unwrap_or_else(|| panic!("task '{id}' not found in graph"))
+        .tags
+        .clone()
+}
+
+/// The Erik regression: `WG_SCOPE=disposable wg add "x"` with no `--tag
+/// persistent` must NOT mint durable follow-up work — the child inherits
+/// `scope:disposable`.
+#[test]
+fn cli_disposable_untagged_add_inherits_disposable_scope() {
+    let dir = TempDir::new().unwrap();
+    let wg_dir = setup_workgraph(dir.path());
+
+    let out = wg_add(
+        &wg_dir,
+        &["follow up work", "--id", "follow-up"],
+        &[("WG_SCOPE", "disposable")],
+    );
+    assert!(
+        out.status.success(),
+        "untagged disposable add should succeed as a disposable child.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        scope_from_tags(&task_tags(&wg_dir, "follow-up")).as_deref(),
+        Some(SCOPE_DISPOSABLE),
+        "untagged add from disposable scope must inherit scope:disposable, not mint durable work"
+    );
+}
+
+/// A disposable caller trying to create a persistent-tagged task is refused.
+#[test]
+fn cli_disposable_persistent_tag_is_refused() {
+    let dir = TempDir::new().unwrap();
+    let wg_dir = setup_workgraph(dir.path());
+
+    let out = wg_add(
+        &wg_dir,
+        &["durable thing", "--id", "nope", "--tag", "persistent"],
+        &[("WG_SCOPE", "disposable")],
+    );
+    assert!(
+        !out.status.success(),
+        "disposable + --tag persistent must be refused"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("disposable"),
+        "error should explain the disposable boundary: {stderr}"
+    );
+    // And nothing was minted.
+    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    assert!(
+        graph.get_task("nope").is_none(),
+        "refused add must not create a task"
+    );
+}
+
+/// A disposable caller trying to escalate a child to a non-disposable scope is refused.
+#[test]
+fn cli_disposable_scope_escalation_is_refused() {
+    let dir = TempDir::new().unwrap();
+    let wg_dir = setup_workgraph(dir.path());
+
+    let out = wg_add(
+        &wg_dir,
+        &["escalate", "--id", "esc", "--scope", "team"],
+        &[("WG_SCOPE", "disposable")],
+    );
+    assert!(
+        !out.status.success(),
+        "disposable + --scope team must be refused"
+    );
+}
+
+/// A normal (unscoped) caller is unaffected: no scope tag is injected.
+#[test]
+fn cli_unscoped_add_is_unaffected() {
+    let dir = TempDir::new().unwrap();
+    let wg_dir = setup_workgraph(dir.path());
+
+    let out = wg_add(&wg_dir, &["ordinary", "--id", "ordinary"], &[]);
+    assert!(
+        out.status.success(),
+        "unscoped add should succeed.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        scope_from_tags(&task_tags(&wg_dir, "ordinary")),
+        None,
+        "unscoped add must not inherit any scope"
+    );
 }

--- a/tests/integration_scope_guard.rs
+++ b/tests/integration_scope_guard.rs
@@ -1,10 +1,13 @@
 //! R8 — `--scope disposable` guard (docs/02 §3.2 in the family-team project).
 //!
 //! A task created with `wg add --scope disposable` runs its agent with
-//! `WG_SCOPE=disposable`. A disposable-scoped agent must not be able to mint a
-//! *persistent* persona: it may not run `wg agent create` or
-//! `wg add --tag persistent`. These tests pin the policy at the library
-//! boundary so the CLI handlers can rely on it.
+//! `WG_SCOPE=disposable`. A disposable-scoped agent must not be able to mint
+//! durable/persistent graph state: it may not run `wg agent create`,
+//! `wg add --tag persistent`, or an ordinary durable `wg add`. From disposable
+//! scope the `wg add` boundary is default-deny — only *explicitly* disposable
+//! child work (`--scope disposable` / `--tag disposable`) is allowed. These
+//! tests pin the policy at the library boundary so the CLI handlers can rely on
+//! it.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -56,17 +59,19 @@ fn test_scope_persisted_as_tag() {
     assert_eq!(scope_from_tags(&["urgent".to_string()]), None);
 }
 
-/// Default-deny at the library boundary: a disposable caller may only ever mint
-/// disposable-scoped children.
+/// Default-deny at the library boundary: from disposable scope only *explicitly*
+/// disposable child work is allowed; every other add is refused.
 #[test]
 fn test_disposable_caller_default_deny_resolution() {
-    // Untagged durable add → inherits scope:disposable (no durable state minted).
-    let resolved =
-        resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["urgent".to_string()]).unwrap();
-    assert_eq!(
-        scope_from_tags(&resolved).as_deref(),
-        Some(SCOPE_DISPOSABLE),
-        "untagged add from disposable scope must inherit disposable scope"
+    // Untagged durable add → REFUSED (not silently downgraded). This is Erik's
+    // blocking case: a disposable agent may not mint durable follow-up work.
+    assert!(
+        resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["urgent".to_string()]).is_err(),
+        "untagged durable add from disposable scope must be refused"
+    );
+    assert!(
+        resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &[]).is_err(),
+        "a fully untagged add from disposable scope must be refused"
     );
 
     // Explicit persistent tag / non-disposable scope → denied.
@@ -77,6 +82,15 @@ fn test_disposable_caller_default_deny_resolution() {
     assert!(
         resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:team".to_string()]).is_err(),
         "disposable caller must not escalate a child to a non-disposable scope"
+    );
+
+    // The allowed case: an explicit disposable child passes through verbatim.
+    let resolved =
+        resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:disposable".to_string()]).unwrap();
+    assert_eq!(
+        scope_from_tags(&resolved).as_deref(),
+        Some(SCOPE_DISPOSABLE),
+        "an explicit --scope disposable child must be allowed from disposable scope"
     );
 
     // Non-disposable callers are unaffected — tags pass through verbatim.
@@ -145,10 +159,10 @@ fn task_tags(wg_dir: &Path, id: &str) -> Vec<String> {
 }
 
 /// The Erik regression: `WG_SCOPE=disposable wg add "x"` with no `--tag
-/// persistent` must NOT mint durable follow-up work — the child inherits
-/// `scope:disposable`.
+/// persistent` must be REFUSED — a disposable agent may not mint durable
+/// follow-up work by omitting the tag, and nothing is minted.
 #[test]
-fn cli_disposable_untagged_add_inherits_disposable_scope() {
+fn cli_disposable_untagged_add_is_refused() {
     let dir = TempDir::new().unwrap();
     let wg_dir = setup_workgraph(dir.path());
 
@@ -158,14 +172,45 @@ fn cli_disposable_untagged_add_inherits_disposable_scope() {
         &[("WG_SCOPE", "disposable")],
     );
     assert!(
+        !out.status.success(),
+        "untagged durable add from disposable scope must be refused.\nstdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("disposable"),
+        "error should explain the disposable boundary: {stderr}"
+    );
+    // And nothing durable was minted.
+    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    assert!(
+        graph.get_task("follow-up").is_none(),
+        "refused durable add must not create a task"
+    );
+}
+
+/// The allowed disposable case Erik asked for: `WG_SCOPE=disposable wg add "x"
+/// --scope disposable` succeeds and the child carries `scope:disposable` — a
+/// disposable agent may spawn an explicitly disposable child.
+#[test]
+fn cli_disposable_explicit_disposable_add_is_allowed() {
+    let dir = TempDir::new().unwrap();
+    let wg_dir = setup_workgraph(dir.path());
+
+    let out = wg_add(
+        &wg_dir,
+        &["scrape child", "--id", "child", "--scope", "disposable"],
+        &[("WG_SCOPE", "disposable")],
+    );
+    assert!(
         out.status.success(),
-        "untagged disposable add should succeed as a disposable child.\nstderr: {}",
+        "explicit --scope disposable child should be allowed from disposable scope.\nstderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
     assert_eq!(
-        scope_from_tags(&task_tags(&wg_dir, "follow-up")).as_deref(),
+        scope_from_tags(&task_tags(&wg_dir, "child")).as_deref(),
         Some(SCOPE_DISPOSABLE),
-        "untagged add from disposable scope must inherit scope:disposable, not mint durable work"
+        "explicit disposable child must carry scope:disposable"
     );
 }
 

--- a/tests/integration_scope_guard.rs
+++ b/tests/integration_scope_guard.rs
@@ -1,0 +1,49 @@
+//! R8 — `--scope disposable` guard (docs/02 §3.2 in the family-team project).
+//!
+//! A task created with `wg add --scope disposable` runs its agent with
+//! `WG_SCOPE=disposable`. A disposable-scoped agent must not be able to mint a
+//! *persistent* persona: it may not run `wg agent create` or
+//! `wg add --tag persistent`. These tests pin the policy at the library
+//! boundary so the CLI handlers can rely on it.
+
+use worksgood::scope_guard::{check_scope, scope_from_tags, PersistentSpawn, SCOPE_DISPOSABLE};
+
+/// The load-bearing R8 policy: a disposable scope forbids every persistent
+/// spawn, while unscoped / non-disposable scopes are unaffected.
+#[test]
+fn test_scoped_disposable_cannot_spawn_persistent() {
+    // disposable is denied both privileged spawns
+    assert!(
+        check_scope(Some(SCOPE_DISPOSABLE), PersistentSpawn::Agent).is_err(),
+        "disposable scope must forbid `wg agent create`"
+    );
+    assert!(
+        check_scope(Some(SCOPE_DISPOSABLE), PersistentSpawn::Task).is_err(),
+        "disposable scope must forbid `wg add --tag persistent`"
+    );
+
+    // unscoped and non-disposable scopes are allowed
+    assert!(
+        check_scope(None, PersistentSpawn::Agent).is_ok(),
+        "unscoped agents may create persistent agents"
+    );
+    assert!(
+        check_scope(Some("persistent"), PersistentSpawn::Task).is_ok(),
+        "a persistent-scoped agent may create persistent tasks"
+    );
+    assert!(
+        check_scope(Some("team"), PersistentSpawn::Agent).is_ok(),
+        "only the reserved `disposable` scope is restricted"
+    );
+}
+
+/// Scope is persisted on a task as a `scope:<value>` tag, which is how the
+/// dispatcher recovers it to set `WG_SCOPE` on the spawned worker.
+#[test]
+fn test_scope_persisted_as_tag() {
+    assert_eq!(
+        scope_from_tags(&["scope:disposable".to_string(), "urgent".to_string()]).as_deref(),
+        Some("disposable"),
+    );
+    assert_eq!(scope_from_tags(&["urgent".to_string()]), None);
+}

--- a/tests/integration_scope_guard.rs
+++ b/tests/integration_scope_guard.rs
@@ -4,10 +4,13 @@
 //! `WG_SCOPE=disposable`. A disposable-scoped agent must not be able to mint
 //! durable/persistent graph state: it may not run `wg agent create`,
 //! `wg add --tag persistent`, or an ordinary durable `wg add`. From disposable
-//! scope the `wg add` boundary is default-deny — only *explicitly* disposable
-//! child work (`--scope disposable` / `--tag disposable`) is allowed. These
-//! tests pin the policy at the library boundary so the CLI handlers can rely on
-//! it.
+//! scope the `wg add` boundary is default-deny — the *only* allowed add is an
+//! explicit, scope-carrying `--scope disposable` (which persists a
+//! `scope:disposable` tag the dispatcher propagates as `WG_SCOPE`). A bare
+//! `--tag disposable` is refused: it carries no `scope:` prefix, so the child
+//! would spawn unscoped and could mint durable grandchildren (Erik, PR #56
+//! rd3). These tests pin the policy at both the library boundary and the real
+//! CLI/dispatch wiring.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -84,7 +87,15 @@ fn test_disposable_caller_default_deny_resolution() {
         "disposable caller must not escalate a child to a non-disposable scope"
     );
 
-    // The allowed case: an explicit disposable child passes through verbatim.
+    // Bare `disposable` tag → denied (Erik PR #56 rd3): no `scope:` prefix, so
+    // plan_spawn would leave the child unscoped. Only `--scope disposable` is ok.
+    assert!(
+        resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["disposable".to_string()]).is_err(),
+        "a bare `--tag disposable` must be refused — it does not carry scope for propagation"
+    );
+
+    // The allowed case: an explicit --scope disposable child passes through, and
+    // the returned tag set carries scope:disposable for WG_SCOPE propagation.
     let resolved =
         resolve_add_scope_for(Some(SCOPE_DISPOSABLE), &["scope:disposable".to_string()]).unwrap();
     assert_eq!(
@@ -256,6 +267,97 @@ fn cli_disposable_scope_escalation_is_refused() {
     assert!(
         !out.status.success(),
         "disposable + --scope team must be refused"
+    );
+}
+
+/// Erik's rd3 blocking hole: `WG_SCOPE=disposable wg add child --tag disposable`
+/// must be REFUSED. A bare `disposable` tag carries no `scope:` prefix, so the
+/// dispatcher's `plan_spawn` would leave the child unscoped — free to mint
+/// durable grandchildren. The allowed route must be scope-carrying
+/// (`--scope disposable`); the bare tag mints nothing.
+#[test]
+fn cli_disposable_bare_disposable_tag_add_is_refused() {
+    let dir = TempDir::new().unwrap();
+    let wg_dir = setup_workgraph(dir.path());
+
+    let out = wg_add(
+        &wg_dir,
+        &["scrape child", "--id", "bare-child", "--tag", "disposable"],
+        &[("WG_SCOPE", "disposable")],
+    );
+    assert!(
+        !out.status.success(),
+        "a bare `--tag disposable` from disposable scope must be refused.\nstdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("disposable"),
+        "error should explain the disposable boundary: {stderr}"
+    );
+    // Nothing was minted — no unscoped child slipped through.
+    let graph = load_graph(&wg_dir.join("graph.jsonl")).unwrap();
+    assert!(
+        graph.get_task("bare-child").is_none(),
+        "refused bare-tag add must not create an unscoped child"
+    );
+}
+
+/// Erik's rd3 required regression #1: a real CLI run of `WG_SCOPE=disposable
+/// wg agent create ...` is refused AND no persona file is written. The prior
+/// `test_scoped_disposable_cannot_spawn_persistent` only exercised `check_scope`
+/// directly; this pins the actual `agent_crud` wiring end-to-end.
+#[test]
+fn cli_disposable_agent_create_is_refused_and_mints_nothing() {
+    let dir = TempDir::new().unwrap();
+    let wg_dir = setup_workgraph(dir.path());
+
+    let mut cmd = Command::new(wg_binary());
+    cmd.arg("--dir")
+        .arg(&wg_dir)
+        .args([
+            "agent",
+            "create",
+            "scratch-bot",
+            "--role",
+            "deadbeef",
+            "--tradeoff",
+            "deadbeef",
+            "--executor",
+            "claude",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.env_remove("WG_DIR").env_remove("WG_TASK_ID");
+    cmd.env("WG_SCOPE", "disposable");
+    let out = cmd.output().expect("failed to run wg agent create");
+
+    assert!(
+        !out.status.success(),
+        "wg agent create from disposable scope must be refused.\nstdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("disposable"),
+        "refusal must come from the scope guard (mention `disposable`), not the \
+         role/tradeoff check: {stderr}"
+    );
+
+    // No persona file was written anywhere under the agency cache.
+    let agents_dir = wg_dir.join("agency").join("cache/agents");
+    let minted: Vec<_> = fs::read_dir(&agents_dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("yaml"))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        minted.is_empty(),
+        "refused agent create must not mint a persona file, found: {minted:?}"
     );
 }
 


### PR DESCRIPTION
## What

Adds a `--scope` flag to `wg add` and a policy guard that stops a **disposable** agent from minting a **persistent** persona. This closes the R8 policy gap: today any agent can call `wg agent create` (or `wg add --tag persistent`) with any role, so a buggy/compromised disposable scraper could in principle create a persistent persona. Ref: docs/02 §3.2 ("`--scope disposable` flag on `wg add`", R8 "Missing (policy)") in the family-team gap analysis.

## How

- **`wg add --scope <value>`** persists the scope as a `scope:<value>` tag (no `Task` schema change).
- **Dispatcher** (`dispatch::plan::plan_spawn`) propagates that scope to the spawned worker as the `WG_SCOPE` environment variable.
- **`worksgood::scope_guard`** (new module) enforces the policy at the CLI boundary:
  - `wg agent create` → refused when `WG_SCOPE=disposable`
  - `wg add --tag persistent` → refused when `WG_SCOPE=disposable`
  - every other scope (including unscoped) is unaffected — only the reserved `disposable` value restricts anything.

`check_scope` is a pure function (scope passed in, not read from the env) so it is deterministic under parallel tests; the env-reading wrappers (`enforce`, `enforce_persistent_tag`) call it.

## Test

`test_scoped_disposable_cannot_spawn_persistent` (tests/integration_scope_guard.rs) — written failing first, then made to pass. Plus module unit tests and an end-to-end CLI check:

```
wg add --scope disposable ...        # stores scope:disposable tag
WG_SCOPE=disposable wg add --tag persistent ...   # -> error, exit 1
WG_SCOPE=disposable wg agent create ...           # -> error, exit 1
wg add --tag persistent ...          # unscoped: allowed
```

`cargo build --locked` clean; the full `dispatch::plan` suite (39) passes. (Pre-existing macOS-only env failures in worktree/federation/smoke tests are unrelated to this change — they stem from `/private/var` symlink canonicalization and GNU `touch -d`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)